### PR TITLE
Refresh Debian Wheezy

### DIFF
--- a/manifests/modules/packer/manifests/vmtools/params.pp
+++ b/manifests/modules/packer/manifests/vmtools/params.pp
@@ -1,15 +1,17 @@
 class packer::vmtools::params {
 
   case $::osfamily {
-    debian, redhat: {
+    'Redhat' : {
       $root_home = '/root'
-    }
-
-    redhat: {
       $required_packages = [ 'kernel-devel' ]
     }
 
-    default: {
+    'Debian' : {
+      $root_home = '/root'
+      $required_packages = [ "linux-headers-${::kernelrelease}" ]
+    }
+
+    default : {
       fail( "Unsupported platform: ${::osfamily}/${::operatingsystem}" )
     }
   }

--- a/scripts/install-puppet-enterprise.sh
+++ b/scripts/install-puppet-enterprise.sh
@@ -2,7 +2,7 @@
 
 # PE can't be installed with PE, so we'll need to use bash for this step
 
-PEVER='3.3.2'
+PEVER='3.7.2'
 HOSTNAME=$(hostname -f)
 
 cat > /tmp/answers <<EOF
@@ -71,7 +71,7 @@ case ${OPERATINGSYSTEM} in
 esac
 
 
-PE_URL="http://pe-releases.puppetlabs.lan/${PEVER}/${PE_TAR}.tar.gz"
+PE_URL="http://pe-releases.puppetlabs.net/${PEVER}/${PE_TAR}.tar.gz"
 
 tarball_path=$(mktemp)
 wget --output-document="${tarball_path}" "${PE_URL}"

--- a/templates/debian-7.6/CHANGELOG
+++ b/templates/debian-7.6/CHANGELOG
@@ -1,3 +1,0 @@
-### 1.0.0
-
-* Initial release

--- a/templates/debian-7.8/CHANGELOG
+++ b/templates/debian-7.8/CHANGELOG
@@ -1,0 +1,9 @@
+### 1.0.1
+
+* Bump to Debian 7.8
+* Fixups for Virtualbox Guest Additions
+* Bump version for Puppet and PE
+
+### 1.0.0
+
+* Initial release

--- a/templates/debian-7.8/files/preseed.cfg
+++ b/templates/debian-7.8/files/preseed.cfg
@@ -28,7 +28,7 @@ popularity-contest popularity-contest/participate boolean false
 tasksel tasksel/first multiselect standard
 d-i grub-installer/only_debian boolean true
 d-i finish-install/reboot_in_progress note
-d-i pkgsel/include string curl gcc make ntp openssh-server perl sudo wget
+d-i pkgsel/include string curl ntp openssh-server perl sudo wget build-essential
 d-i preseed/early_command string sed -i \
   '/in-target/idiscover(){/sbin/discover|grep -v VirtualBox;}' \
   /usr/lib/pre-pkgsel.d/20install-hwpackages

--- a/templates/debian-7.8/i386.virtualbox.base.json
+++ b/templates/debian-7.8/i386.virtualbox.base.json
@@ -2,11 +2,11 @@
 
   "variables":
     {
-      "template_name": "debian-7.6-x86_64",
-      "template_os": "Debian_64",
+      "template_name": "debian-7.8-i386",
+      "template_os": "Debian",
 
-      "iso_url": "http://cdimage.debian.org/debian-cd/7.6.0/amd64/iso-cd/debian-7.6.0-amd64-netinst.iso",
-      "iso_checksum": "8a3c2ad7fd7a9c4c7e9bcb5cae38c135",
+      "iso_url": "http://cdimage.debian.org/debian-cd/7.8.0/i386/iso-cd/debian-7.8.0-i386-netinst.iso",
+      "iso_checksum": "0d2f88d23a9d5945f5bc0276830c7d2c",
       "iso_checksum_type": "md5",
 
       "memory_size": "512",
@@ -45,7 +45,6 @@
       "ssh_port": 22,
       "ssh_wait_timeout": "10000s",
       "shutdown_command": "/sbin/halt -h -p",
-      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "virtualbox_version_file": ".vbox_version",
       "vboxmanage": [
         [
@@ -59,12 +58,6 @@
           "{{.Name}}",
           "--cpus",
           "{{user `cpu_count`}}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--ioapic",
-          "off"
         ]
       ]
     }

--- a/templates/debian-7.8/i386.virtualbox.vagrant.nocm.json
+++ b/templates/debian-7.8/i386.virtualbox.vagrant.nocm.json
@@ -2,18 +2,18 @@
 
   "variables":
     {
-      "template_name": "debian-7.6-i386",
+      "template_name": "debian-7.8-i386",
 
-      "provisioner": "vmware",
-      "required_modules": "puppetlabs-apt puppetlabs-stdlib saz-sudo",
+      "provisioner": "virtualbox",
+      "required_modules": "puppetlabs-stdlib saz-sudo",
       "puppet_nfs": "{{env `PUPPET_NFS`}}"
     },
 
   "builders": [
     {
-      "name": "{{user `template_name`}}-{{user `provisioner`}}-vagrant-puppet",
-      "type": "vmware-vmx",
-      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
+      "name": "{{user `template_name`}}-{{user `provisioner`}}-vagrant-nocm",
+      "type": "virtualbox-ovf",
+      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.ovf",
       "ssh_username": "root",
       "ssh_password": "puppet",
       "ssh_port": 22,
@@ -42,7 +42,7 @@
         "provisioner": "{{user `provisioner`}}"
       },
       "manifest_dir": "../../manifests",
-      "manifest_file": "../../manifests/vagrant/puppet.pp"
+      "manifest_file": "../../manifests/vagrant/nocm.pp"
     },
 
     {
@@ -63,7 +63,7 @@
   "post-processors": [
     {
       "type": "vagrant",
-      "output": "/opt/output/{{.Provider}}/{{user `template_name`}}-{{.Provider}}-puppet.box"
+      "output": "/opt/output/{{.Provider}}/{{user `template_name`}}-{{.Provider}}-nocm.box"
     }
   ]
 

--- a/templates/debian-7.8/i386.virtualbox.vagrant.pe.json
+++ b/templates/debian-7.8/i386.virtualbox.vagrant.pe.json
@@ -2,16 +2,15 @@
 
   "variables":
     {
-      "template_name": "debian-7.6-x86_64",
+      "template_name": "debian-7.8-i386",
 
       "provisioner": "virtualbox",
-      "required_modules": "puppetlabs-stdlib saz-sudo",
-      "puppet_nfs": "{{env `PUPPET_NFS`}}"
+      "required_modules": "puppetlabs-stdlib saz-sudo"
     },
 
   "builders": [
     {
-      "name": "{{user `template_name`}}-{{user `provisioner`}}-vagrant-nocm",
+      "name": "{{user `template_name`}}-{{user `provisioner`}}-vagrant-pe",
       "type": "virtualbox-ovf",
       "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.ovf",
       "ssh_username": "root",
@@ -28,10 +27,11 @@
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
-        "PUPPET_NFS={{user `puppet_nfs`}}"
+        "OPERATINGSYSTEM=debian",
+        "ARCHITECTURE=i386"
       ],
       "scripts": [
-        "../../scripts/bootstrap-puppet.sh"
+        "../../scripts/install-puppet-enterprise.sh"
       ]
     },
 
@@ -49,11 +49,9 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}",
-        "PUPPET_NFS={{user `puppet_nfs`}}"
+        "TEMPLATE={{user `template_name`}}"
       ],
       "scripts": [
-        "../../scripts/cleanup-puppet.sh",
         "../../scripts/cleanup-packer.sh",
         "../../scripts/cleanup-scrub.sh"
       ]
@@ -63,7 +61,7 @@
   "post-processors": [
     {
       "type": "vagrant",
-      "output": "/opt/output/{{.Provider}}/{{user `template_name`}}-{{.Provider}}-nocm.box"
+      "output": "/opt/output/{{.Provider}}/{{user `template_name`}}-{{.Provider}}-pe.box"
     }
   ]
 

--- a/templates/debian-7.8/i386.virtualbox.vagrant.puppet.json
+++ b/templates/debian-7.8/i386.virtualbox.vagrant.puppet.json
@@ -2,9 +2,9 @@
 
   "variables":
     {
-      "template_name": "debian-7.6-x86_64",
+      "template_name": "debian-7.8-i386",
 
-      "provisioner": "vmware",
+      "provisioner": "virtualbox",
       "required_modules": "puppetlabs-apt puppetlabs-stdlib saz-sudo",
       "puppet_nfs": "{{env `PUPPET_NFS`}}"
     },
@@ -12,8 +12,8 @@
   "builders": [
     {
       "name": "{{user `template_name`}}-{{user `provisioner`}}-vagrant-puppet",
-      "type": "vmware-vmx",
-      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
+      "type": "virtualbox-ovf",
+      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.ovf",
       "ssh_username": "root",
       "ssh_password": "puppet",
       "ssh_port": 22,

--- a/templates/debian-7.8/i386.vmware.base.json
+++ b/templates/debian-7.8/i386.vmware.base.json
@@ -2,17 +2,17 @@
 
   "variables":
     {
-      "template_name": "debian-7.6-i386",
-      "template_os": "Debian",
+      "template_name": "debian-7.8-i386",
+      "template_os": "debian7",
 
-      "iso_url": "http://cdimage.debian.org/debian-cd/7.6.0/i386/iso-cd/debian-7.6.0-i386-netinst.iso",
-      "iso_checksum": "528e1a7315da1bbf50bd4d187880a519",
+      "iso_url": "http://cdimage.debian.org/debian-cd/7.8.0/i386/iso-cd/debian-7.8.0-i386-netinst.iso",
+      "iso_checksum": "0d2f88d23a9d5945f5bc0276830c7d2c",
       "iso_checksum_type": "md5",
 
       "memory_size": "512",
       "cpu_count": "1",
 
-      "provisioner": "virtualbox",
+      "provisioner": "vmware",
       "required_modules": "puppetlabs-stdlib saz-ssh",
       "puppet_nfs": "{{env `PUPPET_NFS`}}"
     },
@@ -20,7 +20,7 @@
   "builders": [
     {
       "name": "{{user `template_name`}}-{{user `provisioner`}}",
-      "type": "virtualbox-iso",
+      "type": "vmware-iso",
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
@@ -45,22 +45,12 @@
       "ssh_port": 22,
       "ssh_wait_timeout": "10000s",
       "shutdown_command": "/sbin/halt -h -p",
-      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
-      "virtualbox_version_file": ".vbox_version",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{user `memory_size`}}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{user `cpu_count`}}"
-        ]
-      ]
+      "tools_upload_flavor": "linux",
+      "vmx_data": {
+        "memsize": "{{user `memory_size`}}",
+        "numvcpus": "{{user `cpu_count`}}",
+        "cpuid.coresPerSocket": "1"
+      }
     }
   ],
 

--- a/templates/debian-7.8/i386.vmware.vagrant.nocm.json
+++ b/templates/debian-7.8/i386.vmware.vagrant.nocm.json
@@ -2,17 +2,18 @@
 
   "variables":
     {
-      "template_name": "debian-7.6-x86_64",
+      "template_name": "debian-7.8-i386",
 
-      "provisioner": "virtualbox",
-      "required_modules": "puppetlabs-stdlib saz-sudo"
+      "provisioner": "vmware",
+      "required_modules": "puppetlabs-stdlib saz-sudo",
+      "puppet_nfs": "{{env `PUPPET_NFS`}}"
     },
 
   "builders": [
     {
-      "name": "{{user `template_name`}}-{{user `provisioner`}}-vagrant-pe",
-      "type": "virtualbox-ovf",
-      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.ovf",
+      "name": "{{user `template_name`}}-{{user `provisioner`}}-vagrant-nocm",
+      "type": "vmware-vmx",
+      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
       "ssh_username": "root",
       "ssh_password": "puppet",
       "ssh_port": 22,
@@ -27,11 +28,10 @@
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
-        "OPERATINGSYSTEM=debian",
-        "ARCHITECTURE=x86_64"
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
-        "../../scripts/install-puppet-enterprise.sh"
+        "../../scripts/bootstrap-puppet.sh"
       ]
     },
 
@@ -49,9 +49,11 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
+        "../../scripts/cleanup-puppet.sh",
         "../../scripts/cleanup-packer.sh",
         "../../scripts/cleanup-scrub.sh"
       ]
@@ -61,7 +63,7 @@
   "post-processors": [
     {
       "type": "vagrant",
-      "output": "/opt/output/{{.Provider}}/{{user `template_name`}}-{{.Provider}}-pe.box"
+      "output": "/opt/output/{{.Provider}}/{{user `template_name`}}-{{.Provider}}-nocm.box"
     }
   ]
 

--- a/templates/debian-7.8/i386.vmware.vagrant.pe.json
+++ b/templates/debian-7.8/i386.vmware.vagrant.pe.json
@@ -2,18 +2,17 @@
 
   "variables":
     {
-      "template_name": "debian-7.6-x86_64",
+      "template_name": "debian-7.8-i386",
 
-      "provisioner": "virtualbox",
-      "required_modules": "puppetlabs-apt puppetlabs-stdlib saz-sudo",
-      "puppet_nfs": "{{env `PUPPET_NFS`}}"
+      "provisioner": "vmware",
+      "required_modules": "puppetlabs-stdlib saz-sudo"
     },
 
   "builders": [
     {
-      "name": "{{user `template_name`}}-{{user `provisioner`}}-vagrant-puppet",
-      "type": "virtualbox-ovf",
-      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.ovf",
+      "name": "{{user `template_name`}}-{{user `provisioner`}}-vagrant-pe",
+      "type": "vmware-vmx",
+      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
       "ssh_username": "root",
       "ssh_password": "puppet",
       "ssh_port": 22,
@@ -28,10 +27,11 @@
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
-        "PUPPET_NFS={{user `puppet_nfs`}}"
+        "OPERATINGSYSTEM=debian",
+        "ARCHITECTURE=i386"
       ],
       "scripts": [
-        "../../scripts/bootstrap-puppet.sh"
+        "../../scripts/install-puppet-enterprise.sh"
       ]
     },
 
@@ -42,18 +42,16 @@
         "provisioner": "{{user `provisioner`}}"
       },
       "manifest_dir": "../../manifests",
-      "manifest_file": "../../manifests/vagrant/puppet.pp"
+      "manifest_file": "../../manifests/vagrant/nocm.pp"
     },
 
     {
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}",
-        "PUPPET_NFS={{user `puppet_nfs`}}"
+        "TEMPLATE={{user `template_name`}}"
       ],
       "scripts": [
-        "../../scripts/cleanup-puppet.sh",
         "../../scripts/cleanup-packer.sh",
         "../../scripts/cleanup-scrub.sh"
       ]
@@ -63,7 +61,7 @@
   "post-processors": [
     {
       "type": "vagrant",
-      "output": "/opt/output/{{.Provider}}/{{user `template_name`}}-{{.Provider}}-puppet.box"
+      "output": "/opt/output/{{.Provider}}/{{user `template_name`}}-{{.Provider}}-pe.box"
     }
   ]
 

--- a/templates/debian-7.8/i386.vmware.vagrant.puppet.json
+++ b/templates/debian-7.8/i386.vmware.vagrant.puppet.json
@@ -2,16 +2,16 @@
 
   "variables":
     {
-      "template_name": "debian-7.6-i386",
+      "template_name": "debian-7.8-i386",
 
       "provisioner": "vmware",
-      "required_modules": "puppetlabs-stdlib saz-sudo",
+      "required_modules": "puppetlabs-apt puppetlabs-stdlib saz-sudo",
       "puppet_nfs": "{{env `PUPPET_NFS`}}"
     },
 
   "builders": [
     {
-      "name": "{{user `template_name`}}-{{user `provisioner`}}-vagrant-nocm",
+      "name": "{{user `template_name`}}-{{user `provisioner`}}-vagrant-puppet",
       "type": "vmware-vmx",
       "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
       "ssh_username": "root",
@@ -42,7 +42,7 @@
         "provisioner": "{{user `provisioner`}}"
       },
       "manifest_dir": "../../manifests",
-      "manifest_file": "../../manifests/vagrant/nocm.pp"
+      "manifest_file": "../../manifests/vagrant/puppet.pp"
     },
 
     {
@@ -63,7 +63,7 @@
   "post-processors": [
     {
       "type": "vagrant",
-      "output": "/opt/output/{{.Provider}}/{{user `template_name`}}-{{.Provider}}-nocm.box"
+      "output": "/opt/output/{{.Provider}}/{{user `template_name`}}-{{.Provider}}-puppet.box"
     }
   ]
 

--- a/templates/debian-7.8/vagrantcloud.yaml
+++ b/templates/debian-7.8/vagrantcloud.yaml
@@ -1,7 +1,7 @@
 ---
-name: 'debian-7.6'
-description: 'Debian 7.6 (wheezy)'
-version: '1.0.0'
+name: 'debian-7.8'
+description: 'Debian 7.8 (wheezy)'
+version: '1.0.1'
 
 arches:
   - name: '32'
@@ -13,6 +13,6 @@ configs:
   - name: 'nocm'
     description: 'no configuration management software'
   - name: 'puppet'
-    description: 'Puppet 3.7.1'
+    description: 'Puppet 3.7.4'
   - name: 'puppet-enterprise'
-    description: 'Puppet Enterprise 3.3.2 (agent-only)'
+    description: 'Puppet Enterprise 3.7.2 (agent-only)'

--- a/templates/debian-7.8/x86_64.ec2.nocm.json
+++ b/templates/debian-7.8/x86_64.ec2.nocm.json
@@ -5,8 +5,8 @@
     "pe_url": "'https://pm.puppetlabs.com/cgi-bin/download.cgi?ver=latest&dist=debian&arch=amd64&rel=7'",
     "provisioner": "ec2",
     "source_ami": "ami-f1c5bcc1",
-    "ami_description": "puppetlabs-debian-7.6-x86_64 {{timestamp}}",
-    "ami_name": "puppetlabs-debian-7.6-x86_64 {{timestamp}}",
+    "ami_description": "puppetlabs-debian-7.8-x86_64 {{timestamp}}",
+    "ami_name": "puppetlabs-debian-7.8-x86_64 {{timestamp}}",
     "required_modules": "puppetlabs-stdlib saz-ssh",
     "user_data": "#cloud-config\ndisable_root: 0\n"
   },

--- a/templates/debian-7.8/x86_64.virtualbox.base.json
+++ b/templates/debian-7.8/x86_64.virtualbox.base.json
@@ -2,17 +2,17 @@
 
   "variables":
     {
-      "template_name": "debian-7.6-x86_64",
-      "template_os": "debian7-64",
+      "template_name": "debian-7.8-x86_64",
+      "template_os": "Debian_64",
 
-      "iso_url": "http://cdimage.debian.org/debian-cd/7.6.0/amd64/iso-cd/debian-7.6.0-amd64-netinst.iso",
-      "iso_checksum": "8a3c2ad7fd7a9c4c7e9bcb5cae38c135",
+      "iso_url": "http://cdimage.debian.org/debian-cd/7.8.0/amd64/iso-cd/debian-7.8.0-amd64-netinst.iso",
+      "iso_checksum": "a91fba5001cf0fbccb44a7ae38c63b6e",
       "iso_checksum_type": "md5",
 
       "memory_size": "512",
       "cpu_count": "1",
 
-      "provisioner": "vmware",
+      "provisioner": "virtualbox",
       "required_modules": "puppetlabs-stdlib saz-ssh",
       "puppet_nfs": "{{env `PUPPET_NFS`}}"
     },
@@ -20,7 +20,7 @@
   "builders": [
     {
       "name": "{{user `template_name`}}-{{user `provisioner`}}",
-      "type": "vmware-iso",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
@@ -45,12 +45,27 @@
       "ssh_port": 22,
       "ssh_wait_timeout": "10000s",
       "shutdown_command": "/sbin/halt -h -p",
-      "tools_upload_flavor": "linux",
-      "vmx_data": {
-        "memsize": "{{user `memory_size`}}",
-        "numvcpus": "{{user `cpu_count`}}",
-        "cpuid.coresPerSocket": "1"
-      }
+      "virtualbox_version_file": ".vbox_version",
+      "vboxmanage": [
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "{{user `memory_size`}}"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "{{user `cpu_count`}}"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--ioapic",
+          "off"
+        ]
+      ]
     }
   ],
 

--- a/templates/debian-7.8/x86_64.virtualbox.vagrant.nocm.json
+++ b/templates/debian-7.8/x86_64.virtualbox.vagrant.nocm.json
@@ -2,17 +2,18 @@
 
   "variables":
     {
-      "template_name": "debian-7.6-x86_64",
+      "template_name": "debian-7.8-x86_64",
 
-      "provisioner": "vmware",
-      "required_modules": "puppetlabs-stdlib saz-sudo"
+      "provisioner": "virtualbox",
+      "required_modules": "puppetlabs-stdlib saz-sudo",
+      "puppet_nfs": "{{env `PUPPET_NFS`}}"
     },
 
   "builders": [
     {
-      "name": "{{user `template_name`}}-{{user `provisioner`}}-vagrant-pe",
-      "type": "vmware-vmx",
-      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
+      "name": "{{user `template_name`}}-{{user `provisioner`}}-vagrant-nocm",
+      "type": "virtualbox-ovf",
+      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.ovf",
       "ssh_username": "root",
       "ssh_password": "puppet",
       "ssh_port": 22,
@@ -27,11 +28,10 @@
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
-        "OPERATINGSYSTEM=debian",
-        "ARCHITECTURE=x86_64"
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
-        "../../scripts/install-puppet-enterprise.sh"
+        "../../scripts/bootstrap-puppet.sh"
       ]
     },
 
@@ -49,9 +49,11 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
+        "../../scripts/cleanup-puppet.sh",
         "../../scripts/cleanup-packer.sh",
         "../../scripts/cleanup-scrub.sh"
       ]
@@ -61,7 +63,7 @@
   "post-processors": [
     {
       "type": "vagrant",
-      "output": "/opt/output/{{.Provider}}/{{user `template_name`}}-{{.Provider}}-pe.box"
+      "output": "/opt/output/{{.Provider}}/{{user `template_name`}}-{{.Provider}}-nocm.box"
     }
   ]
 

--- a/templates/debian-7.8/x86_64.virtualbox.vagrant.pe.json
+++ b/templates/debian-7.8/x86_64.virtualbox.vagrant.pe.json
@@ -2,18 +2,17 @@
 
   "variables":
     {
-      "template_name": "debian-7.6-x86_64",
+      "template_name": "debian-7.8-x86_64",
 
-      "provisioner": "vmware",
-      "required_modules": "puppetlabs-stdlib saz-sudo",
-      "puppet_nfs": "{{env `PUPPET_NFS`}}"
+      "provisioner": "virtualbox",
+      "required_modules": "puppetlabs-stdlib saz-sudo"
     },
 
   "builders": [
     {
-      "name": "{{user `template_name`}}-{{user `provisioner`}}-vagrant-nocm",
-      "type": "vmware-vmx",
-      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
+      "name": "{{user `template_name`}}-{{user `provisioner`}}-vagrant-pe",
+      "type": "virtualbox-ovf",
+      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.ovf",
       "ssh_username": "root",
       "ssh_password": "puppet",
       "ssh_port": 22,
@@ -28,10 +27,11 @@
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
-        "PUPPET_NFS={{user `puppet_nfs`}}"
+        "OPERATINGSYSTEM=debian",
+        "ARCHITECTURE=x86_64"
       ],
       "scripts": [
-        "../../scripts/bootstrap-puppet.sh"
+        "../../scripts/install-puppet-enterprise.sh"
       ]
     },
 
@@ -49,11 +49,9 @@
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}",
-        "PUPPET_NFS={{user `puppet_nfs`}}"
+        "TEMPLATE={{user `template_name`}}"
       ],
       "scripts": [
-        "../../scripts/cleanup-puppet.sh",
         "../../scripts/cleanup-packer.sh",
         "../../scripts/cleanup-scrub.sh"
       ]
@@ -63,7 +61,7 @@
   "post-processors": [
     {
       "type": "vagrant",
-      "output": "/opt/output/{{.Provider}}/{{user `template_name`}}-{{.Provider}}-nocm.box"
+      "output": "/opt/output/{{.Provider}}/{{user `template_name`}}-{{.Provider}}-pe.box"
     }
   ]
 

--- a/templates/debian-7.8/x86_64.virtualbox.vagrant.puppet.json
+++ b/templates/debian-7.8/x86_64.virtualbox.vagrant.puppet.json
@@ -2,7 +2,7 @@
 
   "variables":
     {
-      "template_name": "debian-7.6-i386",
+      "template_name": "debian-7.8-x86_64",
 
       "provisioner": "virtualbox",
       "required_modules": "puppetlabs-apt puppetlabs-stdlib saz-sudo",

--- a/templates/debian-7.8/x86_64.vmware.base.json
+++ b/templates/debian-7.8/x86_64.vmware.base.json
@@ -2,11 +2,11 @@
 
   "variables":
     {
-      "template_name": "debian-7.6-i386",
-      "template_os": "debian7",
+      "template_name": "debian-7.8-x86_64",
+      "template_os": "debian7-64",
 
-      "iso_url": "http://cdimage.debian.org/debian-cd/7.6.0/i386/iso-cd/debian-7.6.0-i386-netinst.iso",
-      "iso_checksum": "528e1a7315da1bbf50bd4d187880a519",
+      "iso_url": "http://cdimage.debian.org/debian-cd/7.8.0/amd64/iso-cd/debian-7.8.0-amd64-netinst.iso",
+      "iso_checksum": "a91fba5001cf0fbccb44a7ae38c63b6e",
       "iso_checksum_type": "md5",
 
       "memory_size": "512",

--- a/templates/debian-7.8/x86_64.vmware.vagrant.nocm.json
+++ b/templates/debian-7.8/x86_64.vmware.vagrant.nocm.json
@@ -2,9 +2,9 @@
 
   "variables":
     {
-      "template_name": "debian-7.6-i386",
+      "template_name": "debian-7.8-x86_64",
 
-      "provisioner": "virtualbox",
+      "provisioner": "vmware",
       "required_modules": "puppetlabs-stdlib saz-sudo",
       "puppet_nfs": "{{env `PUPPET_NFS`}}"
     },
@@ -12,8 +12,8 @@
   "builders": [
     {
       "name": "{{user `template_name`}}-{{user `provisioner`}}-vagrant-nocm",
-      "type": "virtualbox-ovf",
-      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.ovf",
+      "type": "vmware-vmx",
+      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
       "ssh_username": "root",
       "ssh_password": "puppet",
       "ssh_port": 22,

--- a/templates/debian-7.8/x86_64.vmware.vagrant.pe.json
+++ b/templates/debian-7.8/x86_64.vmware.vagrant.pe.json
@@ -2,17 +2,17 @@
 
   "variables":
     {
-      "template_name": "debian-7.6-i386",
+      "template_name": "debian-7.8-x86_64",
 
-      "provisioner": "virtualbox",
+      "provisioner": "vmware",
       "required_modules": "puppetlabs-stdlib saz-sudo"
     },
 
   "builders": [
     {
       "name": "{{user `template_name`}}-{{user `provisioner`}}-vagrant-pe",
-      "type": "virtualbox-ovf",
-      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.ovf",
+      "type": "vmware-vmx",
+      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
       "ssh_username": "root",
       "ssh_password": "puppet",
       "ssh_port": 22,
@@ -28,7 +28,7 @@
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "OPERATINGSYSTEM=debian",
-        "ARCHITECTURE=i386"
+        "ARCHITECTURE=x86_64"
       ],
       "scripts": [
         "../../scripts/install-puppet-enterprise.sh"

--- a/templates/debian-7.8/x86_64.vmware.vagrant.puppet.json
+++ b/templates/debian-7.8/x86_64.vmware.vagrant.puppet.json
@@ -2,15 +2,16 @@
 
   "variables":
     {
-      "template_name": "debian-7.6-i386",
+      "template_name": "debian-7.8-x86_64",
 
       "provisioner": "vmware",
-      "required_modules": "puppetlabs-stdlib saz-sudo"
+      "required_modules": "puppetlabs-apt puppetlabs-stdlib saz-sudo",
+      "puppet_nfs": "{{env `PUPPET_NFS`}}"
     },
 
   "builders": [
     {
-      "name": "{{user `template_name`}}-{{user `provisioner`}}-vagrant-pe",
+      "name": "{{user `template_name`}}-{{user `provisioner`}}-vagrant-puppet",
       "type": "vmware-vmx",
       "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
       "ssh_username": "root",
@@ -27,11 +28,10 @@
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
-        "OPERATINGSYSTEM=debian",
-        "ARCHITECTURE=i386"
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
-        "../../scripts/install-puppet-enterprise.sh"
+        "../../scripts/bootstrap-puppet.sh"
       ]
     },
 
@@ -42,16 +42,18 @@
         "provisioner": "{{user `provisioner`}}"
       },
       "manifest_dir": "../../manifests",
-      "manifest_file": "../../manifests/vagrant/nocm.pp"
+      "manifest_file": "../../manifests/vagrant/puppet.pp"
     },
 
     {
       "type": "shell",
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
-        "TEMPLATE={{user `template_name`}}"
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
+        "../../scripts/cleanup-puppet.sh",
         "../../scripts/cleanup-packer.sh",
         "../../scripts/cleanup-scrub.sh"
       ]
@@ -61,7 +63,7 @@
   "post-processors": [
     {
       "type": "vagrant",
-      "output": "/opt/output/{{.Provider}}/{{user `template_name`}}-{{.Provider}}-pe.box"
+      "output": "/opt/output/{{.Provider}}/{{user `template_name`}}-{{.Provider}}-puppet.box"
     }
   ]
 


### PR DESCRIPTION
This PR refreshes the vagrant boxes for Debian Wheezy.  The OS is bumped from 7.6 to 7.8, both Puppet and PE get version bumps, and a couple issues are addressed with the Virtualbox Guest Additions.