### PR TITLE
Don't scrub the base OS

### DIFF
--- a/templates/centos-5.10/i386.virtualbox.base.json
+++ b/templates/centos-5.10/i386.virtualbox.base.json
@@ -89,8 +89,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/centos-5.10/i386.vmware.base.json
+++ b/templates/centos-5.10/i386.vmware.base.json
@@ -79,8 +79,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/centos-5.10/x86_64.virtualbox.base.json
+++ b/templates/centos-5.10/x86_64.virtualbox.base.json
@@ -89,8 +89,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/centos-5.10/x86_64.vmware.base.json
+++ b/templates/centos-5.10/x86_64.vmware.base.json
@@ -79,8 +79,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/centos-6.5/i386.virtualbox.base.json
+++ b/templates/centos-6.5/i386.virtualbox.base.json
@@ -89,8 +89,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/centos-6.5/i386.vmware.base.json
+++ b/templates/centos-6.5/i386.vmware.base.json
@@ -79,8 +79,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/centos-6.5/x86_64.virtualbox.base.json
+++ b/templates/centos-6.5/x86_64.virtualbox.base.json
@@ -95,8 +95,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/centos-6.5/x86_64.vmware.base.json
+++ b/templates/centos-6.5/x86_64.vmware.base.json
@@ -79,8 +79,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/debian-6.0.9/i386.virtualbox.base.json
+++ b/templates/debian-6.0.9/i386.virtualbox.base.json
@@ -103,8 +103,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/debian-6.0.9/i386.vmware.base.json
+++ b/templates/debian-6.0.9/i386.vmware.base.json
@@ -93,8 +93,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/debian-6.0.9/x86_64.virtualbox.base.json
+++ b/templates/debian-6.0.9/x86_64.virtualbox.base.json
@@ -109,8 +109,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/debian-6.0.9/x86_64.vmware.base.json
+++ b/templates/debian-6.0.9/x86_64.vmware.base.json
@@ -93,8 +93,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/debian-7.5/i386.virtualbox.base.json
+++ b/templates/debian-7.5/i386.virtualbox.base.json
@@ -95,8 +95,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/debian-7.5/i386.vmware.base.json
+++ b/templates/debian-7.5/i386.vmware.base.json
@@ -85,8 +85,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/debian-7.5/x86_64.virtualbox.base.json
+++ b/templates/debian-7.5/x86_64.virtualbox.base.json
@@ -101,8 +101,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/debian-7.5/x86_64.vmware.base.json
+++ b/templates/debian-7.5/x86_64.vmware.base.json
@@ -85,8 +85,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/debian-7.6/i386.virtualbox.base.json
+++ b/templates/debian-7.6/i386.virtualbox.base.json
@@ -95,8 +95,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/debian-7.6/i386.vmware.base.json
+++ b/templates/debian-7.6/i386.vmware.base.json
@@ -85,8 +85,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/debian-7.6/x86_64.virtualbox.base.json
+++ b/templates/debian-7.6/x86_64.virtualbox.base.json
@@ -101,8 +101,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/debian-7.6/x86_64.vmware.base.json
+++ b/templates/debian-7.6/x86_64.vmware.base.json
@@ -85,8 +85,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/oracle-5.10/i386.virtualbox.base.json
+++ b/templates/oracle-5.10/i386.virtualbox.base.json
@@ -89,8 +89,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/oracle-5.10/i386.vmware.base.json
+++ b/templates/oracle-5.10/i386.vmware.base.json
@@ -79,8 +79,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/oracle-5.10/x86_64.virtualbox.base.json
+++ b/templates/oracle-5.10/x86_64.virtualbox.base.json
@@ -89,8 +89,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/oracle-5.10/x86_64.vmware.base.json
+++ b/templates/oracle-5.10/x86_64.vmware.base.json
@@ -79,8 +79,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/oracle-6.5/i386.virtualbox.base.json
+++ b/templates/oracle-6.5/i386.virtualbox.base.json
@@ -89,8 +89,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/oracle-6.5/i386.vmware.base.json
+++ b/templates/oracle-6.5/i386.vmware.base.json
@@ -79,8 +79,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/oracle-6.5/x86_64.virtualbox.base.json
+++ b/templates/oracle-6.5/x86_64.virtualbox.base.json
@@ -95,8 +95,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/oracle-6.5/x86_64.vmware.base.json
+++ b/templates/oracle-6.5/x86_64.vmware.base.json
@@ -79,8 +79,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/scientific-5.10/i386.virtualbox.base.json
+++ b/templates/scientific-5.10/i386.virtualbox.base.json
@@ -89,8 +89,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/scientific-5.10/i386.vmware.base.json
+++ b/templates/scientific-5.10/i386.vmware.base.json
@@ -79,8 +79,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/scientific-5.10/x86_64.virtualbox.base.json
+++ b/templates/scientific-5.10/x86_64.virtualbox.base.json
@@ -89,8 +89,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/scientific-5.10/x86_64.vmware.base.json
+++ b/templates/scientific-5.10/x86_64.vmware.base.json
@@ -79,8 +79,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/scientific-6.5/i386.virtualbox.base.json
+++ b/templates/scientific-6.5/i386.virtualbox.base.json
@@ -89,8 +89,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/scientific-6.5/i386.vmware.base.json
+++ b/templates/scientific-6.5/i386.vmware.base.json
@@ -79,8 +79,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/scientific-6.5/x86_64.virtualbox.base.json
+++ b/templates/scientific-6.5/x86_64.virtualbox.base.json
@@ -95,8 +95,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/scientific-6.5/x86_64.vmware.base.json
+++ b/templates/scientific-6.5/x86_64.vmware.base.json
@@ -79,8 +79,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/ubuntu-12.04/i386.virtualbox.base.json
+++ b/templates/ubuntu-12.04/i386.virtualbox.base.json
@@ -104,8 +104,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/ubuntu-12.04/i386.vmware.base.json
+++ b/templates/ubuntu-12.04/i386.vmware.base.json
@@ -94,8 +94,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/ubuntu-12.04/x86_64.virtualbox.base.json
+++ b/templates/ubuntu-12.04/x86_64.virtualbox.base.json
@@ -110,8 +110,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/ubuntu-12.04/x86_64.vmware.base.json
+++ b/templates/ubuntu-12.04/x86_64.vmware.base.json
@@ -94,8 +94,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/ubuntu-14.04/i386.virtualbox.base.json
+++ b/templates/ubuntu-14.04/i386.virtualbox.base.json
@@ -104,8 +104,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/ubuntu-14.04/i386.vmware.base.json
+++ b/templates/ubuntu-14.04/i386.vmware.base.json
@@ -94,8 +94,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/ubuntu-14.04/x86_64.virtualbox.base.json
+++ b/templates/ubuntu-14.04/x86_64.virtualbox.base.json
@@ -110,8 +110,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/ubuntu-14.04/x86_64.vmware.base.json
+++ b/templates/ubuntu-14.04/x86_64.vmware.base.json
@@ -94,8 +94,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",
-        "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]


### PR DESCRIPTION
The filesystem is cleaned up and zero-disk'd at the end of Vagrant steps; this step is unneeded churn for the base OS build.
