### PR TITLE
Adding PUPPET_NFS env var for cleanup-puppet.sh

### DIFF
--- a/templates/centos-5.11/i386.virtualbox.base.json
+++ b/templates/centos-5.11/i386.virtualbox.base.json
@@ -85,7 +85,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/centos-5.11/i386.virtualbox.vagrant.nocm.json
+++ b/templates/centos-5.11/i386.virtualbox.vagrant.nocm.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/centos-5.11/i386.virtualbox.vagrant.puppet.json
+++ b/templates/centos-5.11/i386.virtualbox.vagrant.puppet.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/centos-5.11/i386.vmware.base.json
+++ b/templates/centos-5.11/i386.vmware.base.json
@@ -75,7 +75,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/centos-5.11/i386.vmware.vagrant.nocm.json
+++ b/templates/centos-5.11/i386.vmware.vagrant.nocm.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/centos-5.11/i386.vmware.vagrant.puppet.json
+++ b/templates/centos-5.11/i386.vmware.vagrant.puppet.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/centos-5.11/x86_64.virtualbox.base.json
+++ b/templates/centos-5.11/x86_64.virtualbox.base.json
@@ -85,7 +85,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/centos-5.11/x86_64.virtualbox.vagrant.nocm.json
+++ b/templates/centos-5.11/x86_64.virtualbox.vagrant.nocm.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/centos-5.11/x86_64.virtualbox.vagrant.puppet.json
+++ b/templates/centos-5.11/x86_64.virtualbox.vagrant.puppet.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/centos-5.11/x86_64.vmware.base.json
+++ b/templates/centos-5.11/x86_64.vmware.base.json
@@ -75,7 +75,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/centos-5.11/x86_64.vmware.vagrant.nocm.json
+++ b/templates/centos-5.11/x86_64.vmware.vagrant.nocm.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/centos-5.11/x86_64.vmware.vagrant.puppet.json
+++ b/templates/centos-5.11/x86_64.vmware.vagrant.puppet.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/centos-6.5/i386.virtualbox.base.json
+++ b/templates/centos-6.5/i386.virtualbox.base.json
@@ -85,7 +85,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/centos-6.5/i386.virtualbox.vagrant.nocm.json
+++ b/templates/centos-6.5/i386.virtualbox.vagrant.nocm.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/centos-6.5/i386.virtualbox.vagrant.puppet.json
+++ b/templates/centos-6.5/i386.virtualbox.vagrant.puppet.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/centos-6.5/i386.vmware.base.json
+++ b/templates/centos-6.5/i386.vmware.base.json
@@ -75,7 +75,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/centos-6.5/i386.vmware.vagrant.nocm.json
+++ b/templates/centos-6.5/i386.vmware.vagrant.nocm.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/centos-6.5/i386.vmware.vagrant.puppet.json
+++ b/templates/centos-6.5/i386.vmware.vagrant.puppet.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/centos-6.5/x86_64.virtualbox.base.json
+++ b/templates/centos-6.5/x86_64.virtualbox.base.json
@@ -91,7 +91,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/centos-6.5/x86_64.virtualbox.vagrant.nocm.json
+++ b/templates/centos-6.5/x86_64.virtualbox.vagrant.nocm.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/centos-6.5/x86_64.virtualbox.vagrant.puppet.json
+++ b/templates/centos-6.5/x86_64.virtualbox.vagrant.puppet.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/centos-6.5/x86_64.vmware.base.json
+++ b/templates/centos-6.5/x86_64.vmware.base.json
@@ -75,7 +75,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/centos-6.5/x86_64.vmware.vagrant.nocm.json
+++ b/templates/centos-6.5/x86_64.vmware.vagrant.nocm.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/centos-6.5/x86_64.vmware.vagrant.puppet.json
+++ b/templates/centos-6.5/x86_64.vmware.vagrant.puppet.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/debian-6.0.9/i386.virtualbox.base.json
+++ b/templates/debian-6.0.9/i386.virtualbox.base.json
@@ -99,7 +99,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/debian-6.0.9/i386.virtualbox.vagrant.nocm.json
+++ b/templates/debian-6.0.9/i386.virtualbox.vagrant.nocm.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/debian-6.0.9/i386.virtualbox.vagrant.puppet.json
+++ b/templates/debian-6.0.9/i386.virtualbox.vagrant.puppet.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/debian-6.0.9/i386.vmware.base.json
+++ b/templates/debian-6.0.9/i386.vmware.base.json
@@ -89,7 +89,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/debian-6.0.9/i386.vmware.vagrant.nocm.json
+++ b/templates/debian-6.0.9/i386.vmware.vagrant.nocm.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/debian-6.0.9/i386.vmware.vagrant.puppet.json
+++ b/templates/debian-6.0.9/i386.vmware.vagrant.puppet.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/debian-6.0.9/x86_64.virtualbox.base.json
+++ b/templates/debian-6.0.9/x86_64.virtualbox.base.json
@@ -105,7 +105,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/debian-6.0.9/x86_64.virtualbox.vagrant.nocm.json
+++ b/templates/debian-6.0.9/x86_64.virtualbox.vagrant.nocm.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/debian-6.0.9/x86_64.virtualbox.vagrant.puppet.json
+++ b/templates/debian-6.0.9/x86_64.virtualbox.vagrant.puppet.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/debian-6.0.9/x86_64.vmware.base.json
+++ b/templates/debian-6.0.9/x86_64.vmware.base.json
@@ -89,7 +89,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/debian-6.0.9/x86_64.vmware.vagrant.nocm.json
+++ b/templates/debian-6.0.9/x86_64.vmware.vagrant.nocm.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/debian-6.0.9/x86_64.vmware.vagrant.puppet.json
+++ b/templates/debian-6.0.9/x86_64.vmware.vagrant.puppet.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/debian-7.6/i386.virtualbox.base.json
+++ b/templates/debian-7.6/i386.virtualbox.base.json
@@ -91,7 +91,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/debian-7.6/i386.virtualbox.vagrant.nocm.json
+++ b/templates/debian-7.6/i386.virtualbox.vagrant.nocm.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/debian-7.6/i386.virtualbox.vagrant.puppet.json
+++ b/templates/debian-7.6/i386.virtualbox.vagrant.puppet.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/debian-7.6/i386.vmware.base.json
+++ b/templates/debian-7.6/i386.vmware.base.json
@@ -81,7 +81,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/debian-7.6/i386.vmware.vagrant.nocm.json
+++ b/templates/debian-7.6/i386.vmware.vagrant.nocm.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/debian-7.6/i386.vmware.vagrant.puppet.json
+++ b/templates/debian-7.6/i386.vmware.vagrant.puppet.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/debian-7.6/x86_64.virtualbox.base.json
+++ b/templates/debian-7.6/x86_64.virtualbox.base.json
@@ -97,7 +97,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/debian-7.6/x86_64.virtualbox.vagrant.nocm.json
+++ b/templates/debian-7.6/x86_64.virtualbox.vagrant.nocm.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/debian-7.6/x86_64.virtualbox.vagrant.puppet.json
+++ b/templates/debian-7.6/x86_64.virtualbox.vagrant.puppet.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/debian-7.6/x86_64.vmware.base.json
+++ b/templates/debian-7.6/x86_64.vmware.base.json
@@ -81,7 +81,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/debian-7.6/x86_64.vmware.vagrant.nocm.json
+++ b/templates/debian-7.6/x86_64.vmware.vagrant.nocm.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/debian-7.6/x86_64.vmware.vagrant.puppet.json
+++ b/templates/debian-7.6/x86_64.vmware.vagrant.puppet.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/oracle-5.10/i386.virtualbox.base.json
+++ b/templates/oracle-5.10/i386.virtualbox.base.json
@@ -85,7 +85,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/oracle-5.10/i386.virtualbox.vagrant.nocm.json
+++ b/templates/oracle-5.10/i386.virtualbox.vagrant.nocm.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/oracle-5.10/i386.virtualbox.vagrant.puppet.json
+++ b/templates/oracle-5.10/i386.virtualbox.vagrant.puppet.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/oracle-5.10/i386.vmware.base.json
+++ b/templates/oracle-5.10/i386.vmware.base.json
@@ -75,7 +75,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/oracle-5.10/i386.vmware.vagrant.nocm.json
+++ b/templates/oracle-5.10/i386.vmware.vagrant.nocm.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/oracle-5.10/i386.vmware.vagrant.puppet.json
+++ b/templates/oracle-5.10/i386.vmware.vagrant.puppet.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/oracle-5.10/x86_64.virtualbox.base.json
+++ b/templates/oracle-5.10/x86_64.virtualbox.base.json
@@ -85,7 +85,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/oracle-5.10/x86_64.virtualbox.vagrant.nocm.json
+++ b/templates/oracle-5.10/x86_64.virtualbox.vagrant.nocm.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/oracle-5.10/x86_64.virtualbox.vagrant.puppet.json
+++ b/templates/oracle-5.10/x86_64.virtualbox.vagrant.puppet.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/oracle-5.10/x86_64.vmware.base.json
+++ b/templates/oracle-5.10/x86_64.vmware.base.json
@@ -75,7 +75,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/oracle-5.10/x86_64.vmware.vagrant.nocm.json
+++ b/templates/oracle-5.10/x86_64.vmware.vagrant.nocm.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/oracle-5.10/x86_64.vmware.vagrant.puppet.json
+++ b/templates/oracle-5.10/x86_64.vmware.vagrant.puppet.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/oracle-6.5/i386.virtualbox.base.json
+++ b/templates/oracle-6.5/i386.virtualbox.base.json
@@ -85,7 +85,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/oracle-6.5/i386.virtualbox.vagrant.nocm.json
+++ b/templates/oracle-6.5/i386.virtualbox.vagrant.nocm.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/oracle-6.5/i386.virtualbox.vagrant.puppet.json
+++ b/templates/oracle-6.5/i386.virtualbox.vagrant.puppet.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/oracle-6.5/i386.vmware.base.json
+++ b/templates/oracle-6.5/i386.vmware.base.json
@@ -75,7 +75,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/oracle-6.5/i386.vmware.vagrant.nocm.json
+++ b/templates/oracle-6.5/i386.vmware.vagrant.nocm.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/oracle-6.5/i386.vmware.vagrant.puppet.json
+++ b/templates/oracle-6.5/i386.vmware.vagrant.puppet.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/oracle-6.5/x86_64.virtualbox.base.json
+++ b/templates/oracle-6.5/x86_64.virtualbox.base.json
@@ -91,7 +91,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/oracle-6.5/x86_64.virtualbox.vagrant.nocm.json
+++ b/templates/oracle-6.5/x86_64.virtualbox.vagrant.nocm.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/oracle-6.5/x86_64.virtualbox.vagrant.puppet.json
+++ b/templates/oracle-6.5/x86_64.virtualbox.vagrant.puppet.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/oracle-6.5/x86_64.vmware.base.json
+++ b/templates/oracle-6.5/x86_64.vmware.base.json
@@ -75,7 +75,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/oracle-6.5/x86_64.vmware.vagrant.nocm.json
+++ b/templates/oracle-6.5/x86_64.vmware.vagrant.nocm.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/oracle-6.5/x86_64.vmware.vagrant.puppet.json
+++ b/templates/oracle-6.5/x86_64.vmware.vagrant.puppet.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/scientific-5.10/i386.virtualbox.base.json
+++ b/templates/scientific-5.10/i386.virtualbox.base.json
@@ -85,7 +85,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/scientific-5.10/i386.virtualbox.vagrant.nocm.json
+++ b/templates/scientific-5.10/i386.virtualbox.vagrant.nocm.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/scientific-5.10/i386.virtualbox.vagrant.puppet.json
+++ b/templates/scientific-5.10/i386.virtualbox.vagrant.puppet.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/scientific-5.10/i386.vmware.base.json
+++ b/templates/scientific-5.10/i386.vmware.base.json
@@ -75,7 +75,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/scientific-5.10/i386.vmware.vagrant.nocm.json
+++ b/templates/scientific-5.10/i386.vmware.vagrant.nocm.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/scientific-5.10/i386.vmware.vagrant.puppet.json
+++ b/templates/scientific-5.10/i386.vmware.vagrant.puppet.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/scientific-5.10/x86_64.virtualbox.base.json
+++ b/templates/scientific-5.10/x86_64.virtualbox.base.json
@@ -85,7 +85,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/scientific-5.10/x86_64.virtualbox.vagrant.nocm.json
+++ b/templates/scientific-5.10/x86_64.virtualbox.vagrant.nocm.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/scientific-5.10/x86_64.virtualbox.vagrant.puppet.json
+++ b/templates/scientific-5.10/x86_64.virtualbox.vagrant.puppet.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/scientific-5.10/x86_64.vmware.base.json
+++ b/templates/scientific-5.10/x86_64.vmware.base.json
@@ -75,7 +75,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/scientific-5.10/x86_64.vmware.vagrant.nocm.json
+++ b/templates/scientific-5.10/x86_64.vmware.vagrant.nocm.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/scientific-5.10/x86_64.vmware.vagrant.puppet.json
+++ b/templates/scientific-5.10/x86_64.vmware.vagrant.puppet.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/scientific-6.5/i386.virtualbox.base.json
+++ b/templates/scientific-6.5/i386.virtualbox.base.json
@@ -85,7 +85,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/scientific-6.5/i386.virtualbox.vagrant.nocm.json
+++ b/templates/scientific-6.5/i386.virtualbox.vagrant.nocm.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/scientific-6.5/i386.virtualbox.vagrant.puppet.json
+++ b/templates/scientific-6.5/i386.virtualbox.vagrant.puppet.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/scientific-6.5/i386.vmware.base.json
+++ b/templates/scientific-6.5/i386.vmware.base.json
@@ -75,7 +75,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/scientific-6.5/i386.vmware.vagrant.nocm.json
+++ b/templates/scientific-6.5/i386.vmware.vagrant.nocm.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/scientific-6.5/i386.vmware.vagrant.puppet.json
+++ b/templates/scientific-6.5/i386.vmware.vagrant.puppet.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/scientific-6.5/x86_64.virtualbox.base.json
+++ b/templates/scientific-6.5/x86_64.virtualbox.base.json
@@ -91,7 +91,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/scientific-6.5/x86_64.virtualbox.vagrant.nocm.json
+++ b/templates/scientific-6.5/x86_64.virtualbox.vagrant.nocm.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/scientific-6.5/x86_64.virtualbox.vagrant.puppet.json
+++ b/templates/scientific-6.5/x86_64.virtualbox.vagrant.puppet.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/scientific-6.5/x86_64.vmware.base.json
+++ b/templates/scientific-6.5/x86_64.vmware.base.json
@@ -75,7 +75,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/scientific-6.5/x86_64.vmware.vagrant.nocm.json
+++ b/templates/scientific-6.5/x86_64.vmware.vagrant.nocm.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/scientific-6.5/x86_64.vmware.vagrant.puppet.json
+++ b/templates/scientific-6.5/x86_64.vmware.vagrant.puppet.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/ubuntu-12.04/i386.virtualbox.base.json
+++ b/templates/ubuntu-12.04/i386.virtualbox.base.json
@@ -100,7 +100,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/ubuntu-12.04/i386.virtualbox.vagrant.nocm.json
+++ b/templates/ubuntu-12.04/i386.virtualbox.vagrant.nocm.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/ubuntu-12.04/i386.virtualbox.vagrant.puppet.json
+++ b/templates/ubuntu-12.04/i386.virtualbox.vagrant.puppet.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/ubuntu-12.04/i386.vmware.base.json
+++ b/templates/ubuntu-12.04/i386.vmware.base.json
@@ -90,7 +90,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/ubuntu-12.04/i386.vmware.vagrant.nocm.json
+++ b/templates/ubuntu-12.04/i386.vmware.vagrant.nocm.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/ubuntu-12.04/i386.vmware.vagrant.puppet.json
+++ b/templates/ubuntu-12.04/i386.vmware.vagrant.puppet.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/ubuntu-12.04/x86_64.virtualbox.base.json
+++ b/templates/ubuntu-12.04/x86_64.virtualbox.base.json
@@ -106,7 +106,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/ubuntu-12.04/x86_64.virtualbox.vagrant.nocm.json
+++ b/templates/ubuntu-12.04/x86_64.virtualbox.vagrant.nocm.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/ubuntu-12.04/x86_64.virtualbox.vagrant.puppet.json
+++ b/templates/ubuntu-12.04/x86_64.virtualbox.vagrant.puppet.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/ubuntu-12.04/x86_64.vmware.base.json
+++ b/templates/ubuntu-12.04/x86_64.vmware.base.json
@@ -90,7 +90,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/ubuntu-12.04/x86_64.vmware.vagrant.nocm.json
+++ b/templates/ubuntu-12.04/x86_64.vmware.vagrant.nocm.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",

--- a/templates/ubuntu-12.04/x86_64.vmware.vagrant.puppet.json
+++ b/templates/ubuntu-12.04/x86_64.vmware.vagrant.puppet.json
@@ -49,7 +49,8 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-puppet.sh",


### PR DESCRIPTION
PR #17 requires PUPPET_NFS environment variable be set in order for the cleanup-puppet.sh script to determine whether the NFS mount should be unmounted before proceeding with Puppet artifact cleanup.
