### PR TITLE
(maint) add template/script for building ec2 images for beaker testing.

### DIFF
--- a/manifests/ec2.pp
+++ b/manifests/ec2.pp
@@ -1,0 +1,1 @@
+include packer::sshd

--- a/scripts/bootstrap-ec2.sh
+++ b/scripts/bootstrap-ec2.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+cat > /tmp/answers <<EOF
+q_all_in_one_install=n
+q_continue_or_reenter_master_hostname=c
+q_database_install=n
+q_fail_on_unsuccessful_master_lookup=n
+q_install=y
+q_puppet_cloud_install=n
+q_puppet_enterpriseconsole_install=n
+q_puppetagent_certname=scratch.debian
+q_puppetagent_install=y
+q_puppetagent_server=puppet
+q_puppetca_install=n
+q_puppetdb_install=n
+q_puppetmaster_install=n
+q_run_updtvpkg=n
+q_vendor_packages_install=y
+EOF
+
+## extract and install PE
+tar -xzvf pe.tar.gz
+cd `ls -d puppet*`
+./puppet-enterprise-installer -a /tmp/answers
+
+# Install required modules
+for i in "$@"
+do
+  puppet module install $i --modulepath=/tmp/manifests/modules >/dev/null 2>&1
+done
+
+puppet apply /tmp/manifests/ec2.pp --modulepath=/tmp/manifests/modules
+
+## uninstall puppet
+sudo ./puppet-enterprise-uninstaller -y
+cd ..
+rm -rf `ls -d puppet*`
+rm pe.tar.gz
+sed -i "s/disable_root: true/disable_root: 0/" /etc/cloud/cloud.cfg
+if ! [ -d /usr/local/bin ];
+then
+  mkdir /usr/local/bin
+fi
+
+## clean up
+rm -rf /etc/puppetlabs
+rm -rf /opt/puppet
+rm -rf /var/cache/yum/puppetdeps
+rm -rf /var/opt/lib/pe-puppet
+rm -rf /tmp/*
+cat /dev/null > /var/log/wtmp
+rm /root/.ssh/authorized_keys

--- a/templates/debian-7.6/x86_64.ec2.nocm.json
+++ b/templates/debian-7.6/x86_64.ec2.nocm.json
@@ -1,0 +1,51 @@
+{
+  "variables": {
+    "aws_access_key": "",
+    "aws_secret_key": "",
+    "template_name": "debian-7.6-x86_64",
+    "note": "the url below must be fetched without a cert check as of 10/6/2014",
+    "pe_url": "https://pm.puppetlabs.com/cgi-bin/download.cgi?ver=latest&dist=debian&arch=amd64&rel=7",
+    "provisioner": "ec2",
+    "source_ami": "ami-f1c5bcc1",
+    "ami_description": "puppetlabs-debian-7.6-x86_64 {{timestamp}}",
+    "ami_name": "puppetlabs-debian-7.6-x86_64 {{timestamp}}",
+    "required_modules": "puppetlabs-stdlib saz-ssh",
+    "user_data": "#cloud-config\ndisable_root: 0"
+  },
+
+  "builders": [
+    {
+      "name": "amazon-ebs-us-west-2",
+      "access_key": "{{user `aws_access_key`}}",
+      "secret_key": "{{user `aws_secret_key`}}",
+      "type": "amazon-ebs",
+      "region": "us-west-2",
+      "instance_type": "c3.large",
+      "ssh_username": "root",
+      "ami_description": "{{user `ami_description`}}",
+      "ami_name": "{{user `ami_name`}}",
+      "source_ami": "{{user `source_ami`}}",
+      "region": "us-west-2",
+      "ami_regions": ["us-west-2"],
+      "ssh_timeout": "10000s",
+      "user_data": "{{user `user_data`}}"
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type": "file",
+      "source": "../../../puppetlabs-packer/",
+      "destination": "/tmp/"
+    },
+    {
+      "type": "shell",
+      "inline": ["wget --no-check-certificate \"{{user `pe_url`}}\" -O pe.tar.gz"]
+    },
+    {
+      "type": "shell",
+      "execute_command": "sudo sh {{.Path}} {{user `required_modules`}}",
+      "scripts": ["../../scripts/bootstrap-ec2.sh"]
+    }
+  ]
+}


### PR DESCRIPTION
This patch adds a wrapper script and ec2 template to easily build AMIs for
beaker testing.
