### PR TITLE
Prefer SATA hard disk interface over IDE

### DIFF
--- a/templates/centos-5.11/i386.virtualbox.base.json
+++ b/templates/centos-5.11/i386.virtualbox.base.json
@@ -30,6 +30,7 @@
       "boot_wait": "10s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
+      "hard_drive_interface": "sata",
       "http_directory": "files",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/templates/centos-5.11/x86_64.virtualbox.base.json
+++ b/templates/centos-5.11/x86_64.virtualbox.base.json
@@ -30,6 +30,7 @@
       "boot_wait": "10s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
+      "hard_drive_interface": "sata",
       "http_directory": "files",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/templates/centos-6.5/i386.virtualbox.base.json
+++ b/templates/centos-6.5/i386.virtualbox.base.json
@@ -30,6 +30,7 @@
       "boot_wait": "10s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
+      "hard_drive_interface": "sata",
       "http_directory": "files",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/templates/centos-6.5/x86_64.virtualbox.base.json
+++ b/templates/centos-6.5/x86_64.virtualbox.base.json
@@ -30,6 +30,7 @@
       "boot_wait": "10s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
+      "hard_drive_interface": "sata",
       "http_directory": "files",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/templates/centos-7.0/x86_64.virtualbox.base.json
+++ b/templates/centos-7.0/x86_64.virtualbox.base.json
@@ -30,6 +30,7 @@
       "boot_wait": "10s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
+      "hard_drive_interface": "sata",
       "http_directory": "files",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/templates/debian-6.0.9/i386.virtualbox.base.json
+++ b/templates/debian-6.0.9/i386.virtualbox.base.json
@@ -44,6 +44,7 @@
       "boot_wait": "10s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
+      "hard_drive_interface": "sata",
       "http_directory": "files",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/templates/debian-6.0.9/x86_64.virtualbox.base.json
+++ b/templates/debian-6.0.9/x86_64.virtualbox.base.json
@@ -44,6 +44,7 @@
       "boot_wait": "10s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
+      "hard_drive_interface": "sata",
       "http_directory": "files",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/templates/debian-7.6/i386.virtualbox.base.json
+++ b/templates/debian-7.6/i386.virtualbox.base.json
@@ -36,6 +36,7 @@
       "boot_wait": "10s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
+      "hard_drive_interface": "sata",
       "http_directory": "files",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/templates/debian-7.6/x86_64.virtualbox.base.json
+++ b/templates/debian-7.6/x86_64.virtualbox.base.json
@@ -36,6 +36,7 @@
       "boot_wait": "10s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
+      "hard_drive_interface": "sata",
       "http_directory": "files",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/templates/oracle-5.10/i386.virtualbox.base.json
+++ b/templates/oracle-5.10/i386.virtualbox.base.json
@@ -30,6 +30,7 @@
       "boot_wait": "10s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
+      "hard_drive_interface": "sata",
       "http_directory": "files",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/templates/oracle-5.10/x86_64.virtualbox.base.json
+++ b/templates/oracle-5.10/x86_64.virtualbox.base.json
@@ -30,6 +30,7 @@
       "boot_wait": "10s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
+      "hard_drive_interface": "sata",
       "http_directory": "files",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/templates/oracle-6.5/i386.virtualbox.base.json
+++ b/templates/oracle-6.5/i386.virtualbox.base.json
@@ -30,6 +30,7 @@
       "boot_wait": "10s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
+      "hard_drive_interface": "sata",
       "http_directory": "files",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/templates/oracle-6.5/x86_64.virtualbox.base.json
+++ b/templates/oracle-6.5/x86_64.virtualbox.base.json
@@ -30,6 +30,7 @@
       "boot_wait": "10s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
+      "hard_drive_interface": "sata",
       "http_directory": "files",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/templates/scientific-5.10/i386.virtualbox.base.json
+++ b/templates/scientific-5.10/i386.virtualbox.base.json
@@ -30,6 +30,7 @@
       "boot_wait": "10s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
+      "hard_drive_interface": "sata",
       "http_directory": "files",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/templates/scientific-5.10/x86_64.virtualbox.base.json
+++ b/templates/scientific-5.10/x86_64.virtualbox.base.json
@@ -30,6 +30,7 @@
       "boot_wait": "10s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
+      "hard_drive_interface": "sata",
       "http_directory": "files",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/templates/scientific-6.5/i386.virtualbox.base.json
+++ b/templates/scientific-6.5/i386.virtualbox.base.json
@@ -30,6 +30,7 @@
       "boot_wait": "10s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
+      "hard_drive_interface": "sata",
       "http_directory": "files",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/templates/scientific-6.5/x86_64.virtualbox.base.json
+++ b/templates/scientific-6.5/x86_64.virtualbox.base.json
@@ -30,6 +30,7 @@
       "boot_wait": "10s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
+      "hard_drive_interface": "sata",
       "http_directory": "files",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/templates/solaris-10/i386.virtualbox.base.json
+++ b/templates/solaris-10/i386.virtualbox.base.json
@@ -37,6 +37,7 @@
         "files/finish"
       ],
       "guest_os_type": "{{user `template_os`}}",
+      "hard_drive_interface": "sata",
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/templates/solaris-11/i386.virtualbox.base.json
+++ b/templates/solaris-11/i386.virtualbox.base.json
@@ -54,6 +54,7 @@
       ],
       "http_directory": "files",
       "guest_os_type": "{{user `template_os`}}",
+      "hard_drive_interface": "sata",
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/templates/ubuntu-12.04/i386.virtualbox.base.json
+++ b/templates/ubuntu-12.04/i386.virtualbox.base.json
@@ -45,6 +45,7 @@
       "boot_wait": "10s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
+      "hard_drive_interface": "sata",
       "http_directory": "files",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/templates/ubuntu-12.04/x86_64.virtualbox.base.json
+++ b/templates/ubuntu-12.04/x86_64.virtualbox.base.json
@@ -45,6 +45,7 @@
       "boot_wait": "10s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
+      "hard_drive_interface": "sata",
       "http_directory": "files",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/templates/ubuntu-14.04/i386.virtualbox.base.json
+++ b/templates/ubuntu-14.04/i386.virtualbox.base.json
@@ -45,6 +45,7 @@
       "boot_wait": "10s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
+      "hard_drive_interface": "sata",
       "http_directory": "files",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/templates/ubuntu-14.04/x86_64.virtualbox.base.json
+++ b/templates/ubuntu-14.04/x86_64.virtualbox.base.json
@@ -45,6 +45,7 @@
       "boot_wait": "10s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
+      "hard_drive_interface": "sata",
       "http_directory": "files",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",


### PR DESCRIPTION
Packer's `virtualbox-iso` builder creates an IDE hard disk interface by
default, presumably for backwards compatibility.

SATA interfaces should be supported on all modern systems; this commit
tells VirtualBox to use SATA instead of IDE.

According to VirtualBox's documentation, the SATA interface is faster;
see https://www.virtualbox.org/manual/ch05.html:

> Like a real SATA controller, VirtualBox's virtual SATA controller
> operates faster and also consumes fewer CPU resources than the virtual
> IDE controller.

This also has the benefit of making it easier to create Vagrant machines
with several hard disks - the SATA interface allows for up to 30 virtual
hard disks compared to 4 under IDE (or 3 if you need a CD-ROM drive).

See the Packer's `virtualbox-iso` documentation:
http://www.packer.io/docs/builders/virtualbox-iso.html