### PR TITLE
(RE-6104) packer::vsphere support for CentOS and Fedora

### DIFF
--- a/manifests/modules/packer/manifests/vsphere/params.pp
+++ b/manifests/modules/packer/manifests/vsphere/params.pp
@@ -1,6 +1,7 @@
 class packer::vsphere::params {
 
-  $repo_mirror    = 'http://osmirror.delivery.puppetlabs.net'
+  $repo_mirror = 'http://osmirror.delivery.puppetlabs.net'
+  $loweros     = downcase($::operatingsystem)
 
   case $::operatingsystem {
     'Ubuntu': {
@@ -29,12 +30,22 @@ class packer::vsphere::params {
       $updates_release       = "${lsbdistcodename}-updates"
     }
 
-    'CentOS', 'Fedora', 'Redhat': {
+    'CentOS', 'Redhat': {
       $startup_file          = '/etc/rc.d/rc.local'
       $startup_file_source   = 'rc.local'
       $bootstrap_file        = '/etc/vsphere-bootstrap.rb'
       $bootstrap_file_source = 'redhat.rb.erb'
       $ruby_package          = [ 'ruby' ]
+      $gpgkey                = "RPM-GPG-KEY-${::operatingsystem}-${::operatingsystemmajrelease}"
+    }
+
+    'Fedora': {
+      $startup_file          = '/etc/rc.d/rc.local'
+      $startup_file_source   = 'rc.local'
+      $bootstrap_file        = '/etc/vsphere-bootstrap.rb'
+      $bootstrap_file_source = 'redhat.rb.erb'
+      $ruby_package          = [ 'ruby' ]
+      $gpgkey                = "RPM-GPG-KEY-${::operatingsystemmajrelease}-${loweros}"
     }
 
     default: {

--- a/manifests/modules/packer/templates/vsphere/redhat.rb.erb
+++ b/manifests/modules/packer/templates/vsphere/redhat.rb.erb
@@ -17,13 +17,43 @@ end
 
 Kernel.system('hostname -F /etc/hostname')
 
-File.open('/var/lib/NetworkManager/dhclient-ens32.conf', 'a') do |f|
-  f << "send host-name #{hostname}"
-end
-
 puts '- Re-obtaining DHCP lease...'
 
-Kernel.system('/sbin/service NetworkManager restart')
+<% if @operatingsystem == 'CentOS' -%>
+  <% if @operatingsystemmajrelease == '7' -%>
+    File.open('/var/lib/NetworkManager/dhclient-ens32.conf', 'a') do |f|
+      f << "send host-name #{hostname}"
+    end
+    Kernel.system('/sbin/service NetworkManager restart')
+    Kernel.system('/usr/bin/nmcli con down id ens32')
+    Kernel.system('/usr/bin/nmcli con up id ens32')
+  <% end -%>
+  <% if @operatingsystemmajrelease == '6' -%>
+    File.open('/etc/dhcp/dhclient-eth0.conf', 'a') do |f|
+  <% end -%>
+  <% if @operatingsystemmajrelease == '5' -%>
+    File.open('/etc/dhclient-eth0.conf', 'a') do |f|
+  <% end -%>
+  <% if (@operatingsystemmajrelease == '6') or (@operatingsystemmajrelease == '5') -%>
+      f << "\nsend host-name #{hostname};"
+    end
+    network = File.read('/etc/sysconfig/network')
+    File.open('/etc/sysconfig/network', 'w') do |f|
+      network.gsub!(/localhost.localdomain/, "#{hostname}")
+      f.write(network)
+    end
+    Kernel.system('/etc/init.d/network restart')
+  <% end -%>
+<% end -%>
+
+<% if @operatingsystem == 'Fedora' -%>
+  File.open('/var/lib/NetworkManager/dhclient-ens32.conf', 'a') do |f|
+    f << "send host-name #{hostname}"
+  end
+  Kernel.system('/sbin/service NetworkManager restart')
+  Kernel.system('/usr/bin/nmcli con down id ens32')
+  Kernel.system('/usr/bin/nmcli con up id ens32')
+<% end -%>
 
 puts '- Cleaning up...'
 

--- a/templates/centos-5.11/i386.vsphere.nocm.json
+++ b/templates/centos-5.11/i386.vsphere.nocm.json
@@ -1,0 +1,105 @@
+{
+
+  "variables":
+    {
+      "template_name": "centos-5.11-i386",
+      "version": "0.0.1",
+
+      "provisioner": "vmware",
+      "required_modules": "puppetlabs-stdlib",
+      "puppet_nfs": "{{env `PUPPET_NFS`}}",
+      "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
+      "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",
+      "packer_vcenter_username": "{{env `PACKER_VCENTER_USERNAME`}}",
+      "packer_vcenter_password": "{{env `PACKER_VCENTER_PASSWORD`}}",
+      "packer_vcenter_dc": "{{env `PACKER_VCENTER_DC`}}",
+      "packer_vcenter_cluster": "{{env `PACKER_VCENTER_CLUSTER`}}",
+      "packer_vcenter_datastore": "{{env `PACKER_VCENTER_DATASTORE`}}",
+      "packer_vcenter_folder": "{{env `PACKER_VCENTER_FOLDER`}}",
+      "packer_vcenter_net": "{{env `PACKER_VCENTER_NET`}}",
+      "packer_vcenter_insecure": "{{env `PACKER_VCENTER_INSECURE`}}",
+
+      "memory_size": "2048",
+      "cpu_count": "2"
+
+    },
+
+  "builders": [
+    {
+      "name": "{{user `template_name`}}-{{user `provisioner`}}-vsphere-nocm",
+      "vm_name": "packer-{{build_name}}",
+      "type": "vmware-vmx",
+      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
+      "ssh_username": "root",
+      "ssh_password": "puppet",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "/sbin/halt -h -p",
+      "vmx_data_post": {
+        "memsize": "{{user `memory_size`}}",
+        "numvcpus": "{{user `cpu_count`}}",
+        "cpuid.coresPerSocket": "1"
+      }
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type": "shell",
+      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
+      ],
+      "scripts": [
+        "../../scripts/bootstrap-puppet.sh"
+      ]
+    },
+
+    {
+      "type": "file",
+      "source": "../../hiera",
+      "destination": "/tmp/packer-puppet-masterless"
+    },
+
+    {
+      "type": "puppet-masterless",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --hiera_config='/tmp/packer-puppet-masterless/hiera/hiera.yaml' --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "facter": {
+        "provisioner": "{{user `provisioner`}}",
+        "qa_root_passwd": "{{user `qa_root_passwd`}}"
+      },
+      "manifest_dir": "../../manifests",
+      "manifest_file": "../../manifests/vsphere/nocm.pp"
+    },
+
+    {
+      "type": "shell",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
+      ],
+      "scripts": [
+        "../../scripts/cleanup-puppet.sh",
+        "../../scripts/cleanup-packer.sh",
+        "../../scripts/cleanup-scrub.sh"
+      ]
+    }
+  ],
+
+  "post-processors": [
+    {
+      "type": "vsphere",
+      "host": "{{user `packer_vcenter_host`}}",
+      "username": "{{user `packer_vcenter_username`}}",
+      "password": "{{user `packer_vcenter_password`}}",
+      "datacenter": "{{user `packer_vcenter_dc`}}",
+      "cluster": "{{user `packer_vcenter_cluster`}}",
+      "datastore": "{{user `packer_vcenter_datastore`}}",
+      "vm_folder": "{{user `packer_vcenter_folder`}}",
+      "vm_name": "{{user `template_name`}}-{{user `version`}}",
+      "vm_network": "{{user `packer_vcenter_net`}}",
+      "insecure" : "{{user `packer_vcenter_insecure`}}"
+    }
+  ]
+}

--- a/templates/centos-5.11/x86_64.vsphere.nocm.json
+++ b/templates/centos-5.11/x86_64.vsphere.nocm.json
@@ -1,0 +1,105 @@
+{
+
+  "variables":
+    {
+      "template_name": "centos-5.11-x86_64",
+      "version": "0.0.1",
+
+      "provisioner": "vmware",
+      "required_modules": "puppetlabs-stdlib",
+      "puppet_nfs": "{{env `PUPPET_NFS`}}",
+      "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
+      "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",
+      "packer_vcenter_username": "{{env `PACKER_VCENTER_USERNAME`}}",
+      "packer_vcenter_password": "{{env `PACKER_VCENTER_PASSWORD`}}",
+      "packer_vcenter_dc": "{{env `PACKER_VCENTER_DC`}}",
+      "packer_vcenter_cluster": "{{env `PACKER_VCENTER_CLUSTER`}}",
+      "packer_vcenter_datastore": "{{env `PACKER_VCENTER_DATASTORE`}}",
+      "packer_vcenter_folder": "{{env `PACKER_VCENTER_FOLDER`}}",
+      "packer_vcenter_net": "{{env `PACKER_VCENTER_NET`}}",
+      "packer_vcenter_insecure": "{{env `PACKER_VCENTER_INSECURE`}}",
+
+      "memory_size": "4096",
+      "cpu_count": "2"
+
+    },
+
+  "builders": [
+    {
+      "name": "{{user `template_name`}}-{{user `provisioner`}}-vsphere-nocm",
+      "vm_name": "packer-{{build_name}}",
+      "type": "vmware-vmx",
+      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
+      "ssh_username": "root",
+      "ssh_password": "puppet",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "/sbin/halt -h -p",
+      "vmx_data_post": {
+        "memsize": "{{user `memory_size`}}",
+        "numvcpus": "{{user `cpu_count`}}",
+        "cpuid.coresPerSocket": "1"
+      }
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type": "shell",
+      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
+      ],
+      "scripts": [
+        "../../scripts/bootstrap-puppet.sh"
+      ]
+    },
+
+    {
+      "type": "file",
+      "source": "../../hiera",
+      "destination": "/tmp/packer-puppet-masterless"
+    },
+
+    {
+      "type": "puppet-masterless",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --hiera_config='/tmp/packer-puppet-masterless/hiera/hiera.yaml' --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "facter": {
+        "provisioner": "{{user `provisioner`}}",
+        "qa_root_passwd": "{{user `qa_root_passwd`}}"
+      },
+      "manifest_dir": "../../manifests",
+      "manifest_file": "../../manifests/vsphere/nocm.pp"
+    },
+
+    {
+      "type": "shell",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
+      ],
+      "scripts": [
+        "../../scripts/cleanup-puppet.sh",
+        "../../scripts/cleanup-packer.sh",
+        "../../scripts/cleanup-scrub.sh"
+      ]
+    }
+  ],
+
+  "post-processors": [
+    {
+      "type": "vsphere",
+      "host": "{{user `packer_vcenter_host`}}",
+      "username": "{{user `packer_vcenter_username`}}",
+      "password": "{{user `packer_vcenter_password`}}",
+      "datacenter": "{{user `packer_vcenter_dc`}}",
+      "cluster": "{{user `packer_vcenter_cluster`}}",
+      "datastore": "{{user `packer_vcenter_datastore`}}",
+      "vm_folder": "{{user `packer_vcenter_folder`}}",
+      "vm_name": "{{user `template_name`}}-{{user `version`}}",
+      "vm_network": "{{user `packer_vcenter_net`}}",
+      "insecure" : "{{user `packer_vcenter_insecure`}}"
+    }
+  ]
+}

--- a/templates/centos-6.6/i386.vsphere.nocm.json
+++ b/templates/centos-6.6/i386.vsphere.nocm.json
@@ -1,0 +1,105 @@
+{
+
+  "variables":
+    {
+      "template_name": "centos-6.6-i386",
+      "version": "0.0.1",
+
+      "provisioner": "vmware",
+      "required_modules": "puppetlabs-stdlib",
+      "puppet_nfs": "{{env `PUPPET_NFS`}}",
+      "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
+      "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",
+      "packer_vcenter_username": "{{env `PACKER_VCENTER_USERNAME`}}",
+      "packer_vcenter_password": "{{env `PACKER_VCENTER_PASSWORD`}}",
+      "packer_vcenter_dc": "{{env `PACKER_VCENTER_DC`}}",
+      "packer_vcenter_cluster": "{{env `PACKER_VCENTER_CLUSTER`}}",
+      "packer_vcenter_datastore": "{{env `PACKER_VCENTER_DATASTORE`}}",
+      "packer_vcenter_folder": "{{env `PACKER_VCENTER_FOLDER`}}",
+      "packer_vcenter_net": "{{env `PACKER_VCENTER_NET`}}",
+      "packer_vcenter_insecure": "{{env `PACKER_VCENTER_INSECURE`}}",
+
+      "memory_size": "2048",
+      "cpu_count": "2"
+
+    },
+
+  "builders": [
+    {
+      "name": "{{user `template_name`}}-{{user `provisioner`}}-vsphere-nocm",
+      "vm_name": "packer-{{build_name}}",
+      "type": "vmware-vmx",
+      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
+      "ssh_username": "root",
+      "ssh_password": "puppet",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "/sbin/halt -h -p",
+      "vmx_data_post": {
+        "memsize": "{{user `memory_size`}}",
+        "numvcpus": "{{user `cpu_count`}}",
+        "cpuid.coresPerSocket": "1"
+      }
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type": "shell",
+      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
+      ],
+      "scripts": [
+        "../../scripts/bootstrap-puppet.sh"
+      ]
+    },
+
+    {
+      "type": "file",
+      "source": "../../hiera",
+      "destination": "/tmp/packer-puppet-masterless"
+    },
+
+    {
+      "type": "puppet-masterless",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --hiera_config='/tmp/packer-puppet-masterless/hiera/hiera.yaml' --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "facter": {
+        "provisioner": "{{user `provisioner`}}",
+        "qa_root_passwd": "{{user `qa_root_passwd`}}"
+      },
+      "manifest_dir": "../../manifests",
+      "manifest_file": "../../manifests/vsphere/nocm.pp"
+    },
+
+    {
+      "type": "shell",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
+      ],
+      "scripts": [
+        "../../scripts/cleanup-puppet.sh",
+        "../../scripts/cleanup-packer.sh",
+        "../../scripts/cleanup-scrub.sh"
+      ]
+    }
+  ],
+
+  "post-processors": [
+    {
+      "type": "vsphere",
+      "host": "{{user `packer_vcenter_host`}}",
+      "username": "{{user `packer_vcenter_username`}}",
+      "password": "{{user `packer_vcenter_password`}}",
+      "datacenter": "{{user `packer_vcenter_dc`}}",
+      "cluster": "{{user `packer_vcenter_cluster`}}",
+      "datastore": "{{user `packer_vcenter_datastore`}}",
+      "vm_folder": "{{user `packer_vcenter_folder`}}",
+      "vm_name": "{{user `template_name`}}-{{user `version`}}",
+      "vm_network": "{{user `packer_vcenter_net`}}",
+      "insecure" : "{{user `packer_vcenter_insecure`}}"
+    }
+  ]
+}

--- a/templates/centos-6.6/x86_64.vsphere.nocm.json
+++ b/templates/centos-6.6/x86_64.vsphere.nocm.json
@@ -1,0 +1,105 @@
+{
+
+  "variables":
+    {
+      "template_name": "centos-6.6-x86_64",
+      "version": "0.0.1",
+
+      "provisioner": "vmware",
+      "required_modules": "puppetlabs-stdlib",
+      "puppet_nfs": "{{env `PUPPET_NFS`}}",
+      "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
+      "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",
+      "packer_vcenter_username": "{{env `PACKER_VCENTER_USERNAME`}}",
+      "packer_vcenter_password": "{{env `PACKER_VCENTER_PASSWORD`}}",
+      "packer_vcenter_dc": "{{env `PACKER_VCENTER_DC`}}",
+      "packer_vcenter_cluster": "{{env `PACKER_VCENTER_CLUSTER`}}",
+      "packer_vcenter_datastore": "{{env `PACKER_VCENTER_DATASTORE`}}",
+      "packer_vcenter_folder": "{{env `PACKER_VCENTER_FOLDER`}}",
+      "packer_vcenter_net": "{{env `PACKER_VCENTER_NET`}}",
+      "packer_vcenter_insecure": "{{env `PACKER_VCENTER_INSECURE`}}",
+
+      "memory_size": "4096",
+      "cpu_count": "2"
+
+    },
+
+  "builders": [
+    {
+      "name": "{{user `template_name`}}-{{user `provisioner`}}-vsphere-nocm",
+      "vm_name": "packer-{{build_name}}",
+      "type": "vmware-vmx",
+      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
+      "ssh_username": "root",
+      "ssh_password": "puppet",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "/sbin/halt -h -p",
+      "vmx_data_post": {
+        "memsize": "{{user `memory_size`}}",
+        "numvcpus": "{{user `cpu_count`}}",
+        "cpuid.coresPerSocket": "1"
+      }
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type": "shell",
+      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
+      ],
+      "scripts": [
+        "../../scripts/bootstrap-puppet.sh"
+      ]
+    },
+
+    {
+      "type": "file",
+      "source": "../../hiera",
+      "destination": "/tmp/packer-puppet-masterless"
+    },
+
+    {
+      "type": "puppet-masterless",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --hiera_config='/tmp/packer-puppet-masterless/hiera/hiera.yaml' --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "facter": {
+        "provisioner": "{{user `provisioner`}}",
+        "qa_root_passwd": "{{user `qa_root_passwd`}}"
+      },
+      "manifest_dir": "../../manifests",
+      "manifest_file": "../../manifests/vsphere/nocm.pp"
+    },
+
+    {
+      "type": "shell",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
+      ],
+      "scripts": [
+        "../../scripts/cleanup-puppet.sh",
+        "../../scripts/cleanup-packer.sh",
+        "../../scripts/cleanup-scrub.sh"
+      ]
+    }
+  ],
+
+  "post-processors": [
+    {
+      "type": "vsphere",
+      "host": "{{user `packer_vcenter_host`}}",
+      "username": "{{user `packer_vcenter_username`}}",
+      "password": "{{user `packer_vcenter_password`}}",
+      "datacenter": "{{user `packer_vcenter_dc`}}",
+      "cluster": "{{user `packer_vcenter_cluster`}}",
+      "datastore": "{{user `packer_vcenter_datastore`}}",
+      "vm_folder": "{{user `packer_vcenter_folder`}}",
+      "vm_name": "{{user `template_name`}}-{{user `version`}}",
+      "vm_network": "{{user `packer_vcenter_net`}}",
+      "insecure" : "{{user `packer_vcenter_insecure`}}"
+    }
+  ]
+}

--- a/templates/centos-7.0/x86_64.vsphere.nocm.json
+++ b/templates/centos-7.0/x86_64.vsphere.nocm.json
@@ -1,0 +1,105 @@
+{
+
+  "variables":
+    {
+      "template_name": "centos-7.0-x86_64",
+      "version": "0.0.1",
+
+      "provisioner": "vmware",
+      "required_modules": "puppetlabs-stdlib",
+      "puppet_nfs": "{{env `PUPPET_NFS`}}",
+      "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
+      "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",
+      "packer_vcenter_username": "{{env `PACKER_VCENTER_USERNAME`}}",
+      "packer_vcenter_password": "{{env `PACKER_VCENTER_PASSWORD`}}",
+      "packer_vcenter_dc": "{{env `PACKER_VCENTER_DC`}}",
+      "packer_vcenter_cluster": "{{env `PACKER_VCENTER_CLUSTER`}}",
+      "packer_vcenter_datastore": "{{env `PACKER_VCENTER_DATASTORE`}}",
+      "packer_vcenter_folder": "{{env `PACKER_VCENTER_FOLDER`}}",
+      "packer_vcenter_net": "{{env `PACKER_VCENTER_NET`}}",
+      "packer_vcenter_insecure": "{{env `PACKER_VCENTER_INSECURE`}}",
+
+      "memory_size": "4096",
+      "cpu_count": "2"
+
+    },
+
+  "builders": [
+    {
+      "name": "{{user `template_name`}}-{{user `provisioner`}}-vsphere-nocm",
+      "vm_name": "packer-{{build_name}}",
+      "type": "vmware-vmx",
+      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
+      "ssh_username": "root",
+      "ssh_password": "puppet",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "/sbin/halt -h -p",
+      "vmx_data_post": {
+        "memsize": "{{user `memory_size`}}",
+        "numvcpus": "{{user `cpu_count`}}",
+        "cpuid.coresPerSocket": "1"
+      }
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type": "shell",
+      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
+      ],
+      "scripts": [
+        "../../scripts/bootstrap-puppet.sh"
+      ]
+    },
+
+    {
+      "type": "file",
+      "source": "../../hiera",
+      "destination": "/tmp/packer-puppet-masterless"
+    },
+
+    {
+      "type": "puppet-masterless",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --hiera_config='/tmp/packer-puppet-masterless/hiera/hiera.yaml' --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "facter": {
+        "provisioner": "{{user `provisioner`}}",
+        "qa_root_passwd": "{{user `qa_root_passwd`}}"
+      },
+      "manifest_dir": "../../manifests",
+      "manifest_file": "../../manifests/vsphere/nocm.pp"
+    },
+
+    {
+      "type": "shell",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
+      ],
+      "scripts": [
+        "../../scripts/cleanup-puppet.sh",
+        "../../scripts/cleanup-packer.sh",
+        "../../scripts/cleanup-scrub.sh"
+      ]
+    }
+  ],
+
+  "post-processors": [
+    {
+      "type": "vsphere",
+      "host": "{{user `packer_vcenter_host`}}",
+      "username": "{{user `packer_vcenter_username`}}",
+      "password": "{{user `packer_vcenter_password`}}",
+      "datacenter": "{{user `packer_vcenter_dc`}}",
+      "cluster": "{{user `packer_vcenter_cluster`}}",
+      "datastore": "{{user `packer_vcenter_datastore`}}",
+      "vm_folder": "{{user `packer_vcenter_folder`}}",
+      "vm_name": "{{user `template_name`}}-{{user `version`}}",
+      "vm_network": "{{user `packer_vcenter_net`}}",
+      "insecure" : "{{user `packer_vcenter_insecure`}}"
+    }
+  ]
+}

--- a/templates/fedora-21/i386.vsphere.nocm.json
+++ b/templates/fedora-21/i386.vsphere.nocm.json
@@ -1,0 +1,105 @@
+{
+
+  "variables":
+    {
+      "template_name": "fedora-21-i386",
+      "version": "0.0.1",
+
+      "provisioner": "vmware",
+      "required_modules": "puppetlabs-stdlib",
+      "puppet_nfs": "{{env `PUPPET_NFS`}}",
+      "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
+      "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",
+      "packer_vcenter_username": "{{env `PACKER_VCENTER_USERNAME`}}",
+      "packer_vcenter_password": "{{env `PACKER_VCENTER_PASSWORD`}}",
+      "packer_vcenter_dc": "{{env `PACKER_VCENTER_DC`}}",
+      "packer_vcenter_cluster": "{{env `PACKER_VCENTER_CLUSTER`}}",
+      "packer_vcenter_datastore": "{{env `PACKER_VCENTER_DATASTORE`}}",
+      "packer_vcenter_folder": "{{env `PACKER_VCENTER_FOLDER`}}",
+      "packer_vcenter_net": "{{env `PACKER_VCENTER_NET`}}",
+      "packer_vcenter_insecure": "{{env `PACKER_VCENTER_INSECURE`}}",
+
+      "memory_size": "2048",
+      "cpu_count": "2"
+
+    },
+
+  "builders": [
+    {
+      "name": "{{user `template_name`}}-{{user `provisioner`}}-vsphere-nocm",
+      "vm_name": "packer-{{build_name}}",
+      "type": "vmware-vmx",
+      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
+      "ssh_username": "root",
+      "ssh_password": "puppet",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "/sbin/halt -h -p",
+      "vmx_data_post": {
+        "memsize": "{{user `memory_size`}}",
+        "numvcpus": "{{user `cpu_count`}}",
+        "cpuid.coresPerSocket": "1"
+      }
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type": "shell",
+      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
+      ],
+      "scripts": [
+        "../../scripts/bootstrap-puppet.sh"
+      ]
+    },
+
+    {
+      "type": "file",
+      "source": "../../hiera",
+      "destination": "/tmp/packer-puppet-masterless"
+    },
+
+    {
+      "type": "puppet-masterless",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --hiera_config='/tmp/packer-puppet-masterless/hiera/hiera.yaml' --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "facter": {
+        "provisioner": "{{user `provisioner`}}",
+        "qa_root_passwd": "{{user `qa_root_passwd`}}"
+      },
+      "manifest_dir": "../../manifests",
+      "manifest_file": "../../manifests/vsphere/nocm.pp"
+    },
+
+    {
+      "type": "shell",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
+      ],
+      "scripts": [
+        "../../scripts/cleanup-puppet.sh",
+        "../../scripts/cleanup-packer.sh",
+        "../../scripts/cleanup-scrub.sh"
+      ]
+    }
+  ],
+
+  "post-processors": [
+    {
+      "type": "vsphere",
+      "host": "{{user `packer_vcenter_host`}}",
+      "username": "{{user `packer_vcenter_username`}}",
+      "password": "{{user `packer_vcenter_password`}}",
+      "datacenter": "{{user `packer_vcenter_dc`}}",
+      "cluster": "{{user `packer_vcenter_cluster`}}",
+      "datastore": "{{user `packer_vcenter_datastore`}}",
+      "vm_folder": "{{user `packer_vcenter_folder`}}",
+      "vm_name": "{{user `template_name`}}-{{user `version`}}",
+      "vm_network": "{{user `packer_vcenter_net`}}",
+      "insecure" : "{{user `packer_vcenter_insecure`}}"
+    }
+  ]
+}

--- a/templates/fedora-21/x86_64.vsphere.nocm.json
+++ b/templates/fedora-21/x86_64.vsphere.nocm.json
@@ -1,0 +1,105 @@
+{
+
+  "variables":
+    {
+      "template_name": "fedora-21-x86_64",
+      "version": "0.0.1",
+
+      "provisioner": "vmware",
+      "required_modules": "puppetlabs-stdlib",
+      "puppet_nfs": "{{env `PUPPET_NFS`}}",
+      "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
+      "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",
+      "packer_vcenter_username": "{{env `PACKER_VCENTER_USERNAME`}}",
+      "packer_vcenter_password": "{{env `PACKER_VCENTER_PASSWORD`}}",
+      "packer_vcenter_dc": "{{env `PACKER_VCENTER_DC`}}",
+      "packer_vcenter_cluster": "{{env `PACKER_VCENTER_CLUSTER`}}",
+      "packer_vcenter_datastore": "{{env `PACKER_VCENTER_DATASTORE`}}",
+      "packer_vcenter_folder": "{{env `PACKER_VCENTER_FOLDER`}}",
+      "packer_vcenter_net": "{{env `PACKER_VCENTER_NET`}}",
+      "packer_vcenter_insecure": "{{env `PACKER_VCENTER_INSECURE`}}",
+
+      "memory_size": "2048",
+      "cpu_count": "2"
+
+    },
+
+  "builders": [
+    {
+      "name": "{{user `template_name`}}-{{user `provisioner`}}-vsphere-nocm",
+      "vm_name": "packer-{{build_name}}",
+      "type": "vmware-vmx",
+      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
+      "ssh_username": "root",
+      "ssh_password": "puppet",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "/sbin/halt -h -p",
+      "vmx_data_post": {
+        "memsize": "{{user `memory_size`}}",
+        "numvcpus": "{{user `cpu_count`}}",
+        "cpuid.coresPerSocket": "1"
+      }
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type": "shell",
+      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
+      ],
+      "scripts": [
+        "../../scripts/bootstrap-puppet.sh"
+      ]
+    },
+
+    {
+      "type": "file",
+      "source": "../../hiera",
+      "destination": "/tmp/packer-puppet-masterless"
+    },
+
+    {
+      "type": "puppet-masterless",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --hiera_config='/tmp/packer-puppet-masterless/hiera/hiera.yaml' --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "facter": {
+        "provisioner": "{{user `provisioner`}}",
+        "qa_root_passwd": "{{user `qa_root_passwd`}}"
+      },
+      "manifest_dir": "../../manifests",
+      "manifest_file": "../../manifests/vsphere/nocm.pp"
+    },
+
+    {
+      "type": "shell",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
+      ],
+      "scripts": [
+        "../../scripts/cleanup-puppet.sh",
+        "../../scripts/cleanup-packer.sh",
+        "../../scripts/cleanup-scrub.sh"
+      ]
+    }
+  ],
+
+  "post-processors": [
+    {
+      "type": "vsphere",
+      "host": "{{user `packer_vcenter_host`}}",
+      "username": "{{user `packer_vcenter_username`}}",
+      "password": "{{user `packer_vcenter_password`}}",
+      "datacenter": "{{user `packer_vcenter_dc`}}",
+      "cluster": "{{user `packer_vcenter_cluster`}}",
+      "datastore": "{{user `packer_vcenter_datastore`}}",
+      "vm_folder": "{{user `packer_vcenter_folder`}}",
+      "vm_name": "{{user `template_name`}}-{{user `version`}}",
+      "vm_network": "{{user `packer_vcenter_net`}}",
+      "insecure" : "{{user `packer_vcenter_insecure`}}"
+    }
+  ]
+}

--- a/templates/fedora-22/i386.vsphere.nocm.json
+++ b/templates/fedora-22/i386.vsphere.nocm.json
@@ -1,0 +1,105 @@
+{
+
+  "variables":
+    {
+      "template_name": "fedora-22-i386",
+      "version": "0.0.1",
+
+      "provisioner": "vmware",
+      "required_modules": "puppetlabs-stdlib",
+      "puppet_nfs": "{{env `PUPPET_NFS`}}",
+      "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
+      "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",
+      "packer_vcenter_username": "{{env `PACKER_VCENTER_USERNAME`}}",
+      "packer_vcenter_password": "{{env `PACKER_VCENTER_PASSWORD`}}",
+      "packer_vcenter_dc": "{{env `PACKER_VCENTER_DC`}}",
+      "packer_vcenter_cluster": "{{env `PACKER_VCENTER_CLUSTER`}}",
+      "packer_vcenter_datastore": "{{env `PACKER_VCENTER_DATASTORE`}}",
+      "packer_vcenter_folder": "{{env `PACKER_VCENTER_FOLDER`}}",
+      "packer_vcenter_net": "{{env `PACKER_VCENTER_NET`}}",
+      "packer_vcenter_insecure": "{{env `PACKER_VCENTER_INSECURE`}}",
+
+      "memory_size": "2048",
+      "cpu_count": "2"
+
+    },
+
+  "builders": [
+    {
+      "name": "{{user `template_name`}}-{{user `provisioner`}}-vsphere-nocm",
+      "vm_name": "packer-{{build_name}}",
+      "type": "vmware-vmx",
+      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
+      "ssh_username": "root",
+      "ssh_password": "puppet",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "/sbin/halt -h -p",
+      "vmx_data_post": {
+        "memsize": "{{user `memory_size`}}",
+        "numvcpus": "{{user `cpu_count`}}",
+        "cpuid.coresPerSocket": "1"
+      }
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type": "shell",
+      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
+      ],
+      "scripts": [
+        "../../scripts/bootstrap-puppet.sh"
+      ]
+    },
+
+    {
+      "type": "file",
+      "source": "../../hiera",
+      "destination": "/tmp/packer-puppet-masterless"
+    },
+
+    {
+      "type": "puppet-masterless",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --hiera_config='/tmp/packer-puppet-masterless/hiera/hiera.yaml' --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "facter": {
+        "provisioner": "{{user `provisioner`}}",
+        "qa_root_passwd": "{{user `qa_root_passwd`}}"
+      },
+      "manifest_dir": "../../manifests",
+      "manifest_file": "../../manifests/vsphere/nocm.pp"
+    },
+
+    {
+      "type": "shell",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
+      ],
+      "scripts": [
+        "../../scripts/cleanup-puppet.sh",
+        "../../scripts/cleanup-packer.sh",
+        "../../scripts/cleanup-scrub.sh"
+      ]
+    }
+  ],
+
+  "post-processors": [
+    {
+      "type": "vsphere",
+      "host": "{{user `packer_vcenter_host`}}",
+      "username": "{{user `packer_vcenter_username`}}",
+      "password": "{{user `packer_vcenter_password`}}",
+      "datacenter": "{{user `packer_vcenter_dc`}}",
+      "cluster": "{{user `packer_vcenter_cluster`}}",
+      "datastore": "{{user `packer_vcenter_datastore`}}",
+      "vm_folder": "{{user `packer_vcenter_folder`}}",
+      "vm_name": "{{user `template_name`}}-{{user `version`}}",
+      "vm_network": "{{user `packer_vcenter_net`}}",
+      "insecure" : "{{user `packer_vcenter_insecure`}}"
+    }
+  ]
+}

--- a/templates/fedora-22/x86_64.vsphere.nocm.json
+++ b/templates/fedora-22/x86_64.vsphere.nocm.json
@@ -1,0 +1,105 @@
+{
+
+  "variables":
+    {
+      "template_name": "fedora-22-x86_64",
+      "version": "0.0.1",
+
+      "provisioner": "vmware",
+      "required_modules": "puppetlabs-stdlib",
+      "puppet_nfs": "{{env `PUPPET_NFS`}}",
+      "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
+      "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",
+      "packer_vcenter_username": "{{env `PACKER_VCENTER_USERNAME`}}",
+      "packer_vcenter_password": "{{env `PACKER_VCENTER_PASSWORD`}}",
+      "packer_vcenter_dc": "{{env `PACKER_VCENTER_DC`}}",
+      "packer_vcenter_cluster": "{{env `PACKER_VCENTER_CLUSTER`}}",
+      "packer_vcenter_datastore": "{{env `PACKER_VCENTER_DATASTORE`}}",
+      "packer_vcenter_folder": "{{env `PACKER_VCENTER_FOLDER`}}",
+      "packer_vcenter_net": "{{env `PACKER_VCENTER_NET`}}",
+      "packer_vcenter_insecure": "{{env `PACKER_VCENTER_INSECURE`}}",
+
+      "memory_size": "4096",
+      "cpu_count": "2"
+
+    },
+
+  "builders": [
+    {
+      "name": "{{user `template_name`}}-{{user `provisioner`}}-vsphere-nocm",
+      "vm_name": "packer-{{build_name}}",
+      "type": "vmware-vmx",
+      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
+      "ssh_username": "root",
+      "ssh_password": "puppet",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "/sbin/halt -h -p",
+      "vmx_data_post": {
+        "memsize": "{{user `memory_size`}}",
+        "numvcpus": "{{user `cpu_count`}}",
+        "cpuid.coresPerSocket": "1"
+      }
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type": "shell",
+      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
+      ],
+      "scripts": [
+        "../../scripts/bootstrap-puppet.sh"
+      ]
+    },
+
+    {
+      "type": "file",
+      "source": "../../hiera",
+      "destination": "/tmp/packer-puppet-masterless"
+    },
+
+    {
+      "type": "puppet-masterless",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --hiera_config='/tmp/packer-puppet-masterless/hiera/hiera.yaml' --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "facter": {
+        "provisioner": "{{user `provisioner`}}",
+        "qa_root_passwd": "{{user `qa_root_passwd`}}"
+      },
+      "manifest_dir": "../../manifests",
+      "manifest_file": "../../manifests/vsphere/nocm.pp"
+    },
+
+    {
+      "type": "shell",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
+      ],
+      "scripts": [
+        "../../scripts/cleanup-puppet.sh",
+        "../../scripts/cleanup-packer.sh",
+        "../../scripts/cleanup-scrub.sh"
+      ]
+    }
+  ],
+
+  "post-processors": [
+    {
+      "type": "vsphere",
+      "host": "{{user `packer_vcenter_host`}}",
+      "username": "{{user `packer_vcenter_username`}}",
+      "password": "{{user `packer_vcenter_password`}}",
+      "datacenter": "{{user `packer_vcenter_dc`}}",
+      "cluster": "{{user `packer_vcenter_cluster`}}",
+      "datastore": "{{user `packer_vcenter_datastore`}}",
+      "vm_folder": "{{user `packer_vcenter_folder`}}",
+      "vm_name": "{{user `template_name`}}-{{user `version`}}",
+      "vm_network": "{{user `packer_vcenter_net`}}",
+      "insecure" : "{{user `packer_vcenter_insecure`}}"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds initial support for shipping CentOS and Fedora artifacts using the vSphere post-processor.  It's primarily intended to be used with the [vmpooler](https://github.com/puppetlabs/vmpooler).

- [x] Fixups/improvements to the packer::vsphere module
  - [x] update to support new bootstrap method ( using vmtools )
  - [x] add bootstrap templates and ssh authorized_keys
  - [x] yum repo management
- [x] Add vSphere Configs
   - [x] CentOS 5
   - [x] CentOS 6
   - [x] CentOS 7
   - [x] Fedora 21
   - [x] Fedora 22

 