### PR TITLE
(maint) nocm box cleanup

### DIFF
--- a/manifests/modules/packer/manifests/puppet.pp
+++ b/manifests/modules/packer/manifests/puppet.pp
@@ -49,4 +49,9 @@ class packer::puppet {
     }
   }
 
+  file { '/etc/profile.d/append-puppetlabs-path.sh':
+    mode    => '0644',
+    content => 'PATH=$PATH:/opt/puppetlabs/bin',
+  }
+
 }

--- a/manifests/modules/packer/manifests/vagrant.pp
+++ b/manifests/modules/packer/manifests/vagrant.pp
@@ -29,11 +29,6 @@ class packer::vagrant inherits packer::vagrant::params {
     type    => 'ssh-rsa',
   }
 
-  file { '/etc/profile.d/append-puppetlabs-path.sh':
-    mode    => '0644',
-    content => 'PATH=$PATH:/opt/puppetlabs/bin',
-  }
-
   class { 'sudo': }
 
   sudo::conf { 'vagrant':

--- a/scripts/cleanup-puppet.sh
+++ b/scripts/cleanup-puppet.sh
@@ -1,13 +1,21 @@
 #!/bin/bash
 
+# PE is currently used to provision nocm and puppet boxes.
+# This script cleans up directories that may be left around
+# as part of that process.
+
 # Unmount NFS share if PUPPET_NFS provided
 if [ -n "${PUPPET_NFS}" ]; then
   umount -l /opt/puppet
 fi
 
-# Remove Puppet-related files and directories
-#rm -rf /etc/puppetlabs
+# Only remove /etc/puppetlabs on -nocm boxes
+if [[ "${PACKER_BUILD_NAME}" =~ .*-nocm ]]; then
+  rm -rf /etc/puppetlabs
+fi
+
+# Remove other Puppet-related files and directories
 rm -rf /opt/puppet
 rm -rf /var/cache/yum/puppetdeps
 rm -rf /var/opt/lib/pe-puppet
-rm -rf /var/opt/puppetlabs/puppet
+rm -rf /var/opt/puppetlabs

--- a/templates/debian-6.0.10/i386.virtualbox.base.json
+++ b/templates/debian-6.0.10/i386.virtualbox.base.json
@@ -96,7 +96,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/debian-6.0.10/i386.virtualbox.vagrant.nocm.json
+++ b/templates/debian-6.0.10/i386.virtualbox.vagrant.nocm.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/debian-6.0.10/i386.virtualbox.vagrant.pe.json
+++ b/templates/debian-6.0.10/i386.virtualbox.vagrant.pe.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}"
       ],

--- a/templates/debian-6.0.10/i386.virtualbox.vagrant.puppet.json
+++ b/templates/debian-6.0.10/i386.virtualbox.vagrant.puppet.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/debian-6.0.10/i386.vmware.base.json
+++ b/templates/debian-6.0.10/i386.vmware.base.json
@@ -87,7 +87,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/debian-6.0.10/i386.vmware.vagrant.nocm.json
+++ b/templates/debian-6.0.10/i386.vmware.vagrant.nocm.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/debian-6.0.10/i386.vmware.vagrant.pe.json
+++ b/templates/debian-6.0.10/i386.vmware.vagrant.pe.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}"
       ],

--- a/templates/debian-6.0.10/i386.vmware.vagrant.puppet.json
+++ b/templates/debian-6.0.10/i386.vmware.vagrant.puppet.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/debian-6.0.10/x86_64.virtualbox.base.json
+++ b/templates/debian-6.0.10/x86_64.virtualbox.base.json
@@ -102,7 +102,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/debian-6.0.10/x86_64.virtualbox.vagrant.nocm.json
+++ b/templates/debian-6.0.10/x86_64.virtualbox.vagrant.nocm.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/debian-6.0.10/x86_64.virtualbox.vagrant.pe.json
+++ b/templates/debian-6.0.10/x86_64.virtualbox.vagrant.pe.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}"
       ],

--- a/templates/debian-6.0.10/x86_64.virtualbox.vagrant.puppet.json
+++ b/templates/debian-6.0.10/x86_64.virtualbox.vagrant.puppet.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/debian-6.0.10/x86_64.vmware.base.json
+++ b/templates/debian-6.0.10/x86_64.vmware.base.json
@@ -87,7 +87,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/debian-6.0.10/x86_64.vmware.vagrant.nocm.json
+++ b/templates/debian-6.0.10/x86_64.vmware.vagrant.nocm.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/debian-6.0.10/x86_64.vmware.vagrant.pe.json
+++ b/templates/debian-6.0.10/x86_64.vmware.vagrant.pe.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}"
       ],

--- a/templates/debian-6.0.10/x86_64.vmware.vagrant.puppet.json
+++ b/templates/debian-6.0.10/x86_64.vmware.vagrant.puppet.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/debian-7.8/i386.virtualbox.base.json
+++ b/templates/debian-7.8/i386.virtualbox.base.json
@@ -88,7 +88,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/debian-7.8/i386.virtualbox.vagrant.nocm.json
+++ b/templates/debian-7.8/i386.virtualbox.vagrant.nocm.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/debian-7.8/i386.virtualbox.vagrant.pe.json
+++ b/templates/debian-7.8/i386.virtualbox.vagrant.pe.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}"
       ],

--- a/templates/debian-7.8/i386.virtualbox.vagrant.puppet.json
+++ b/templates/debian-7.8/i386.virtualbox.vagrant.puppet.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/debian-7.8/i386.vmware.vagrant.nocm.json
+++ b/templates/debian-7.8/i386.vmware.vagrant.nocm.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/debian-7.8/i386.vmware.vagrant.pe.json
+++ b/templates/debian-7.8/i386.vmware.vagrant.pe.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}"
       ],

--- a/templates/debian-7.8/i386.vmware.vagrant.puppet.json
+++ b/templates/debian-7.8/i386.vmware.vagrant.puppet.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/debian-7.8/x86_64.virtualbox.base.json
+++ b/templates/debian-7.8/x86_64.virtualbox.base.json
@@ -93,7 +93,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/debian-7.8/x86_64.virtualbox.vagrant.nocm.json
+++ b/templates/debian-7.8/x86_64.virtualbox.vagrant.nocm.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/debian-7.8/x86_64.virtualbox.vagrant.pe.json
+++ b/templates/debian-7.8/x86_64.virtualbox.vagrant.pe.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}"
       ],

--- a/templates/debian-7.8/x86_64.virtualbox.vagrant.puppet.json
+++ b/templates/debian-7.8/x86_64.virtualbox.vagrant.puppet.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/debian-7.8/x86_64.vmware.vagrant.nocm.json
+++ b/templates/debian-7.8/x86_64.vmware.vagrant.nocm.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/debian-7.8/x86_64.vmware.vagrant.pe.json
+++ b/templates/debian-7.8/x86_64.vmware.vagrant.pe.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}"
       ],

--- a/templates/debian-7.8/x86_64.vmware.vagrant.puppet.json
+++ b/templates/debian-7.8/x86_64.vmware.vagrant.puppet.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/ubuntu-12.04/i386.virtualbox.base.json
+++ b/templates/ubuntu-12.04/i386.virtualbox.base.json
@@ -97,7 +97,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/ubuntu-12.04/i386.virtualbox.vagrant.nocm.json
+++ b/templates/ubuntu-12.04/i386.virtualbox.vagrant.nocm.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/ubuntu-12.04/i386.virtualbox.vagrant.pe.json
+++ b/templates/ubuntu-12.04/i386.virtualbox.vagrant.pe.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}"
       ],

--- a/templates/ubuntu-12.04/i386.virtualbox.vagrant.puppet.json
+++ b/templates/ubuntu-12.04/i386.virtualbox.vagrant.puppet.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/ubuntu-12.04/i386.vmware.base.json
+++ b/templates/ubuntu-12.04/i386.vmware.base.json
@@ -88,7 +88,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/ubuntu-12.04/i386.vmware.vagrant.nocm.json
+++ b/templates/ubuntu-12.04/i386.vmware.vagrant.nocm.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/ubuntu-12.04/i386.vmware.vagrant.pe.json
+++ b/templates/ubuntu-12.04/i386.vmware.vagrant.pe.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}"
       ],

--- a/templates/ubuntu-12.04/i386.vmware.vagrant.puppet.json
+++ b/templates/ubuntu-12.04/i386.vmware.vagrant.puppet.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/ubuntu-12.04/x86_64.virtualbox.base.json
+++ b/templates/ubuntu-12.04/x86_64.virtualbox.base.json
@@ -103,7 +103,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/ubuntu-12.04/x86_64.virtualbox.vagrant.nocm.json
+++ b/templates/ubuntu-12.04/x86_64.virtualbox.vagrant.nocm.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/ubuntu-12.04/x86_64.virtualbox.vagrant.pe.json
+++ b/templates/ubuntu-12.04/x86_64.virtualbox.vagrant.pe.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}"
       ],

--- a/templates/ubuntu-12.04/x86_64.virtualbox.vagrant.puppet.json
+++ b/templates/ubuntu-12.04/x86_64.virtualbox.vagrant.puppet.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/ubuntu-12.04/x86_64.vmware.base.json
+++ b/templates/ubuntu-12.04/x86_64.vmware.base.json
@@ -88,7 +88,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/ubuntu-12.04/x86_64.vmware.vagrant.nocm.json
+++ b/templates/ubuntu-12.04/x86_64.vmware.vagrant.nocm.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/ubuntu-12.04/x86_64.vmware.vagrant.pe.json
+++ b/templates/ubuntu-12.04/x86_64.vmware.vagrant.pe.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}"
       ],

--- a/templates/ubuntu-12.04/x86_64.vmware.vagrant.puppet.json
+++ b/templates/ubuntu-12.04/x86_64.vmware.vagrant.puppet.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/ubuntu-14.04/i386.virtualbox.base.json
+++ b/templates/ubuntu-14.04/i386.virtualbox.base.json
@@ -97,7 +97,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/ubuntu-14.04/i386.virtualbox.vagrant.nocm.json
+++ b/templates/ubuntu-14.04/i386.virtualbox.vagrant.nocm.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/ubuntu-14.04/i386.virtualbox.vagrant.pe.json
+++ b/templates/ubuntu-14.04/i386.virtualbox.vagrant.pe.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}"
       ],

--- a/templates/ubuntu-14.04/i386.virtualbox.vagrant.puppet.json
+++ b/templates/ubuntu-14.04/i386.virtualbox.vagrant.puppet.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/ubuntu-14.04/i386.vmware.base.json
+++ b/templates/ubuntu-14.04/i386.vmware.base.json
@@ -88,7 +88,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/ubuntu-14.04/i386.vmware.vagrant.nocm.json
+++ b/templates/ubuntu-14.04/i386.vmware.vagrant.nocm.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/ubuntu-14.04/i386.vmware.vagrant.pe.json
+++ b/templates/ubuntu-14.04/i386.vmware.vagrant.pe.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}"
       ],

--- a/templates/ubuntu-14.04/i386.vmware.vagrant.puppet.json
+++ b/templates/ubuntu-14.04/i386.vmware.vagrant.puppet.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/ubuntu-14.04/x86_64.virtualbox.base.json
+++ b/templates/ubuntu-14.04/x86_64.virtualbox.base.json
@@ -103,7 +103,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/ubuntu-14.04/x86_64.virtualbox.vagrant.nocm.json
+++ b/templates/ubuntu-14.04/x86_64.virtualbox.vagrant.nocm.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/ubuntu-14.04/x86_64.virtualbox.vagrant.pe.json
+++ b/templates/ubuntu-14.04/x86_64.virtualbox.vagrant.pe.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}"
       ],

--- a/templates/ubuntu-14.04/x86_64.virtualbox.vagrant.puppet.json
+++ b/templates/ubuntu-14.04/x86_64.virtualbox.vagrant.puppet.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/ubuntu-14.04/x86_64.vmware.base.json
+++ b/templates/ubuntu-14.04/x86_64.vmware.base.json
@@ -88,7 +88,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/ubuntu-14.04/x86_64.vmware.vagrant.nocm.json
+++ b/templates/ubuntu-14.04/x86_64.vmware.vagrant.nocm.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"

--- a/templates/ubuntu-14.04/x86_64.vmware.vagrant.pe.json
+++ b/templates/ubuntu-14.04/x86_64.vmware.vagrant.pe.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}"
       ],

--- a/templates/ubuntu-14.04/x86_64.vmware.vagrant.puppet.json
+++ b/templates/ubuntu-14.04/x86_64.vmware.vagrant.puppet.json
@@ -47,7 +47,6 @@
 
     {
       "type": "shell",
-      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
         "PUPPET_NFS={{user `puppet_nfs`}}"


### PR DESCRIPTION
PE is utilized for bootstrapping even our nocm box configurations.  The cleanup portion of provisioning should cleanup all the PE bits.   After the last box updates some empty directories were being left behind.   These commits address the cleanup. 