### PR TITLE
Correct path to sftp-server

### DIFF
--- a/manifests/modules/packer/manifests/sshd.pp
+++ b/manifests/modules/packer/manifests/sshd.pp
@@ -6,6 +6,7 @@ class packer::sshd {
       'PermitRootLogin'      => 'yes',
       'UseDNS'               => 'no',
       'GSSAPIAuthentication' => 'no',
+      'Subsystem'            => 'sftp /usr/libexec/openssh/sftp-server',
     },
   }
 


### PR DESCRIPTION
sshd_config currently include's `/usr/lib/openssh/sftp-server` which doesn't exist.