### PR TITLE
(RE-5101) add path for puppet-agent binaries

### DIFF
--- a/manifests/modules/packer/manifests/puppet.pp
+++ b/manifests/modules/packer/manifests/puppet.pp
@@ -20,11 +20,11 @@ class packer::puppet {
     redhat: {
 
         if $operatingsystem == "Fedora" {
-             $ostype="fedora"
-             $prefix="f"
-        } elsif $repo_osfamily == "RedHat" {
-             $ostype="el"
-             $prefix=""
+          $ostype = 'fedora'
+          $prefix = 'f'
+        } elsif $osfamily == "RedHat" {
+          $ostype = 'el'
+          $prefix = ''
         }
         else {
           err("Unable to determine operating system information to assign yum repo.")

--- a/manifests/modules/packer/manifests/vagrant.pp
+++ b/manifests/modules/packer/manifests/vagrant.pp
@@ -29,6 +29,11 @@ class packer::vagrant inherits packer::vagrant::params {
     type    => 'ssh-rsa',
   }
 
+  file { '/etc/profile.d/append-puppetlabs-path.sh':
+    mode    => '0644',
+    content => 'PATH=$PATH:/opt/puppetlabs/bin',
+  }
+
   class { 'sudo': }
 
   sudo::conf { 'vagrant':

--- a/templates/centos-5.11/vagrantcloud.yaml
+++ b/templates/centos-5.11/vagrantcloud.yaml
@@ -13,6 +13,6 @@ configs:
   - name: 'nocm'
     description: 'no configuration management software'
   - name: 'puppet'
-    description: 'Puppet 4.2.0'
+    description: 'Puppet 4.2.1'
   - name: 'puppet-enterprise'
     description: 'Puppet Enterprise 3.8.1 (agent-only)'

--- a/templates/centos-6.6/vagrantcloud.yaml
+++ b/templates/centos-6.6/vagrantcloud.yaml
@@ -13,6 +13,6 @@ configs:
   - name: 'nocm'
     description: 'no configuration management software'
   - name: 'puppet'
-    description: 'Puppet 4.2.0'
+    description: 'Puppet 4.2.1'
   - name: 'puppet-enterprise'
     description: 'Puppet Enterprise 3.8.1 (agent-only)'

--- a/templates/centos-7.0/vagrantcloud.yaml
+++ b/templates/centos-7.0/vagrantcloud.yaml
@@ -11,6 +11,6 @@ configs:
   - name: 'nocm'
     description: 'no configuration management software'
   - name: 'puppet'
-    description: 'Puppet 4.2.0'
+    description: 'Puppet 4.2.1'
   - name: 'puppet-enterprise'
     description: 'Puppet Enterprise 3.8.1 (agent-only)'

--- a/templates/debian-6.0.10/vagrantcloud.yaml
+++ b/templates/debian-6.0.10/vagrantcloud.yaml
@@ -13,6 +13,6 @@ configs:
   - name: 'nocm'
     description: 'no configuration management software'
   - name: 'puppet'
-    description: 'Puppet 4.2.0'
+    description: 'Puppet 4.2.1'
   - name: 'puppet-enterprise'
     description: 'Puppet Enterprise 3.8.1 (agent-only)'

--- a/templates/debian-7.8/vagrantcloud.yaml
+++ b/templates/debian-7.8/vagrantcloud.yaml
@@ -13,6 +13,6 @@ configs:
   - name: 'nocm'
     description: 'no configuration management software'
   - name: 'puppet'
-    description: 'Puppet 4.2.0'
+    description: 'Puppet 4.2.1'
   - name: 'puppet-enterprise'
     description: 'Puppet Enterprise 3.8.1 (agent-only)'

--- a/templates/fedora-21/vagrantcloud.yaml
+++ b/templates/fedora-21/vagrantcloud.yaml
@@ -13,4 +13,4 @@ configs:
   - name: 'nocm'
     description: 'no configuration management software'
   - name: 'puppet'
-    description: 'Puppet 4.2.0'
+    description: 'Puppet 4.2.1'

--- a/templates/fedora-22/vagrantcloud.yaml
+++ b/templates/fedora-22/vagrantcloud.yaml
@@ -12,5 +12,3 @@ arches:
 configs:
   - name: 'nocm'
     description: 'no configuration management software'
-  - name: 'puppet'
-    description: 'Puppet 4.2.0'

--- a/templates/ubuntu-12.04/vagrantcloud.yaml
+++ b/templates/ubuntu-12.04/vagrantcloud.yaml
@@ -13,6 +13,6 @@ configs:
   - name: 'nocm'
     description: 'no configuration management software'
   - name: 'puppet'
-    description: 'Puppet 4.2.0'
+    description: 'Puppet 4.2.1'
   - name: 'puppet-enterprise'
     description: 'Puppet Enterprise 3.8.1 (agent-only)'

--- a/templates/ubuntu-14.04/vagrantcloud.yaml
+++ b/templates/ubuntu-14.04/vagrantcloud.yaml
@@ -13,6 +13,6 @@ configs:
   - name: 'nocm'
     description: 'no configuration management software'
   - name: 'puppet'
-    description: 'Puppet 4.2.0'
+    description: 'Puppet 4.2.1'
   - name: 'puppet-enterprise'
     description: 'Puppet Enterprise 3.8.1 (agent-only)'


### PR DESCRIPTION
This commit utilizes the profile.d directory to append the path to the
puppet-agent binaries to the user environment.

(maint) fix regression in determining repo type

A module was removed that provided a custom fact regarding yum repo type.
This commit removes the usage of that fact and relies on osfamily
instead.

(maint) bump puppet-agent

puppet-agent 1.2.2 is now available in the public repos.  This commit updates the 
vagrantcloud.yaml to reflect the updated version of puppet.