### PR TITLE
(RE-4873) initial AIO packaging updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 packer_cache
 output-*
+*.bak

--- a/manifests/modules/packer/manifests/puppet.pp
+++ b/manifests/modules/packer/manifests/puppet.pp
@@ -4,26 +4,31 @@ class packer::puppet {
     debian: {
       include apt
 
-      apt::source { 'puppetlabs':
-        location => 'http://apt.puppetlabs.com',
-        repos    => 'main dependencies',
+      apt::source { 'puppetlabs-pc1':
+        location   => 'http://apt.puppetlabs.com',
+        repos      => 'PC1',
         key        => '4BD6EC30',
         key_server => 'pgp.mit.edu',
       }
 
-      package { 'puppet':
+      package { 'puppet-agent':
         ensure  => present,
-        require => Apt::Source[ 'puppetlabs' ],
+        require => Apt::Source[ 'puppetlabs-pc1' ],
       }
     }
 
     redhat: {
-      class { 'puppetlabs_yum': }
+      yumrepo { 'puppetlabs-pc1':
+        baseurl  => 'http://yum.puppetlabs.com/el/$releasever/PC1/$basearch',
+        descr    => 'Puppet Labs PC1 Repository el $releasever - $basearch',
+        gpgkey   => 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs',
+        enabled  => '1',
+        gpgcheck => '1',
+      }
 
-      package { 'puppet':
-        ensure   => present,
-        provider => 'yum',
-        require  => Class[ 'puppetlabs_yum' ],
+      package { 'puppet-agent':
+        ensure  => present,
+        require => Yumrepo[ 'puppetlabs-pc1' ],
       }
     }
 

--- a/manifests/modules/packer/manifests/vmtools.pp
+++ b/manifests/modules/packer/manifests/vmtools.pp
@@ -2,8 +2,8 @@ class packer::vmtools inherits packer::vmtools::params {
 
   if ( $required_packages != undef ) {
     package { $required_packages:
-      ensure     => installed,
-      before     => File[ '/tmp/vmtools' ],
+      ensure => installed,
+      before => File[ '/tmp/vmtools' ],
     }
   }
 

--- a/manifests/modules/packer/manifests/vmtools.pp
+++ b/manifests/modules/packer/manifests/vmtools.pp
@@ -2,8 +2,8 @@ class packer::vmtools inherits packer::vmtools::params {
 
   if ( $required_packages != undef ) {
     package { $required_packages:
-      ensure => installed,
-      before => File[ '/tmp/vmtools' ],
+      ensure     => installed,
+      before     => File[ '/tmp/vmtools' ],
     }
   }
 

--- a/scripts/bootstrap-puppet.sh
+++ b/scripts/bootstrap-puppet.sh
@@ -7,7 +7,7 @@ if [ -n "${PUPPET_NFS}" ]; then
   # Create mount point and required directories
   mkdir -p /opt/puppet
   mkdir -p /etc/puppetlabs
-  mkdir -p /var/opt/lib/pe-puppet
+  mkdir -p /var/opt/puppetlabs/puppet
 
   mount -o ro -t nfs ${PUPPET_NFS}/${TEMPLATE} /opt/puppet
 elif [ -n "${PE_URL}" ]; then

--- a/scripts/cleanup-puppet.sh
+++ b/scripts/cleanup-puppet.sh
@@ -6,7 +6,8 @@ if [ -n "${PUPPET_NFS}" ]; then
 fi
 
 # Remove Puppet-related files and directories
-rm -rf /etc/puppetlabs
+#rm -rf /etc/puppetlabs
 rm -rf /opt/puppet
 rm -rf /var/cache/yum/puppetdeps
 rm -rf /var/opt/lib/pe-puppet
+rm -rf /var/opt/puppetlabs/puppet

--- a/scripts/install-puppet-enterprise.sh
+++ b/scripts/install-puppet-enterprise.sh
@@ -2,7 +2,7 @@
 
 # PE can't be installed with PE, so we'll need to use bash for this step
 
-PEVER='3.7.2'
+PEVER='3.8.1'
 HOSTNAME=$(hostname -f)
 
 cat > /tmp/answers <<EOF

--- a/templates/centos-5.11/CHANGELOG
+++ b/templates/centos-5.11/CHANGELOG
@@ -1,3 +1,8 @@
+### 1.0.2
+
+* Switch to puppet-agent packaging
+* Bump version for Puppet and PE
+
 ### 1.0.1
 
 * Base image update 

--- a/templates/centos-5.11/files/i386.ks
+++ b/templates/centos-5.11/files/i386.ks
@@ -1,6 +1,5 @@
 install
-
-url --url=http://mirrors.cat.pdx.edu/centos/5.11/os/i386/
+cdrom
 lang en_US.UTF-8
 keyboard us
 network --bootproto=dhcp
@@ -21,11 +20,6 @@ autopart
 auth  --useshadow  --enablemd5
 firstboot --disabled
 reboot --eject
-
-repo --name=updates --baseurl=http://mirrors.cat.pdx.edu/centos/5.11/updates/i386/
-repo --name=epel --mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-5&arch=i386
-repo --name=puppetlabs --baseurl=http://yum.puppetlabs.com/el/5/products/i386/
-repo --name=puppetdeps --baseurl=http://yum.puppetlabs.com/el/5/dependencies/i386/
 
 %packages --ignoremissing
 @base

--- a/templates/centos-5.11/files/x86_64.ks
+++ b/templates/centos-5.11/files/x86_64.ks
@@ -1,6 +1,5 @@
 install
-
-url --url=http://mirrors.cat.pdx.edu/centos/5.11/os/x86_64/
+cdrom
 lang en_US.UTF-8
 keyboard us
 network --bootproto=dhcp
@@ -21,11 +20,6 @@ autopart
 auth  --useshadow  --enablemd5
 firstboot --disabled
 reboot --eject
-
-repo --name=updates --baseurl=http://mirrors.cat.pdx.edu/centos/5.11/updates/x86_64/
-repo --name=epel --mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-5&arch=x86_64
-repo --name=puppetlabs --baseurl=http://yum.puppetlabs.com/el/5/products/x86_64/
-repo --name=puppetdeps --baseurl=http://yum.puppetlabs.com/el/5/dependencies/x86_64/
 
 %packages --ignoremissing
 @base

--- a/templates/centos-5.11/i386.virtualbox.base.json
+++ b/templates/centos-5.11/i386.virtualbox.base.json
@@ -5,8 +5,8 @@
       "template_name": "centos-5.11-i386",
       "template_os": "RedHat",
 
-      "iso_url": "http://mirrors.cat.pdx.edu/centos/5.11/isos/i386/CentOS-5.11-i386-netinstall.iso",
-      "iso_checksum": "3f43eb9f3e2d45425baf691c0142f79d",
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/CentOS-5.11-i386-bin-DVD-1of2.iso",
+      "iso_checksum": "6ec9fd58d5e05ad9d336fa391928c5de",
       "iso_checksum_type": "md5",
 
       "memory_size": "512",

--- a/templates/centos-5.11/i386.virtualbox.base.json
+++ b/templates/centos-5.11/i386.virtualbox.base.json
@@ -72,7 +72,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-5.11/i386.virtualbox.vagrant.nocm.json
+++ b/templates/centos-5.11/i386.virtualbox.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-5.11/i386.virtualbox.vagrant.pe.json
+++ b/templates/centos-5.11/i386.virtualbox.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-5.11/i386.virtualbox.vagrant.puppet.json
+++ b/templates/centos-5.11/i386.virtualbox.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-5.11/i386.vmware.base.json
+++ b/templates/centos-5.11/i386.vmware.base.json
@@ -63,7 +63,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-5.11/i386.vmware.base.json
+++ b/templates/centos-5.11/i386.vmware.base.json
@@ -5,8 +5,8 @@
       "template_name": "centos-5.11-i386",
       "template_os": "rhel6",
 
-      "iso_url": "http://mirrors.cat.pdx.edu/centos/5.11/isos/i386/CentOS-5.11-i386-netinstall.iso",
-      "iso_checksum": "3f43eb9f3e2d45425baf691c0142f79d",
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/CentOS-5.11-i386-bin-DVD-1of2.iso",
+      "iso_checksum": "6ec9fd58d5e05ad9d336fa391928c5de",
       "iso_checksum_type": "md5",
 
       "memory_size": "512",

--- a/templates/centos-5.11/i386.vmware.vagrant.nocm.json
+++ b/templates/centos-5.11/i386.vmware.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-5.11/i386.vmware.vagrant.pe.json
+++ b/templates/centos-5.11/i386.vmware.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-5.11/i386.vmware.vagrant.puppet.json
+++ b/templates/centos-5.11/i386.vmware.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-5.11/vagrantcloud.yaml
+++ b/templates/centos-5.11/vagrantcloud.yaml
@@ -1,7 +1,7 @@
 ---
 name: 'centos-5.11'
 description: 'CentOS 5.11'
-version: '1.0.1'
+version: '1.0.2'
 
 arches:
   - name: '32'
@@ -13,6 +13,6 @@ configs:
   - name: 'nocm'
     description: 'no configuration management software'
   - name: 'puppet'
-    description: 'Puppet 3.7.4'
+    description: 'Puppet 4.2.0'
   - name: 'puppet-enterprise'
-    description: 'Puppet Enterprise 3.7.2 (agent-only)'
+    description: 'Puppet Enterprise 3.8.1 (agent-only)'

--- a/templates/centos-5.11/x86_64.virtualbox.base.json
+++ b/templates/centos-5.11/x86_64.virtualbox.base.json
@@ -5,8 +5,8 @@
       "template_name": "centos-5.11-x86_64",
       "template_os": "RedHat_64",
 
-      "iso_url": "http://mirrors.cat.pdx.edu/centos/5.11/isos/x86_64/CentOS-5.11-x86_64-netinstall.iso",
-      "iso_checksum": "f2087f9af0d50df05144a1f0d1c5b404",
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/CentOS-5.11-x86_64-bin-DVD-1of2.iso",
+      "iso_checksum": "2deb566098aa21ebfd829ff147a1f71c",
       "iso_checksum_type": "md5",
 
       "memory_size": "512",

--- a/templates/centos-5.11/x86_64.virtualbox.base.json
+++ b/templates/centos-5.11/x86_64.virtualbox.base.json
@@ -72,7 +72,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-5.11/x86_64.virtualbox.vagrant.nocm.json
+++ b/templates/centos-5.11/x86_64.virtualbox.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-5.11/x86_64.virtualbox.vagrant.pe.json
+++ b/templates/centos-5.11/x86_64.virtualbox.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-5.11/x86_64.virtualbox.vagrant.puppet.json
+++ b/templates/centos-5.11/x86_64.virtualbox.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-5.11/x86_64.vmware.base.json
+++ b/templates/centos-5.11/x86_64.vmware.base.json
@@ -5,8 +5,8 @@
       "template_name": "centos-5.11-x86_64",
       "template_os": "rhel6-64",
 
-      "iso_url": "http://mirrors.cat.pdx.edu/centos/5.11/isos/x86_64/CentOS-5.11-x86_64-netinstall.iso",
-      "iso_checksum": "f2087f9af0d50df05144a1f0d1c5b404",
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/CentOS-5.11-x86_64-bin-DVD-1of2.iso",
+      "iso_checksum": "2deb566098aa21ebfd829ff147a1f71c",
       "iso_checksum_type": "md5",
 
       "memory_size": "512",

--- a/templates/centos-5.11/x86_64.vmware.base.json
+++ b/templates/centos-5.11/x86_64.vmware.base.json
@@ -63,7 +63,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-5.11/x86_64.vmware.vagrant.nocm.json
+++ b/templates/centos-5.11/x86_64.vmware.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-5.11/x86_64.vmware.vagrant.pe.json
+++ b/templates/centos-5.11/x86_64.vmware.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-5.11/x86_64.vmware.vagrant.puppet.json
+++ b/templates/centos-5.11/x86_64.vmware.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-6.6/CHANGELOG
+++ b/templates/centos-6.6/CHANGELOG
@@ -1,3 +1,8 @@
+### 1.0.2
+
+* Switch to puppet-agent packaging
+* Bump version for Puppet and PE
+
 ### 1.0.1
 
 * Bump version to CentOS 6.6 

--- a/templates/centos-6.6/files/i386.ks
+++ b/templates/centos-6.6/files/i386.ks
@@ -1,6 +1,5 @@
 install
-
-url --url=http://mirror.centos.org/centos-6/6/os/i386/
+cdrom
 lang en_US.UTF-8
 keyboard us
 network --bootproto=dhcp
@@ -21,11 +20,6 @@ autopart
 auth  --useshadow  --enablemd5
 firstboot --disabled
 reboot --eject
-
-repo --name=updates --baseurl=http://mirror.centos.org/centos-6/6/updates/i386/
-repo --name=epel --mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-6&arch=i386
-repo --name=puppetlabs --baseurl=http://yum.puppetlabs.com/el/6/products/i386/
-repo --name=puppetdeps --baseurl=http://yum.puppetlabs.com/el/6/dependencies/i386/
 
 %packages --ignoremissing
 @core

--- a/templates/centos-6.6/files/x86_64.ks
+++ b/templates/centos-6.6/files/x86_64.ks
@@ -1,6 +1,5 @@
 install
-
-url --url=http://mirror.centos.org/centos-6/6/os/x86_64/
+cdrom
 lang en_US.UTF-8
 keyboard us
 network --bootproto=dhcp
@@ -21,11 +20,6 @@ autopart
 auth  --useshadow  --enablemd5
 firstboot --disabled
 reboot --eject
-
-repo --name=updates --baseurl=http://mirror.centos.org/centos-6/6/updates/x86_64/
-repo --name=epel --mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-6&arch=x86_64
-repo --name=puppetlabs --baseurl=http://yum.puppetlabs.com/el/6/products/x86_64/
-repo --name=puppetdeps --baseurl=http://yum.puppetlabs.com/el/6/dependencies/x86_64/
 
 %packages --ignoremissing
 @core

--- a/templates/centos-6.6/i386.virtualbox.base.json
+++ b/templates/centos-6.6/i386.virtualbox.base.json
@@ -5,8 +5,8 @@
       "template_name": "centos-6.6-i386",
       "template_os": "RedHat",
 
-      "iso_url": "http://mirrors.cat.pdx.edu/centos/6.6/isos/i386/CentOS-6.6-i386-netinstall.iso",
-      "iso_checksum": "d1d5017e14ac5d323fe2d0891bb2203a",
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/CentOS-6.6-i386-bin-DVD1.iso",
+      "iso_checksum": "4199f9106ea5e01f66ec691d8628af54",
       "iso_checksum_type": "md5",
 
       "memory_size": "512",

--- a/templates/centos-6.6/i386.virtualbox.base.json
+++ b/templates/centos-6.6/i386.virtualbox.base.json
@@ -72,7 +72,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-6.6/i386.virtualbox.vagrant.nocm.json
+++ b/templates/centos-6.6/i386.virtualbox.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-6.6/i386.virtualbox.vagrant.pe.json
+++ b/templates/centos-6.6/i386.virtualbox.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-6.6/i386.virtualbox.vagrant.puppet.json
+++ b/templates/centos-6.6/i386.virtualbox.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-6.6/i386.vmware.base.json
+++ b/templates/centos-6.6/i386.vmware.base.json
@@ -5,8 +5,8 @@
       "template_name": "centos-6.6-i386",
       "template_os": "rhel6",
 
-      "iso_url": "http://mirrors.cat.pdx.edu/centos/6.6/isos/i386/CentOS-6.6-i386-netinstall.iso",
-      "iso_checksum": "d1d5017e14ac5d323fe2d0891bb2203a",
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/CentOS-6.6-i386-bin-DVD1.iso",
+      "iso_checksum": "4199f9106ea5e01f66ec691d8628af54",
       "iso_checksum_type": "md5",
 
       "memory_size": "512",

--- a/templates/centos-6.6/i386.vmware.base.json
+++ b/templates/centos-6.6/i386.vmware.base.json
@@ -63,7 +63,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-6.6/i386.vmware.vagrant.nocm.json
+++ b/templates/centos-6.6/i386.vmware.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-6.6/i386.vmware.vagrant.pe.json
+++ b/templates/centos-6.6/i386.vmware.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-6.6/i386.vmware.vagrant.puppet.json
+++ b/templates/centos-6.6/i386.vmware.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-6.6/vagrantcloud.yaml
+++ b/templates/centos-6.6/vagrantcloud.yaml
@@ -1,7 +1,7 @@
 ---
 name: 'centos-6.6'
 description: 'CentOS 6.6'
-version: '1.0.1'
+version: '1.0.2'
 
 arches:
   - name: '32'
@@ -13,6 +13,6 @@ configs:
   - name: 'nocm'
     description: 'no configuration management software'
   - name: 'puppet'
-    description: 'Puppet 3.7.4'
+    description: 'Puppet 4.2.0'
   - name: 'puppet-enterprise'
-    description: 'Puppet Enterprise 3.7.2 (agent-only)'
+    description: 'Puppet Enterprise 3.8.1 (agent-only)'

--- a/templates/centos-6.6/x86_64.virtualbox.base.json
+++ b/templates/centos-6.6/x86_64.virtualbox.base.json
@@ -4,9 +4,9 @@
     {
       "template_name": "centos-6.6-x86_64",
       "template_os": "RedHat_64",
-
-      "iso_url": "http://mirrors.cat.pdx.edu/centos/6.6/isos/x86_64/CentOS-6.6-x86_64-netinstall.iso",
-      "iso_checksum": "2342bc5ea72fc028972aa0f21cee28b4",
+      
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/CentOS-6.6-x86_64-bin-DVD1.iso",
+      "iso_checksum": "7b1fb1a11499b31271ded79da6af8584",
       "iso_checksum_type": "md5",
 
       "memory_size": "512",

--- a/templates/centos-6.6/x86_64.virtualbox.base.json
+++ b/templates/centos-6.6/x86_64.virtualbox.base.json
@@ -78,7 +78,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-6.6/x86_64.virtualbox.vagrant.nocm.json
+++ b/templates/centos-6.6/x86_64.virtualbox.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-6.6/x86_64.virtualbox.vagrant.pe.json
+++ b/templates/centos-6.6/x86_64.virtualbox.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-6.6/x86_64.virtualbox.vagrant.puppet.json
+++ b/templates/centos-6.6/x86_64.virtualbox.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-6.6/x86_64.vmware.base.json
+++ b/templates/centos-6.6/x86_64.vmware.base.json
@@ -4,9 +4,9 @@
     {
       "template_name": "centos-6.6-x86_64",
       "template_os": "rhel6-64",
-
-      "iso_url": "http://mirrors.cat.pdx.edu/centos/6.6/isos/x86_64/CentOS-6.6-x86_64-netinstall.iso",
-      "iso_checksum": "2342bc5ea72fc028972aa0f21cee28b4",
+      
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/CentOS-6.6-x86_64-bin-DVD1.iso",
+      "iso_checksum": "7b1fb1a11499b31271ded79da6af8584",
       "iso_checksum_type": "md5",
 
       "memory_size": "512",

--- a/templates/centos-6.6/x86_64.vmware.base.json
+++ b/templates/centos-6.6/x86_64.vmware.base.json
@@ -63,7 +63,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-6.6/x86_64.vmware.vagrant.nocm.json
+++ b/templates/centos-6.6/x86_64.vmware.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-6.6/x86_64.vmware.vagrant.pe.json
+++ b/templates/centos-6.6/x86_64.vmware.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-6.6/x86_64.vmware.vagrant.puppet.json
+++ b/templates/centos-6.6/x86_64.vmware.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-7.0/CHANGELOG
+++ b/templates/centos-7.0/CHANGELOG
@@ -1,3 +1,7 @@
+### 1.0.2
+
+* Switch to puppet-agent packaging
+
 ### 1.0.1
 
 * Base image update

--- a/templates/centos-7.0/CHANGELOG
+++ b/templates/centos-7.0/CHANGELOG
@@ -1,6 +1,7 @@
 ### 1.0.2
 
 * Switch to puppet-agent packaging
+* Bump version for Puppet and PE
 
 ### 1.0.1
 

--- a/templates/centos-7.0/files/x86_64.ks
+++ b/templates/centos-7.0/files/x86_64.ks
@@ -1,6 +1,5 @@
 install
-
-url --url=http://mirrors.cat.pdx.edu/centos/7/os/x86_64/
+cdrom
 lang en_US.UTF-8
 keyboard us
 network --bootproto=dhcp

--- a/templates/centos-7.0/files/x86_64.ks
+++ b/templates/centos-7.0/files/x86_64.ks
@@ -22,11 +22,6 @@ auth  --useshadow  --enablemd5
 firstboot --disabled
 reboot --eject
 
-repo --name=updates --baseurl=http://mirrors.cat.pdx.edu/centos/7/updates/x86_64/
-repo --name=epel --mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-7&arch=x86_64
-repo --name=puppetlabs --baseurl=http://yum.puppetlabs.com/el/7/products/x86_64/
-repo --name=puppetdeps --baseurl=http://yum.puppetlabs.com/el/7/dependencies/x86_64/
-
 %packages --ignoremissing
 @core
 bzip2

--- a/templates/centos-7.0/vagrantcloud.yaml
+++ b/templates/centos-7.0/vagrantcloud.yaml
@@ -1,7 +1,7 @@
 ---
 name: 'centos-7.0'
 description: 'CentOS 7.0'
-version: '1.0.1'
+version: '1.0.2'
 
 arches:
   - name: '64'
@@ -11,6 +11,6 @@ configs:
   - name: 'nocm'
     description: 'no configuration management software'
   - name: 'puppet'
-    description: 'Puppet 3.7.4'
+    description: 'Puppet 4.2.0'
   - name: 'puppet-enterprise'
-    description: 'Puppet Enterprise 3.7.2 (agent-only)'
+    description: 'Puppet Enterprise 3.8.1 (agent-only)'

--- a/templates/centos-7.0/x86_64.ec2.nocm.json
+++ b/templates/centos-7.0/x86_64.ec2.nocm.json
@@ -52,7 +52,7 @@
     },
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' --manifestdir='{{.ManifestDir}}' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' --manifestdir='{{.ManifestDir}}' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-7.0/x86_64.virtualbox.base.json
+++ b/templates/centos-7.0/x86_64.virtualbox.base.json
@@ -5,8 +5,8 @@
       "template_name": "centos-7.0-x86_64",
       "template_os": "RedHat_64",
 
-      "iso_url": "http://mirrors.cat.pdx.edu/centos/7.0.1406/isos/x86_64/CentOS-7.0-1406-x86_64-Minimal.iso",
-      "iso_checksum": "e3afe3f1121d69c40cc23f0bafa05e5d",
+      "iso_url": "http://centos.weepeetelecom.be/7/isos/x86_64/CentOS-7-x86_64-Minimal-1503-01.iso",
+      "iso_checksum": "d07ab3e615c66a8b2e9a50f4852e6a77",
       "iso_checksum_type": "md5",
 
       "memory_size": "512",
@@ -78,7 +78,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-7.0/x86_64.virtualbox.base.json
+++ b/templates/centos-7.0/x86_64.virtualbox.base.json
@@ -5,8 +5,8 @@
       "template_name": "centos-7.0-x86_64",
       "template_os": "RedHat_64",
 
-      "iso_url": "http://centos.weepeetelecom.be/7/isos/x86_64/CentOS-7-x86_64-Minimal-1503-01.iso",
-      "iso_checksum": "d07ab3e615c66a8b2e9a50f4852e6a77",
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/CentOS-7.0-1406-x86_64-DVD.iso",
+      "iso_checksum": "713ea7847adcdd1700e92429f212721a",
       "iso_checksum_type": "md5",
 
       "memory_size": "512",

--- a/templates/centos-7.0/x86_64.virtualbox.vagrant.nocm.json
+++ b/templates/centos-7.0/x86_64.virtualbox.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-7.0/x86_64.virtualbox.vagrant.pe.json
+++ b/templates/centos-7.0/x86_64.virtualbox.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-7.0/x86_64.virtualbox.vagrant.puppet.json
+++ b/templates/centos-7.0/x86_64.virtualbox.vagrant.puppet.json
@@ -5,7 +5,7 @@
       "template_name": "centos-7.0-x86_64",
 
       "provisioner": "virtualbox",
-      "required_modules": "puppetlabs-stdlib saz-sudo stahnma-puppetlabs_yum",
+      "required_modules": "puppetlabs-stdlib saz-sudo",
       "puppet_nfs": "{{env `PUPPET_NFS`}}"
     },
 
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-7.0/x86_64.vmware.base.json
+++ b/templates/centos-7.0/x86_64.vmware.base.json
@@ -66,7 +66,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-7.0/x86_64.vmware.base.json
+++ b/templates/centos-7.0/x86_64.vmware.base.json
@@ -5,8 +5,8 @@
       "template_name": "centos-7.0-x86_64",
       "template_os": "rhel6-64",
 
-      "iso_url": "http://mirrors.cat.pdx.edu/centos/7.0.1406/isos/x86_64/CentOS-7.0-1406-x86_64-Minimal.iso",
-      "iso_checksum": "e3afe3f1121d69c40cc23f0bafa05e5d",
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/CentOS-7.0-1406-x86_64-DVD.iso",
+      "iso_checksum": "713ea7847adcdd1700e92429f212721a",
       "iso_checksum_type": "md5",
 
       "memory_size": "512",

--- a/templates/centos-7.0/x86_64.vmware.vagrant.nocm.json
+++ b/templates/centos-7.0/x86_64.vmware.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-7.0/x86_64.vmware.vagrant.pe.json
+++ b/templates/centos-7.0/x86_64.vmware.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/centos-7.0/x86_64.vmware.vagrant.puppet.json
+++ b/templates/centos-7.0/x86_64.vmware.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/debian-6.0.10/CHANGELOG
+++ b/templates/debian-6.0.10/CHANGELOG
@@ -1,3 +1,8 @@
+### 1.0.2
+
+* Switch to puppet-agent packaging
+* Bump version for Puppet and PE
+
 ### 1.0.1
 
 * Bump to Debian 6.0.10

--- a/templates/debian-6.0.10/files/preseed.cfg
+++ b/templates/debian-6.0.10/files/preseed.cfg
@@ -32,4 +32,4 @@ d-i pkgsel/include string curl build-essential ntp openssh-server perl sudo wget
 d-i preseed/early_command string sed -i \
   '/in-target/idiscover(){/sbin/discover|grep -v VirtualBox;}' \
   /usr/lib/pre-pkgsel.d/20install-hwpackages
-
+d-i preseed/late_command string sed -i '/^deb cdrom:/s/^/#/' /target/etc/apt/sources.list

--- a/templates/debian-6.0.10/i386.virtualbox.base.json
+++ b/templates/debian-6.0.10/i386.virtualbox.base.json
@@ -86,7 +86,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/debian-6.0.10/i386.virtualbox.base.json
+++ b/templates/debian-6.0.10/i386.virtualbox.base.json
@@ -5,8 +5,8 @@
       "template_name": "debian-6.0.10-i386",
       "template_os": "Debian",
 
-      "iso_url": "http://cdimage.debian.org/cdimage/archive/6.0.10/i386/iso-cd/debian-6.0.10-i386-netinst.iso",
-      "iso_checksum": "574fad7c19d6522b2892c79781e3457a",
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/debian-6.0.10-i386-DVD-1.iso",
+      "iso_checksum": "f44189f29246bb5f9ff87f742959985f",
       "iso_checksum_type": "md5",
 
       "memory_size": "512",

--- a/templates/debian-6.0.10/i386.virtualbox.vagrant.nocm.json
+++ b/templates/debian-6.0.10/i386.virtualbox.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/debian-6.0.10/i386.virtualbox.vagrant.pe.json
+++ b/templates/debian-6.0.10/i386.virtualbox.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/debian-6.0.10/i386.virtualbox.vagrant.puppet.json
+++ b/templates/debian-6.0.10/i386.virtualbox.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/debian-6.0.10/i386.vmware.base.json
+++ b/templates/debian-6.0.10/i386.vmware.base.json
@@ -5,8 +5,8 @@
       "template_name": "debian-6.0.10-i386",
       "template_os": "debian6",
 
-      "iso_url": "http://cdimage.debian.org/cdimage/archive/6.0.10/i386/iso-cd/debian-6.0.10-i386-netinst.iso",
-      "iso_checksum": "574fad7c19d6522b2892c79781e3457a",
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/debian-6.0.10-i386-DVD-1.iso",
+      "iso_checksum": "f44189f29246bb5f9ff87f742959985f",
       "iso_checksum_type": "md5",
 
       "memory_size": "512",

--- a/templates/debian-6.0.10/i386.vmware.base.json
+++ b/templates/debian-6.0.10/i386.vmware.base.json
@@ -77,7 +77,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/debian-6.0.10/i386.vmware.vagrant.nocm.json
+++ b/templates/debian-6.0.10/i386.vmware.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/debian-6.0.10/i386.vmware.vagrant.pe.json
+++ b/templates/debian-6.0.10/i386.vmware.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/debian-6.0.10/i386.vmware.vagrant.puppet.json
+++ b/templates/debian-6.0.10/i386.vmware.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/debian-6.0.10/vagrantcloud.yaml
+++ b/templates/debian-6.0.10/vagrantcloud.yaml
@@ -1,7 +1,7 @@
 ---
 name: 'debian-6.0.10'
 description: 'Debian 6.0.10 (squeeze)'
-version: '1.0.1'
+version: '1.0.2'
 
 arches:
   - name: '32'
@@ -13,6 +13,6 @@ configs:
   - name: 'nocm'
     description: 'no configuration management software'
   - name: 'puppet'
-    description: 'Puppet 3.7.4'
+    description: 'Puppet 4.2.0'
   - name: 'puppet-enterprise'
-    description: 'Puppet Enterprise 3.7.2 (agent-only)'
+    description: 'Puppet Enterprise 3.8.1 (agent-only)'

--- a/templates/debian-6.0.10/x86_64.virtualbox.base.json
+++ b/templates/debian-6.0.10/x86_64.virtualbox.base.json
@@ -5,8 +5,8 @@
       "template_name": "debian-6.0.10-x86_64",
       "template_os": "Debian_64",
 
-      "iso_url": "http://cdimage.debian.org/cdimage/archive/6.0.10/amd64/iso-cd/debian-6.0.10-amd64-netinst.iso",
-      "iso_checksum": "7f82d341561035f65933da43f94d5b52",
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/debian-6.0.10-amd64-DVD-1.iso",
+      "iso_checksum": "146eeebe6535fb2432ba65f1ad0c7989",
       "iso_checksum_type": "md5",
 
       "memory_size": "512",

--- a/templates/debian-6.0.10/x86_64.virtualbox.base.json
+++ b/templates/debian-6.0.10/x86_64.virtualbox.base.json
@@ -92,7 +92,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/debian-6.0.10/x86_64.virtualbox.vagrant.nocm.json
+++ b/templates/debian-6.0.10/x86_64.virtualbox.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/debian-6.0.10/x86_64.virtualbox.vagrant.pe.json
+++ b/templates/debian-6.0.10/x86_64.virtualbox.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/debian-6.0.10/x86_64.virtualbox.vagrant.puppet.json
+++ b/templates/debian-6.0.10/x86_64.virtualbox.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/debian-6.0.10/x86_64.vmware.base.json
+++ b/templates/debian-6.0.10/x86_64.vmware.base.json
@@ -5,8 +5,8 @@
       "template_name": "debian-6.0.10-x86_64",
       "template_os": "debian6-64",
 
-      "iso_url": "http://cdimage.debian.org/cdimage/archive/6.0.10/amd64/iso-cd/debian-6.0.10-amd64-netinst.iso",
-      "iso_checksum": "7f82d341561035f65933da43f94d5b52",
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/debian-6.0.10-amd64-DVD-1.iso",
+      "iso_checksum": "146eeebe6535fb2432ba65f1ad0c7989",
       "iso_checksum_type": "md5",
 
       "memory_size": "512",

--- a/templates/debian-6.0.10/x86_64.vmware.base.json
+++ b/templates/debian-6.0.10/x86_64.vmware.base.json
@@ -77,7 +77,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/debian-6.0.10/x86_64.vmware.vagrant.nocm.json
+++ b/templates/debian-6.0.10/x86_64.vmware.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/debian-6.0.10/x86_64.vmware.vagrant.pe.json
+++ b/templates/debian-6.0.10/x86_64.vmware.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/debian-6.0.10/x86_64.vmware.vagrant.puppet.json
+++ b/templates/debian-6.0.10/x86_64.vmware.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/debian-7.8/CHANGELOG
+++ b/templates/debian-7.8/CHANGELOG
@@ -1,3 +1,8 @@
+### 1.0.3
+
+* Switch to puppet-agent packaging
+* Bump version for Puppet and PE
+
 ### 1.0.2
 
 * inode.c d_alias patch required to successfully compile the vmhgfs module

--- a/templates/debian-7.8/files/preseed.cfg
+++ b/templates/debian-7.8/files/preseed.cfg
@@ -32,4 +32,4 @@ d-i pkgsel/include string curl ntp openssh-server perl sudo wget build-essential
 d-i preseed/early_command string sed -i \
   '/in-target/idiscover(){/sbin/discover|grep -v VirtualBox;}' \
   /usr/lib/pre-pkgsel.d/20install-hwpackages
-
+d-i preseed/late_command string sed -i '/^deb cdrom:/s/^/#/' /target/etc/apt/sources.list

--- a/templates/debian-7.8/i386.virtualbox.base.json
+++ b/templates/debian-7.8/i386.virtualbox.base.json
@@ -5,7 +5,7 @@
       "template_name": "debian-7.8-i386",
       "template_os": "Debian",
 
-      "iso_url": "http://cdimage.debian.org/debian-cd/7.8.0/i386/iso-cd/debian-7.8.0-i386-netinst.iso",
+      "iso_url": "http://cdimage.debian.org/cdimage/archive/7.8.0/i386/iso-cd/debian-7.8.0-i386-netinst.iso",
       "iso_checksum": "0d2f88d23a9d5945f5bc0276830c7d2c",
       "iso_checksum_type": "md5",
 
@@ -78,7 +78,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/debian-7.8/i386.virtualbox.vagrant.nocm.json
+++ b/templates/debian-7.8/i386.virtualbox.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/debian-7.8/i386.virtualbox.vagrant.pe.json
+++ b/templates/debian-7.8/i386.virtualbox.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/debian-7.8/i386.virtualbox.vagrant.puppet.json
+++ b/templates/debian-7.8/i386.virtualbox.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --vardir='/var/opt/puppetlabs/puppet/cache' --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/debian-7.8/i386.vmware.base.json
+++ b/templates/debian-7.8/i386.vmware.base.json
@@ -69,7 +69,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/debian-7.8/i386.vmware.vagrant.nocm.json
+++ b/templates/debian-7.8/i386.vmware.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/debian-7.8/i386.vmware.vagrant.pe.json
+++ b/templates/debian-7.8/i386.vmware.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/debian-7.8/i386.vmware.vagrant.puppet.json
+++ b/templates/debian-7.8/i386.vmware.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/debian-7.8/vagrantcloud.yaml
+++ b/templates/debian-7.8/vagrantcloud.yaml
@@ -1,7 +1,7 @@
 ---
 name: 'debian-7.8'
 description: 'Debian 7.8 (wheezy)'
-version: '1.0.2'
+version: '1.0.3'
 
 arches:
   - name: '32'
@@ -13,6 +13,6 @@ configs:
   - name: 'nocm'
     description: 'no configuration management software'
   - name: 'puppet'
-    description: 'Puppet 3.7.4'
+    description: 'Puppet 4.2.0'
   - name: 'puppet-enterprise'
-    description: 'Puppet Enterprise 3.7.2 (agent-only)'
+    description: 'Puppet Enterprise 3.8.1 (agent-only)'

--- a/templates/debian-7.8/x86_64.ec2.nocm.json
+++ b/templates/debian-7.8/x86_64.ec2.nocm.json
@@ -52,7 +52,7 @@
     },
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' --manifestdir='{{.ManifestDir}}' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' --manifestdir='{{.ManifestDir}}' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/debian-7.8/x86_64.virtualbox.base.json
+++ b/templates/debian-7.8/x86_64.virtualbox.base.json
@@ -4,8 +4,7 @@
     {
       "template_name": "debian-7.8-x86_64",
       "template_os": "Debian_64",
-
-      "iso_url": "http://cdimage.debian.org/debian-cd/7.8.0/amd64/iso-cd/debian-7.8.0-amd64-netinst.iso",
+      "iso_url": "http://cdimage.debian.org/cdimage/archive/7.8.0/amd64/iso-cd/debian-7.8.0-amd64-netinst.iso",
       "iso_checksum": "a91fba5001cf0fbccb44a7ae38c63b6e",
       "iso_checksum_type": "md5",
 
@@ -84,7 +83,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/debian-7.8/x86_64.virtualbox.vagrant.nocm.json
+++ b/templates/debian-7.8/x86_64.virtualbox.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/debian-7.8/x86_64.virtualbox.vagrant.pe.json
+++ b/templates/debian-7.8/x86_64.virtualbox.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/debian-7.8/x86_64.virtualbox.vagrant.puppet.json
+++ b/templates/debian-7.8/x86_64.virtualbox.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --vardir='/var/opt/puppetlabs/puppet/cache' --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/debian-7.8/x86_64.vmware.base.json
+++ b/templates/debian-7.8/x86_64.vmware.base.json
@@ -69,7 +69,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/debian-7.8/x86_64.vmware.vagrant.nocm.json
+++ b/templates/debian-7.8/x86_64.vmware.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/debian-7.8/x86_64.vmware.vagrant.pe.json
+++ b/templates/debian-7.8/x86_64.vmware.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/debian-7.8/x86_64.vmware.vagrant.puppet.json
+++ b/templates/debian-7.8/x86_64.vmware.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/oracle-5.10/i386.virtualbox.base.json
+++ b/templates/oracle-5.10/i386.virtualbox.base.json
@@ -73,7 +73,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/oracle-5.10/i386.virtualbox.vagrant.nocm.json
+++ b/templates/oracle-5.10/i386.virtualbox.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/oracle-5.10/i386.virtualbox.vagrant.pe.json
+++ b/templates/oracle-5.10/i386.virtualbox.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/oracle-5.10/i386.virtualbox.vagrant.puppet.json
+++ b/templates/oracle-5.10/i386.virtualbox.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/oracle-5.10/i386.vmware.base.json
+++ b/templates/oracle-5.10/i386.vmware.base.json
@@ -63,7 +63,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/oracle-5.10/i386.vmware.vagrant.nocm.json
+++ b/templates/oracle-5.10/i386.vmware.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/oracle-5.10/i386.vmware.vagrant.pe.json
+++ b/templates/oracle-5.10/i386.vmware.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/oracle-5.10/i386.vmware.vagrant.puppet.json
+++ b/templates/oracle-5.10/i386.vmware.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/oracle-5.10/x86_64.virtualbox.base.json
+++ b/templates/oracle-5.10/x86_64.virtualbox.base.json
@@ -73,7 +73,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/oracle-5.10/x86_64.virtualbox.vagrant.nocm.json
+++ b/templates/oracle-5.10/x86_64.virtualbox.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/oracle-5.10/x86_64.virtualbox.vagrant.pe.json
+++ b/templates/oracle-5.10/x86_64.virtualbox.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/oracle-5.10/x86_64.virtualbox.vagrant.puppet.json
+++ b/templates/oracle-5.10/x86_64.virtualbox.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/oracle-5.10/x86_64.vmware.base.json
+++ b/templates/oracle-5.10/x86_64.vmware.base.json
@@ -63,7 +63,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/oracle-5.10/x86_64.vmware.vagrant.nocm.json
+++ b/templates/oracle-5.10/x86_64.vmware.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/oracle-5.10/x86_64.vmware.vagrant.pe.json
+++ b/templates/oracle-5.10/x86_64.vmware.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/oracle-5.10/x86_64.vmware.vagrant.puppet.json
+++ b/templates/oracle-5.10/x86_64.vmware.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/oracle-6.5/i386.virtualbox.base.json
+++ b/templates/oracle-6.5/i386.virtualbox.base.json
@@ -73,7 +73,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/oracle-6.5/i386.virtualbox.vagrant.nocm.json
+++ b/templates/oracle-6.5/i386.virtualbox.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/oracle-6.5/i386.virtualbox.vagrant.pe.json
+++ b/templates/oracle-6.5/i386.virtualbox.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/oracle-6.5/i386.virtualbox.vagrant.puppet.json
+++ b/templates/oracle-6.5/i386.virtualbox.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/oracle-6.5/i386.vmware.base.json
+++ b/templates/oracle-6.5/i386.vmware.base.json
@@ -63,7 +63,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/oracle-6.5/i386.vmware.vagrant.nocm.json
+++ b/templates/oracle-6.5/i386.vmware.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/oracle-6.5/i386.vmware.vagrant.pe.json
+++ b/templates/oracle-6.5/i386.vmware.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/oracle-6.5/i386.vmware.vagrant.puppet.json
+++ b/templates/oracle-6.5/i386.vmware.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/oracle-6.5/x86_64.virtualbox.base.json
+++ b/templates/oracle-6.5/x86_64.virtualbox.base.json
@@ -79,7 +79,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/oracle-6.5/x86_64.virtualbox.vagrant.nocm.json
+++ b/templates/oracle-6.5/x86_64.virtualbox.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/oracle-6.5/x86_64.virtualbox.vagrant.pe.json
+++ b/templates/oracle-6.5/x86_64.virtualbox.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/oracle-6.5/x86_64.virtualbox.vagrant.puppet.json
+++ b/templates/oracle-6.5/x86_64.virtualbox.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/oracle-6.5/x86_64.vmware.base.json
+++ b/templates/oracle-6.5/x86_64.vmware.base.json
@@ -63,7 +63,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/oracle-6.5/x86_64.vmware.vagrant.nocm.json
+++ b/templates/oracle-6.5/x86_64.vmware.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/oracle-6.5/x86_64.vmware.vagrant.pe.json
+++ b/templates/oracle-6.5/x86_64.vmware.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/oracle-6.5/x86_64.vmware.vagrant.puppet.json
+++ b/templates/oracle-6.5/x86_64.vmware.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/scientific-5.10/i386.virtualbox.base.json
+++ b/templates/scientific-5.10/i386.virtualbox.base.json
@@ -73,7 +73,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/scientific-5.10/i386.virtualbox.vagrant.nocm.json
+++ b/templates/scientific-5.10/i386.virtualbox.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/scientific-5.10/i386.virtualbox.vagrant.pe.json
+++ b/templates/scientific-5.10/i386.virtualbox.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/scientific-5.10/i386.virtualbox.vagrant.puppet.json
+++ b/templates/scientific-5.10/i386.virtualbox.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/scientific-5.10/i386.vmware.base.json
+++ b/templates/scientific-5.10/i386.vmware.base.json
@@ -63,7 +63,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/scientific-5.10/i386.vmware.vagrant.nocm.json
+++ b/templates/scientific-5.10/i386.vmware.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/scientific-5.10/i386.vmware.vagrant.pe.json
+++ b/templates/scientific-5.10/i386.vmware.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/scientific-5.10/i386.vmware.vagrant.puppet.json
+++ b/templates/scientific-5.10/i386.vmware.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/scientific-5.10/x86_64.virtualbox.base.json
+++ b/templates/scientific-5.10/x86_64.virtualbox.base.json
@@ -73,7 +73,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/scientific-5.10/x86_64.virtualbox.vagrant.nocm.json
+++ b/templates/scientific-5.10/x86_64.virtualbox.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/scientific-5.10/x86_64.virtualbox.vagrant.pe.json
+++ b/templates/scientific-5.10/x86_64.virtualbox.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/scientific-5.10/x86_64.virtualbox.vagrant.puppet.json
+++ b/templates/scientific-5.10/x86_64.virtualbox.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/scientific-5.10/x86_64.vmware.base.json
+++ b/templates/scientific-5.10/x86_64.vmware.base.json
@@ -63,7 +63,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/scientific-5.10/x86_64.vmware.vagrant.nocm.json
+++ b/templates/scientific-5.10/x86_64.vmware.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/scientific-5.10/x86_64.vmware.vagrant.pe.json
+++ b/templates/scientific-5.10/x86_64.vmware.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/scientific-5.10/x86_64.vmware.vagrant.puppet.json
+++ b/templates/scientific-5.10/x86_64.vmware.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/scientific-6.5/i386.virtualbox.base.json
+++ b/templates/scientific-6.5/i386.virtualbox.base.json
@@ -73,7 +73,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/scientific-6.5/i386.virtualbox.vagrant.nocm.json
+++ b/templates/scientific-6.5/i386.virtualbox.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/scientific-6.5/i386.virtualbox.vagrant.pe.json
+++ b/templates/scientific-6.5/i386.virtualbox.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/scientific-6.5/i386.virtualbox.vagrant.puppet.json
+++ b/templates/scientific-6.5/i386.virtualbox.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/scientific-6.5/i386.vmware.base.json
+++ b/templates/scientific-6.5/i386.vmware.base.json
@@ -63,7 +63,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/scientific-6.5/i386.vmware.vagrant.nocm.json
+++ b/templates/scientific-6.5/i386.vmware.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/scientific-6.5/i386.vmware.vagrant.pe.json
+++ b/templates/scientific-6.5/i386.vmware.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/scientific-6.5/i386.vmware.vagrant.puppet.json
+++ b/templates/scientific-6.5/i386.vmware.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/scientific-6.5/x86_64.virtualbox.base.json
+++ b/templates/scientific-6.5/x86_64.virtualbox.base.json
@@ -79,7 +79,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/scientific-6.5/x86_64.virtualbox.vagrant.nocm.json
+++ b/templates/scientific-6.5/x86_64.virtualbox.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/scientific-6.5/x86_64.virtualbox.vagrant.pe.json
+++ b/templates/scientific-6.5/x86_64.virtualbox.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/scientific-6.5/x86_64.virtualbox.vagrant.puppet.json
+++ b/templates/scientific-6.5/x86_64.virtualbox.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/scientific-6.5/x86_64.vmware.base.json
+++ b/templates/scientific-6.5/x86_64.vmware.base.json
@@ -63,7 +63,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/scientific-6.5/x86_64.vmware.vagrant.nocm.json
+++ b/templates/scientific-6.5/x86_64.vmware.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/scientific-6.5/x86_64.vmware.vagrant.pe.json
+++ b/templates/scientific-6.5/x86_64.vmware.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/scientific-6.5/x86_64.vmware.vagrant.puppet.json
+++ b/templates/scientific-6.5/x86_64.vmware.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/ubuntu-12.04/CHANGELOG
+++ b/templates/ubuntu-12.04/CHANGELOG
@@ -1,3 +1,8 @@
+### 1.0.2
+
+* Switch to puppet-agent packaging
+* Bump version for Puppet and PE
+
 ### 1.0.1
 
 * Base image update

--- a/templates/ubuntu-12.04/i386.virtualbox.base.json
+++ b/templates/ubuntu-12.04/i386.virtualbox.base.json
@@ -87,7 +87,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/ubuntu-12.04/i386.virtualbox.vagrant.nocm.json
+++ b/templates/ubuntu-12.04/i386.virtualbox.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/ubuntu-12.04/i386.virtualbox.vagrant.pe.json
+++ b/templates/ubuntu-12.04/i386.virtualbox.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/ubuntu-12.04/i386.virtualbox.vagrant.puppet.json
+++ b/templates/ubuntu-12.04/i386.virtualbox.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/ubuntu-12.04/i386.vmware.base.json
+++ b/templates/ubuntu-12.04/i386.vmware.base.json
@@ -78,7 +78,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/ubuntu-12.04/i386.vmware.vagrant.nocm.json
+++ b/templates/ubuntu-12.04/i386.vmware.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/ubuntu-12.04/i386.vmware.vagrant.pe.json
+++ b/templates/ubuntu-12.04/i386.vmware.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/ubuntu-12.04/i386.vmware.vagrant.puppet.json
+++ b/templates/ubuntu-12.04/i386.vmware.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/ubuntu-12.04/vagrantcloud.yaml
+++ b/templates/ubuntu-12.04/vagrantcloud.yaml
@@ -1,7 +1,7 @@
 ---
 name: 'ubuntu-12.04'
 description: 'Ubuntu 12.04 (precise)'
-version: '1.0.1'
+version: '1.0.2'
 
 arches:
   - name: '32'
@@ -13,6 +13,6 @@ configs:
   - name: 'nocm'
     description: 'no configuration management software'
   - name: 'puppet'
-    description: 'Puppet 3.7.4'
+    description: 'Puppet 4.2.0'
   - name: 'puppet-enterprise'
-    description: 'Puppet Enterprise 3.7.2 (agent-only)'
+    description: 'Puppet Enterprise 3.8.1 (agent-only)'

--- a/templates/ubuntu-12.04/x86_64.virtualbox.base.json
+++ b/templates/ubuntu-12.04/x86_64.virtualbox.base.json
@@ -93,7 +93,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/ubuntu-12.04/x86_64.virtualbox.vagrant.nocm.json
+++ b/templates/ubuntu-12.04/x86_64.virtualbox.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/ubuntu-12.04/x86_64.virtualbox.vagrant.pe.json
+++ b/templates/ubuntu-12.04/x86_64.virtualbox.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/ubuntu-12.04/x86_64.virtualbox.vagrant.puppet.json
+++ b/templates/ubuntu-12.04/x86_64.virtualbox.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/ubuntu-12.04/x86_64.vmware.base.json
+++ b/templates/ubuntu-12.04/x86_64.vmware.base.json
@@ -78,7 +78,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/ubuntu-12.04/x86_64.vmware.vagrant.nocm.json
+++ b/templates/ubuntu-12.04/x86_64.vmware.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/ubuntu-12.04/x86_64.vmware.vagrant.pe.json
+++ b/templates/ubuntu-12.04/x86_64.vmware.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/ubuntu-12.04/x86_64.vmware.vagrant.puppet.json
+++ b/templates/ubuntu-12.04/x86_64.vmware.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/ubuntu-14.04/CHANGELOG
+++ b/templates/ubuntu-14.04/CHANGELOG
@@ -1,3 +1,8 @@
+### 1.0.2
+
+* Switch to puppet-agent packaging
+* Bump version for Puppet and PE
+
 ### 1.0.1
 
 * Base image update

--- a/templates/ubuntu-14.04/i386.virtualbox.base.json
+++ b/templates/ubuntu-14.04/i386.virtualbox.base.json
@@ -87,7 +87,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/ubuntu-14.04/i386.virtualbox.vagrant.nocm.json
+++ b/templates/ubuntu-14.04/i386.virtualbox.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/ubuntu-14.04/i386.virtualbox.vagrant.pe.json
+++ b/templates/ubuntu-14.04/i386.virtualbox.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/ubuntu-14.04/i386.virtualbox.vagrant.puppet.json
+++ b/templates/ubuntu-14.04/i386.virtualbox.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/ubuntu-14.04/i386.vmware.base.json
+++ b/templates/ubuntu-14.04/i386.vmware.base.json
@@ -78,7 +78,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/ubuntu-14.04/i386.vmware.vagrant.nocm.json
+++ b/templates/ubuntu-14.04/i386.vmware.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/ubuntu-14.04/i386.vmware.vagrant.pe.json
+++ b/templates/ubuntu-14.04/i386.vmware.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/ubuntu-14.04/i386.vmware.vagrant.puppet.json
+++ b/templates/ubuntu-14.04/i386.vmware.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/ubuntu-14.04/vagrantcloud.yaml
+++ b/templates/ubuntu-14.04/vagrantcloud.yaml
@@ -1,7 +1,7 @@
 ---
 name: 'ubuntu-14.04'
 description: 'Ubuntu 14.04 (trusty)'
-version: '1.0.1'
+version: '1.0.2'
 
 arches:
   - name: '32'
@@ -13,6 +13,6 @@ configs:
   - name: 'nocm'
     description: 'no configuration management software'
   - name: 'puppet'
-    description: 'Puppet 3.7.4'
+    description: 'Puppet 4.2.0'
   - name: 'puppet-enterprise'
-    description: 'Puppet Enterprise 3.7.2 (agent-only)'
+    description: 'Puppet Enterprise 3.8.1 (agent-only)'

--- a/templates/ubuntu-14.04/x86_64.virtualbox.base.json
+++ b/templates/ubuntu-14.04/x86_64.virtualbox.base.json
@@ -93,7 +93,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/ubuntu-14.04/x86_64.virtualbox.vagrant.nocm.json
+++ b/templates/ubuntu-14.04/x86_64.virtualbox.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/ubuntu-14.04/x86_64.virtualbox.vagrant.pe.json
+++ b/templates/ubuntu-14.04/x86_64.virtualbox.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/ubuntu-14.04/x86_64.virtualbox.vagrant.puppet.json
+++ b/templates/ubuntu-14.04/x86_64.virtualbox.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/ubuntu-14.04/x86_64.vmware.base.json
+++ b/templates/ubuntu-14.04/x86_64.vmware.base.json
@@ -78,7 +78,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/ubuntu-14.04/x86_64.vmware.vagrant.nocm.json
+++ b/templates/ubuntu-14.04/x86_64.vmware.vagrant.nocm.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/ubuntu-14.04/x86_64.vmware.vagrant.pe.json
+++ b/templates/ubuntu-14.04/x86_64.vmware.vagrant.pe.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },

--- a/templates/ubuntu-14.04/x86_64.vmware.vagrant.puppet.json
+++ b/templates/ubuntu-14.04/x86_64.vmware.vagrant.puppet.json
@@ -37,7 +37,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },


### PR DESCRIPTION
This PR provides initial AIO/puppet-agent packaging updates to the CentOS, Ubuntu, and Debian PL packer boxes and bumps the version of the PE agent.  Where applicable, the ISO used during the provisioning process has been updated to use a full ISO instead of minimal ( to reduce network usage ).