### PR TITLE
Solaris 10: Add curl to the base build

### DIFF
--- a/templates/solaris-10u11/scripts/base.sh
+++ b/templates/solaris-10u11/scripts/base.sh
@@ -4,6 +4,7 @@
 yes | /usr/sbin/pkgadd -d http://mirror.opencsw.org/opencsw/pkgutil-`uname -p`.pkg all
 /opt/csw/bin/pkgutil -U
 
+/opt/csw/bin/pkgutil -y -i CSWcurl
 /opt/csw/bin/pkgutil -y -i CSWwget
 /opt/csw/bin/pkgutil -y -i CSWgtar
 /opt/csw/bin/pkgutil -y -i CSWgsed


### PR DESCRIPTION
This patch adds CSWcurl to the base build for Solaris 10. Having `curl` present
allows PE frictionless agent install to be used.