### PR TITLE
Solaris 11: Virtualbox build, Vagrant nocm variant

### DIFF
--- a/templates/solaris-11/README.md
+++ b/templates/solaris-11/README.md
@@ -1,0 +1,71 @@
+Solaris 11
+==========
+
+Some notes about building Solaris 11 under packer.
+Parts of this build, notably the boot command and automated install manifests, have been adapted from the [Chef Bento project][bento-solaris-11].
+
+The Boot Command
+----------------
+
+The boot command needs some explanation because it is truly an epic hack.
+The command is long and does a lot more than any boot command rightfully should --- such as executing a pile of shell commands.
+On the other hand, all Packer boot commands for Solaris 11 that I have seen so far pull similarly crazy shenanigans.
+
+Here is the boot command in its entirety:
+
+```json
+[
+  "e<wait>",
+  "<down><down><down><down><down><wait>",
+  "<end><wait>",
+  "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><wait>",
+  "false<wait>",
+  "<f10><wait>",
+  "<wait10><wait10><wait10><wait10><wait10><wait10>",
+  "<wait10><wait10><wait10><wait10><wait10><wait10>",
+  "<wait10><wait10><wait10><wait10><wait10><wait10>",
+  "root<enter><wait><wait>",
+  "solaris<enter><wait10>",
+
+  "<enter>while (true);",
+  "do test -f /a/etc/ssh/sshd_config && perl -pi -e 's/PermitRootLogin no/PermitRootLogin yes/' /a/etc/ssh/sshd_config && break;",
+  "sleep 10;",
+  "done &<enter><wait>",
+
+  "<enter>while (true);",
+  "do grep \"You may wish to reboot\" \"/var/svc/log/application-auto-installer:default.log\" 2> /dev/null && reboot && break;",
+  "sleep 10;",
+  "done &<enter><wait>",
+
+  "curl http://{{ .HTTPIP }}:{{ .HTTPPort }}/ai.xml -o /system/volatile/ai.xml<enter><wait>",
+  "mkdir /system/volatile/profile<enter><wait>",
+  "curl http://{{ .HTTPIP }}:{{ .HTTPPort }}/profile.xml -o /system/volatile/profile/profile.xml<enter><wait>",
+  "svcadm enable svc:/application/auto-installer:default<enter><wait>",
+  "<enter><wait10><wait><wait>",
+  "<enter><wait>",
+  "tail -f /system/volatile/install_log<enter><wait>"
+]
+```
+
+The first chunk exits to the GRUB shell and boots the system with automated installation disabled.
+The second chunk waits for the system to come up and logs in with the default username and password of `root` and `solaris`.
+The next two chunks set up two background loops:
+
+  - One loop waits for installation to proceed to a point where SSHD configuration is laid down and then enables root login for Packer.
+    Note that `/a` is the mountpoint where the Solaris 11 system will be installed and it will be unmounted at the end of installation.
+
+  - The second loop waits for installation to finish and than reboots the system out of the installer and into the new OS.
+
+The final chunk pulls down the XML configuration for Solaris 11 Automated Installation and kicks off the install process and then tails the progress log.
+The XML definitions are pretty stock except the following differences:
+
+  - `profile.xml` sets up `root` as a normal user account instead of a "role" (whatever a role is, it's not something that packer can log into).
+
+
+Other Notes
+-----------
+
+The VM _must_ have more than 768 MB of memory during install since it is running from a RAM disk.
+Memory size is currently set at 1536 MB, but not sure if that is the lower limit.
+
+  [bento-solaris-11]: https://github.com/opscode/bento/blob/94c618231e40a7e8e69774ed163eea46e62abe37/packer/solaris-11-x86.json

--- a/templates/solaris-11/files/ai.xml
+++ b/templates/solaris-11/files/ai.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ CDDL HEADER START
+
+ The contents of this file are subject to the terms of the
+ Common Development and Distribution License (the "License").
+ You may not use this file except in compliance with the License.
+
+ You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ or http://www.opensolaris.org/os/licensing.
+ See the License for the specific language governing permissions
+ and limitations under the License.
+
+ When distributing Covered Code, include this CDDL HEADER in each
+ file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ If applicable, add the following below this CDDL HEADER, with the
+ fields enclosed by brackets "[]" replaced with your own identifying
+ information: Portions Copyright [yyyy] [name of copyright owner]
+
+ CDDL HEADER END
+
+ Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
+
+-->
+<!DOCTYPE auto_install SYSTEM "file:///usr/share/install/ai.dtd.1">
+<auto_install>
+  <ai_instance name="default">
+    <target>
+      <logical>
+        <zpool name="rpool" is_root="true">
+          <filesystem name="export" mountpoint="/export"/>
+          <filesystem name="export/home"/>
+          <be name="solaris"/>
+        </zpool>
+      </logical>
+    </target>
+    <software>
+      <source>
+        <publisher name="solaris">
+          <origin name="http://pkg.oracle.com/solaris/release"/>
+        </publisher>
+      </source>
+      <!--
+	By default the latest build available, in the specified IPS
+	repository, is installed.  If another build is required, the 
+	build number has to be appended to the 'entire' package in following
+	form:
+
+	<name>pkg:/entire@0.5.11-0.build#</name>
+      -->
+      <software_data action="install">
+        <name>pkg:/server_install</name>
+      </software_data>
+      <!--
+	    babel_install and slim_install are group packages used to
+	    define the default installation.  They are removed here so
+	    that they do not inhibit removal of other packages on the
+	    installed system.
+        -->
+      <software_data action="uninstall">
+        <name>pkg:/server_install</name>
+      </software_data>
+   	
+    </software>
+  </ai_instance>
+</auto_install>

--- a/templates/solaris-11/files/profile.xml
+++ b/templates/solaris-11/files/profile.xml
@@ -1,0 +1,77 @@
+<!--
+CDDL HEADER START
+
+The contents of this file are subject to the terms of the
+Common Development and Distribution License (the "License").
+You may not use this file except in compliance with the License.
+
+You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+or http://www.opensolaris.org/os/licensing.
+See the License for the specific language governing permissions
+and limitations under the License.
+
+When distributing Covered Code, include this CDDL HEADER in each
+file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+If applicable, add the following below this CDDL HEADER, with the
+fields enclosed by brackets "[]" replaced with your own identifying
+information: Portions Copyright [yyyy] [name of copyright owner]
+
+CDDL HEADER END
+
+Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+-->
+
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<service_bundle type="profile" name="system configuration">
+  <service name="system/config-user" version="1">
+    <instance name="default" enabled="true">
+      <property_group name="root_account">
+        <!-- root password is "root" -->
+        <propval name="password" value="$5$mcNmQhWw$Twllt/J1M29Ow/KluqmvYadW9VvBfpc2gNvz.tXeLS8"/>
+        <propval name="type" value="normal"/>
+      </property_group>
+    </instance>
+  </service>
+  <service version="1" name="system/identity">
+    <instance enabled="true" name="node">
+      <property_group name="config">
+        <propval name="nodename" value="vagrant-solaris"/>
+      </property_group>
+    </instance>
+  </service>
+  <service name="system/console-login" version="1">
+    <instance enabled="true" name="default">
+      <property_group name="ttymon">
+        <propval name="terminal_type" value="sun-color"/>
+      </property_group>
+    </instance>
+  </service>
+  <service version="1" name="system/timezone">
+    <instance enabled="true" name="default">
+      <property_group name="timezone">
+        <propval name="localtime" value="UTC"/>
+      </property_group>
+    </instance>
+  </service>
+  <service version="1" name="system/environment">
+    <instance enabled="true" name="init">
+      <property_group name="environment">
+        <propval name="LANG" value="C"/>
+      </property_group>
+    </instance>
+  </service>
+  <service version="1" name="system/keymap">
+    <instance enabled="true" name="default">
+      <property_group name="keymap">
+        <propval name="layout" value="US-English"/>
+      </property_group>
+    </instance>
+  </service>
+  <service version="1" name="network/physical">
+    <instance enabled="true" name="default">
+      <property_group type="application" name="netcfg">
+        <propval name="active_ncp" value="Automatic"/>
+      </property_group>
+    </instance>
+  </service>
+</service_bundle>

--- a/templates/solaris-11/i386.virtualbox.base.json
+++ b/templates/solaris-11/i386.virtualbox.base.json
@@ -1,0 +1,79 @@
+{
+
+  "variables": {
+    "template_name": "solaris-11.2-i386",
+    "template_os": "Solaris11_64",
+
+    "iso_url": "http://int-resources.ops.puppetlabs.net/ISO/Solaris/sol-11_2-ai-x86.iso",
+    "iso_checksum": "2b3859bb7532cfe42214349dff9fcc23",
+    "iso_checksum_type": "md5",
+
+    "memory_size": "1536",
+    "cpu_count": "1",
+
+    "username": "root",
+    "password": "root",
+
+    "provisioner": "virtualbox"
+  },
+
+  "builders": [
+    {
+      "name": "{{user `template_name`}}-{{user `provisioner`}}",
+      "type": "virtualbox-iso",
+      "boot_command": [
+        "e<wait>",
+        "<down><down><down><down><down><wait>",
+        "<end><wait>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><wait>",
+        "false<wait>",
+        "<f10><wait>",
+        "<wait10><wait10><wait10><wait10><wait10><wait10>",
+        "<wait10><wait10><wait10><wait10><wait10><wait10>",
+        "<wait10><wait10><wait10><wait10><wait10><wait10>",
+        "root<enter><wait><wait>",
+        "solaris<enter><wait10>",
+
+        "<enter>while (true);",
+        "do test -f /a/etc/ssh/sshd_config && perl -pi -e 's/PermitRootLogin no/PermitRootLogin yes/' /a/etc/ssh/sshd_config && break;",
+        "sleep 10;",
+        "done &<enter><wait>",
+
+        "<enter>while (true);",
+        "do grep \"You may wish to reboot\" \"/var/svc/log/application-auto-installer:default.log\" 2> /dev/null && reboot && break;",
+        "sleep 10;",
+        "done &<enter><wait>",
+
+        "curl http://{{ .HTTPIP }}:{{ .HTTPPort }}/ai.xml -o /system/volatile/ai.xml<enter><wait>",
+        "mkdir /system/volatile/profile<enter><wait>",
+        "curl http://{{ .HTTPIP }}:{{ .HTTPPort }}/profile.xml -o /system/volatile/profile/profile.xml<enter><wait>",
+        "svcadm enable svc:/application/auto-installer:default<enter><wait>",
+        "<enter><wait10><wait><wait>",
+	      "<enter><wait>",
+        "tail -f /system/volatile/install_log<enter><wait>"
+      ],
+      "http_directory": "files",
+      "guest_os_type": "{{user `template_os`}}",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "ssh_username": "{{user `username`}}",
+      "ssh_password": "{{user `password`}}",
+      "ssh_wait_timeout": "60m",
+      "shutdown_command": "/usr/sbin/poweroff",
+      "vboxmanage": [
+        [ "modifyvm", "{{.Name}}", "--memory", "{{user `memory_size`}}" ],
+        [ "modifyvm", "{{.Name}}", "--cpus", "{{user `cpu_count`}}" ]
+      ]
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type": "shell",
+      "scripts": [
+        "scripts/virtualbox.sh"
+      ]
+    }
+  ]
+}

--- a/templates/solaris-11/i386.virtualbox.vagrant.nocm.json
+++ b/templates/solaris-11/i386.virtualbox.vagrant.nocm.json
@@ -1,0 +1,42 @@
+{
+
+  "variables": {
+    "template_name": "solaris-11.2-i386",
+
+    "username": "root",
+    "password": "root",
+
+    "provisioner": "virtualbox"
+  },
+
+  "builders": [
+    {
+      "name": "{{user `template_name`}}-{{user `provisioner`}}-vagrant-nocm",
+      "type": "virtualbox-ovf",
+      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.ovf",
+
+      "ssh_username": "{{user `username`}}",
+      "ssh_password": "{{user `password`}}",
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "/usr/sbin/poweroff"
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type": "shell",
+      "scripts": [
+        "scripts/vagrant.sh",
+        "scripts/zerodisk.sh"
+      ]
+    }
+  ],
+
+  "post-processors": [
+    {
+      "type": "vagrant",
+      "output": "output/{{.Provider}}/{{user `template_name`}}-{{.Provider}}-nocm.box"
+    }
+  ]
+
+}

--- a/templates/solaris-11/scripts/vagrant.sh
+++ b/templates/solaris-11/scripts/vagrant.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Add vagrant user and group
+
+date > /etc/vagrant_box_build_time
+
+/usr/sbin/groupadd vagrant
+/usr/sbin/useradd -m -d /export/home/vagrant -g vagrant vagrant
+
+PASSWD=`perl -e 'print crypt($ARGV[0], substr(rand(data),2));' vagrant`
+perl -pi -e "s/^vagrant:UP:/vagrant:$PASSWD/" /etc/shadow
+
+# Give Vagrant sudo rights
+echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" > /etc/sudoers.d/vagrant
+
+# Install vagrant keys
+mkdir -pm 700 /export/home/vagrant/.ssh
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O /export/home/vagrant/.ssh/authorized_keys
+chmod 0600 /export/home/vagrant/.ssh/authorized_keys
+chown -R vagrant:vagrant /export/home/vagrant/.ssh

--- a/templates/solaris-11/scripts/virtualbox.sh
+++ b/templates/solaris-11/scripts/virtualbox.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Install the virtualbox guest additions (from the ISO)
+mkdir -p /tmp/vboxguest/mnt
+mount -F hsfs -o ro `lofiadm -a $HOME/VBoxGuestAdditions.iso` /tmp/vboxguest/mnt
+
+cd /tmp/vboxguest
+
+cp mnt/VBoxSolarisAdditions.pkg .
+/usr/bin/pkgtrans VBoxSolarisAdditions.pkg . all
+yes | /usr/sbin/pkgadd -d . SUNWvboxguest
+
+cd
+
+umount /tmp/vboxguest/mnt
+lofiadm -d /dev/lofi/1
+rm -f "$HOME/VBoxGuestAdditions.iso"
+rm -rf /tmp/vboxguest

--- a/templates/solaris-11/scripts/zerodisk.sh
+++ b/templates/solaris-11/scripts/zerodisk.sh
@@ -1,0 +1,12 @@
+# Clear wtmp
+cat /dev/null > /var/adm/wtmpx
+
+# Zero out the free space to save space in the final image:
+dd if=/dev/zero of=/EMPTY bs=1024
+rm -f /EMPTY
+
+# Remove this script
+rm -rf /tmp/script.sh
+
+# Wait for all file ops to complete
+sync


### PR DESCRIPTION
This patch adds a nocm Virtualbox build for Solaris 11.2. See the accompanying
README file for details of how the build is set up and executed.
