### PR TITLE
Solaris 11.2: Add release/evaluation package

### DIFF
--- a/templates/solaris-11.2/files/ai.xml
+++ b/templates/solaris-11.2/files/ai.xml
@@ -50,6 +50,7 @@
       -->
       <software_data action="install">
         <name>pkg:/server_install</name>
+        <name>pkg:/release/evaluation</name>
       </software_data>
       <!--
 	    babel_install and slim_install are group packages used to


### PR DESCRIPTION
Solaris now requires a "licence" package to be installed as a dependency of
many base packages; such as the GCC runtime libraries. Installation of this
package requires an `--accept` flag to be passed to PKG, which breaks
automated builds and installations which aren't expecting a licence check.

This patch adds the `release/evaluation` package to the automated install
manifest for Solaris 11.2.