### PR TITLE
(maint) bump box version for Wheezy

### DIFF
--- a/templates/debian-7.8/CHANGELOG
+++ b/templates/debian-7.8/CHANGELOG
@@ -1,3 +1,7 @@
+### 1.0.2
+
+* inode.c d_alias patch required to successfully compile the vmhgfs module
+
 ### 1.0.1
 
 * Bump to Debian 7.8

--- a/templates/debian-7.8/vagrantcloud.yaml
+++ b/templates/debian-7.8/vagrantcloud.yaml
@@ -1,7 +1,7 @@
 ---
 name: 'debian-7.8'
 description: 'Debian 7.8 (wheezy)'
-version: '1.0.1'
+version: '1.0.2'
 
 arches:
   - name: '32'


### PR DESCRIPTION
successful build of the vmhgfs module using the inode.c d_alias patch.
This commit will bump the box version of Wheezy that we ship to
vagrantcloud.