### PR TITLE
Solaris: Set vm_name on base builds

### DIFF
--- a/templates/solaris-10u11/i386.virtualbox.base.json
+++ b/templates/solaris-10u11/i386.virtualbox.base.json
@@ -20,6 +20,7 @@
   "builders": [
     {
       "name": "{{user `template_name`}}-{{user `provisioner`}}",
+      "vm_name": "packer-{{build_name}}",
       "type": "virtualbox-iso",
       "boot_command": [
         "e<wait>",

--- a/templates/solaris-10u11/i386.vmware.base.json
+++ b/templates/solaris-10u11/i386.vmware.base.json
@@ -20,6 +20,7 @@
   "builders": [
     {
       "name": "{{user `template_name`}}-{{user `provisioner`}}",
+      "vm_name": "packer-{{build_name}}",
       "type": "vmware-iso",
       "boot_command": [
         "e<wait>",

--- a/templates/solaris-11.2/i386.virtualbox.base.json
+++ b/templates/solaris-11.2/i386.virtualbox.base.json
@@ -20,6 +20,7 @@
   "builders": [
     {
       "name": "{{user `template_name`}}-{{user `provisioner`}}",
+      "vm_name": "packer-{{build_name}}",
       "type": "virtualbox-iso",
       "boot_command": [
         "e<wait>",

--- a/templates/solaris-11.2/i386.vmware.base.json
+++ b/templates/solaris-11.2/i386.vmware.base.json
@@ -20,6 +20,7 @@
   "builders": [
     {
       "name": "{{user `template_name`}}-{{user `provisioner`}}",
+      "vm_name": "packer-{{build_name}}",
       "type": "vmware-iso",
       "boot_command": [
         "e<wait>",


### PR DESCRIPTION
Packer now defaults to adding a timestamp to the output of builds --- which
makes it impossible for later build stages to guess the name of the artifacts
produced.

This commit fixes the name of Solaris base stage outputs to the format
expected by later build stages.