### PR TITLE
(maint) vmware tools vmhgfs patch for Wheezy

### DIFF
--- a/templates/debian-7.8/files/inode.c.patch
+++ b/templates/debian-7.8/files/inode.c.patch
@@ -1,0 +1,20 @@
+--- vmhgfs-only/inode.c	2015-01-07 15:51:14.000000000 -0800
++++ vmhgfs-only/inode.c.new	2015-03-06 07:04:18.000000000 -0800
+@@ -1922,7 +1922,7 @@
+                            p,
+ #endif
+                            &inode->i_dentry,
+-                           d_alias) {
++                           d_u.d_alias) {
+          int dcount = hgfs_d_count(dentry);
+          if (dcount) {
+             LOG(4, ("Found %s %d \n", dentry->d_name.name, dcount));
+@@ -1975,7 +1975,7 @@
+       /* Find a dentry with valid d_count. Refer bug 587879. */
+       list_for_each(pos, &inode->i_dentry) {
+          int dcount;
+-         struct dentry *dentry = list_entry(pos, struct dentry, d_alias);
++         struct dentry *dentry = list_entry(pos, struct dentry, d_u.d_alias);
+          dcount = hgfs_d_count(dentry);
+          if (dcount) {
+             LOG(4, ("Found %s %d \n", (dentry)->d_name.name, dcount));

--- a/templates/debian-7.8/i386.vmware.base.json
+++ b/templates/debian-7.8/i386.vmware.base.json
@@ -78,13 +78,19 @@
     },
 
     {
+      "type": "file",
+      "source": "files/inode.c.patch",
+      "destination": "/tmp/inode.c.patch"
+    },
+
+    {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
+        "scripts/patch-tools.sh",
         "../../scripts/cleanup-puppet.sh",
         "../../scripts/cleanup-packer.sh"
       ]

--- a/templates/debian-7.8/scripts/patch-tools.sh
+++ b/templates/debian-7.8/scripts/patch-tools.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+pushd /usr/lib/vmware-tools/modules/source
+if [[ ! -f vmhgfs.tar.orig ]]
+then
+  cp vmhgfs.tar vmhgfs.tar.orig
+fi
+
+rm -rf vmhgfs-only
+tar xf vmhgfs.tar
+
+pushd vmhgfs-only
+patch -p1 < /tmp/inode.c.patch
+popd
+
+tar cf vmhgfs.tar vmhgfs-only
+rm -rf vmhgfs-only
+rm -rf /tmp/inode.c.patch
+popd
+
+/usr/bin/vmware-config-tools.pl --default

--- a/templates/debian-7.8/x86_64.vmware.base.json
+++ b/templates/debian-7.8/x86_64.vmware.base.json
@@ -78,13 +78,19 @@
     },
 
     {
+      "type": "file",
+      "source": "files/inode.c.patch",
+      "destination": "/tmp/inode.c.patch"
+    },
+
+    {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
+        "scripts/patch-tools.sh",
         "../../scripts/cleanup-puppet.sh",
         "../../scripts/cleanup-packer.sh"
       ]


### PR DESCRIPTION
inode.c d_alias patch required to successfully compile the vmhgfs module
on Debian Wheezy