### PR TITLE
(RE-5464) Add Fedora 23 packer configs

### DIFF
--- a/manifests/modules/packer/manifests/networking/params.pp
+++ b/manifests/modules/packer/manifests/networking/params.pp
@@ -23,7 +23,7 @@ class packer::networking::params {
           $udev_rule        = '/etc/udev/rules.d/70-persistent-net.rules'
         }
 
-        21, 22: {
+        21, 22, 23: {
           case $::provisioner {
             'virtualbox': { $interface_script = '/etc/sysconfig/network-scripts/ifcfg-enp0s3' }
             'vmware':     { $interface_script = '/etc/sysconfig/network-scripts/ifcfg-ens33' }

--- a/scripts/bootstrap-puppet.sh
+++ b/scripts/bootstrap-puppet.sh
@@ -63,4 +63,11 @@ do
   /opt/puppet/bin/puppet module install $i --modulepath=/tmp/packer-puppet-masterless/manifests/modules >/dev/null 2>&1
 done
 
+if [[ "${TEMPLATE}" == "fedora-23"* ]]; then
+  dnf -y install git
+  git clone https://github.com/nibalizer/puppet-dnf /tmp/packer-puppet-masterless/manifests/modules/puppet-dnf
+  dnf -y remove git
+fi
+
+
 printf 'Modules installed in ' ; /opt/puppet/bin/puppet module list --modulepath=/tmp/packer-puppet-masterless/manifests/modules

--- a/templates/fedora-23/files/ks.cfg
+++ b/templates/fedora-23/files/ks.cfg
@@ -1,0 +1,35 @@
+install
+cdrom
+lang en_US.UTF-8
+keyboard us
+network --bootproto=dhcp
+rootpw puppet
+firewall --disabled
+authconfig --enableshadow --passalgo=sha512
+selinux --disabled
+timezone UTC
+bootloader --location=mbr
+text
+skipx
+zerombr
+clearpart --all --initlabel
+autopart
+auth  --useshadow  --enablemd5
+firstboot --disabled
+reboot
+
+%packages --ignoremissing
+bzip2
+kernel-devel
+kernel-headers
+tar
+wget
+nfs-utils
+net-tools
+-linux-firmware
+-plymouth
+-plymouth-core-libs
+%end
+
+%post
+%end

--- a/templates/fedora-23/i386.vmware.base.json
+++ b/templates/fedora-23/i386.vmware.base.json
@@ -1,0 +1,88 @@
+{
+
+  "variables":
+    {
+      "template_name": "fedora-23-i386",
+      "template_os": "fedora",
+
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/Fedora-Server-DVD-i386-23.iso",
+      "iso_checksum": "aa2125b6351480ce82ace619925d897d0588195a3287ef74fb203b6eb34cbccf",
+      "iso_checksum_type": "sha256",
+
+      "memory_size": "512",
+      "cpu_count": "1",
+
+      "provisioner": "vmware",
+      "required_modules": "puppetlabs-stdlib saz-ssh",
+      "puppet_nfs": "{{env `PUPPET_NFS`}}"
+    },
+
+  "builders": [
+    {
+      "name": "{{user `template_name`}}-{{user `provisioner`}}",
+      "type": "vmware-iso",
+      "boot_command": [
+        "<tab> <wait>",
+        "text <wait>",
+        "ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg <wait>",
+        "<enter>"
+      ],
+      "boot_wait": "10s",
+      "disk_size": 20480,
+      "guest_os_type": "{{user `template_os`}}",
+      "http_directory": "files",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `iso_url`}}",
+      "ssh_username": "root",
+      "ssh_password": "puppet",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "/sbin/halt -h -p",
+      "tools_upload_flavor": "linux",
+      "vmx_data": {
+        "memsize": "{{user `memory_size`}}",
+        "numvcpus": "{{user `cpu_count`}}",
+        "cpuid.coresPerSocket": "1"
+      }
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type": "shell",
+      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
+      ],
+      "scripts": [
+        "../../scripts/bootstrap-puppet.sh"
+      ]
+    },
+
+    {
+      "type": "puppet-masterless",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "facter": {
+        "provisioner": "{{user `provisioner`}}"
+      },
+      "manifest_dir": "../../manifests",
+      "manifest_file": "../../manifests/base.pp"
+    },
+
+    {
+      "type": "shell",
+      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
+      ],
+      "scripts": [
+        "../../scripts/cleanup-puppet.sh",
+        "../../scripts/cleanup-packer.sh"
+      ]
+    }
+  ]
+
+}

--- a/templates/fedora-23/i386.vsphere.nocm.json
+++ b/templates/fedora-23/i386.vsphere.nocm.json
@@ -1,0 +1,105 @@
+{
+
+  "variables":
+    {
+      "template_name": "fedora-23-i386",
+      "version": "0.0.1",
+
+      "provisioner": "vmware",
+      "required_modules": "puppetlabs-stdlib",
+      "puppet_nfs": "{{env `PUPPET_NFS`}}",
+      "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
+      "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",
+      "packer_vcenter_username": "{{env `PACKER_VCENTER_USERNAME`}}",
+      "packer_vcenter_password": "{{env `PACKER_VCENTER_PASSWORD`}}",
+      "packer_vcenter_dc": "{{env `PACKER_VCENTER_DC`}}",
+      "packer_vcenter_cluster": "{{env `PACKER_VCENTER_CLUSTER`}}",
+      "packer_vcenter_datastore": "{{env `PACKER_VCENTER_DATASTORE`}}",
+      "packer_vcenter_folder": "{{env `PACKER_VCENTER_FOLDER`}}",
+      "packer_vcenter_net": "{{env `PACKER_VCENTER_NET`}}",
+      "packer_vcenter_insecure": "{{env `PACKER_VCENTER_INSECURE`}}",
+
+      "memory_size": "2048",
+      "cpu_count": "2"
+
+    },
+
+  "builders": [
+    {
+      "name": "{{user `template_name`}}-{{user `provisioner`}}-vsphere-nocm",
+      "vm_name": "packer-{{build_name}}",
+      "type": "vmware-vmx",
+      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
+      "ssh_username": "root",
+      "ssh_password": "puppet",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "/sbin/halt -h -p",
+      "vmx_data_post": {
+        "memsize": "{{user `memory_size`}}",
+        "numvcpus": "{{user `cpu_count`}}",
+        "cpuid.coresPerSocket": "1"
+      }
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type": "shell",
+      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
+      ],
+      "scripts": [
+        "../../scripts/bootstrap-puppet.sh"
+      ]
+    },
+
+    {
+      "type": "file",
+      "source": "../../hiera",
+      "destination": "/tmp/packer-puppet-masterless"
+    },
+
+    {
+      "type": "puppet-masterless",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --hiera_config='/tmp/packer-puppet-masterless/hiera/hiera.yaml' --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "facter": {
+        "provisioner": "{{user `provisioner`}}",
+        "qa_root_passwd": "{{user `qa_root_passwd`}}"
+      },
+      "manifest_dir": "../../manifests",
+      "manifest_file": "../../manifests/vsphere/nocm.pp"
+    },
+
+    {
+      "type": "shell",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
+      ],
+      "scripts": [
+        "../../scripts/cleanup-puppet.sh",
+        "../../scripts/cleanup-packer.sh",
+        "../../scripts/cleanup-scrub.sh"
+      ]
+    }
+  ],
+
+  "post-processors": [
+    {
+      "type": "vsphere",
+      "host": "{{user `packer_vcenter_host`}}",
+      "username": "{{user `packer_vcenter_username`}}",
+      "password": "{{user `packer_vcenter_password`}}",
+      "datacenter": "{{user `packer_vcenter_dc`}}",
+      "cluster": "{{user `packer_vcenter_cluster`}}",
+      "datastore": "{{user `packer_vcenter_datastore`}}",
+      "vm_folder": "{{user `packer_vcenter_folder`}}",
+      "vm_name": "{{user `template_name`}}-{{user `version`}}",
+      "vm_network": "{{user `packer_vcenter_net`}}",
+      "insecure" : "{{user `packer_vcenter_insecure`}}"
+    }
+  ]
+}

--- a/templates/fedora-23/x86_64.vmware.base.json
+++ b/templates/fedora-23/x86_64.vmware.base.json
@@ -1,0 +1,88 @@
+{
+
+  "variables":
+    {
+      "template_name": "fedora-23-x86_64",
+      "template_os": "fedora-64",
+
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/Fedora-Server-DVD-x86_64-23.iso",
+      "iso_checksum": "30758dc821d1530de427c9e35212bd79b058bd4282e64b7b34ae1a40c87c05ae",
+      "iso_checksum_type": "sha256",
+
+      "memory_size": "512",
+      "cpu_count": "1",
+
+      "provisioner": "vmware",
+      "required_modules": "puppetlabs-stdlib saz-ssh",
+      "puppet_nfs": "{{env `PUPPET_NFS`}}"
+    },
+
+  "builders": [
+    {
+      "name": "{{user `template_name`}}-{{user `provisioner`}}",
+      "type": "vmware-iso",
+      "boot_command": [
+        "<tab> <wait>",
+        "text <wait>",
+        "ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg <wait>",
+        "<enter>"
+      ],
+      "boot_wait": "10s",
+      "disk_size": 20480,
+      "guest_os_type": "{{user `template_os`}}",
+      "http_directory": "files",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `iso_url`}}",
+      "ssh_username": "root",
+      "ssh_password": "puppet",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "/sbin/halt -h -p",
+      "tools_upload_flavor": "linux",
+      "vmx_data": {
+        "memsize": "{{user `memory_size`}}",
+        "numvcpus": "{{user `cpu_count`}}",
+        "cpuid.coresPerSocket": "1"
+      }
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type": "shell",
+      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
+      ],
+      "scripts": [
+        "../../scripts/bootstrap-puppet.sh"
+      ]
+    },
+
+    {
+      "type": "puppet-masterless",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "facter": {
+        "provisioner": "{{user `provisioner`}}"
+      },
+      "manifest_dir": "../../manifests",
+      "manifest_file": "../../manifests/base.pp"
+    },
+
+    {
+      "type": "shell",
+      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
+      ],
+      "scripts": [
+        "../../scripts/cleanup-puppet.sh",
+        "../../scripts/cleanup-packer.sh"
+      ]
+    }
+  ]
+
+}

--- a/templates/fedora-23/x86_64.vsphere.nocm.json
+++ b/templates/fedora-23/x86_64.vsphere.nocm.json
@@ -1,0 +1,105 @@
+{
+
+  "variables":
+    {
+      "template_name": "fedora-23-x86_64",
+      "version": "0.0.1",
+
+      "provisioner": "vmware",
+      "required_modules": "puppetlabs-stdlib",
+      "puppet_nfs": "{{env `PUPPET_NFS`}}",
+      "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
+      "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",
+      "packer_vcenter_username": "{{env `PACKER_VCENTER_USERNAME`}}",
+      "packer_vcenter_password": "{{env `PACKER_VCENTER_PASSWORD`}}",
+      "packer_vcenter_dc": "{{env `PACKER_VCENTER_DC`}}",
+      "packer_vcenter_cluster": "{{env `PACKER_VCENTER_CLUSTER`}}",
+      "packer_vcenter_datastore": "{{env `PACKER_VCENTER_DATASTORE`}}",
+      "packer_vcenter_folder": "{{env `PACKER_VCENTER_FOLDER`}}",
+      "packer_vcenter_net": "{{env `PACKER_VCENTER_NET`}}",
+      "packer_vcenter_insecure": "{{env `PACKER_VCENTER_INSECURE`}}",
+
+      "memory_size": "4096",
+      "cpu_count": "2"
+
+    },
+
+  "builders": [
+    {
+      "name": "{{user `template_name`}}-{{user `provisioner`}}-vsphere-nocm",
+      "vm_name": "packer-{{build_name}}",
+      "type": "vmware-vmx",
+      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
+      "ssh_username": "root",
+      "ssh_password": "puppet",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "/sbin/halt -h -p",
+      "vmx_data_post": {
+        "memsize": "{{user `memory_size`}}",
+        "numvcpus": "{{user `cpu_count`}}",
+        "cpuid.coresPerSocket": "1"
+      }
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type": "shell",
+      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
+      ],
+      "scripts": [
+        "../../scripts/bootstrap-puppet.sh"
+      ]
+    },
+
+    {
+      "type": "file",
+      "source": "../../hiera",
+      "destination": "/tmp/packer-puppet-masterless"
+    },
+
+    {
+      "type": "puppet-masterless",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --verbose --detailed-exitcodes --hiera_config='/tmp/packer-puppet-masterless/hiera/hiera.yaml' --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "facter": {
+        "provisioner": "{{user `provisioner`}}",
+        "qa_root_passwd": "{{user `qa_root_passwd`}}"
+      },
+      "manifest_dir": "../../manifests",
+      "manifest_file": "../../manifests/vsphere/nocm.pp"
+    },
+
+    {
+      "type": "shell",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
+      ],
+      "scripts": [
+        "../../scripts/cleanup-puppet.sh",
+        "../../scripts/cleanup-packer.sh",
+        "../../scripts/cleanup-scrub.sh"
+      ]
+    }
+  ],
+
+  "post-processors": [
+    {
+      "type": "vsphere",
+      "host": "{{user `packer_vcenter_host`}}",
+      "username": "{{user `packer_vcenter_username`}}",
+      "password": "{{user `packer_vcenter_password`}}",
+      "datacenter": "{{user `packer_vcenter_dc`}}",
+      "cluster": "{{user `packer_vcenter_cluster`}}",
+      "datastore": "{{user `packer_vcenter_datastore`}}",
+      "vm_folder": "{{user `packer_vcenter_folder`}}",
+      "vm_name": "{{user `template_name`}}-{{user `version`}}",
+      "vm_network": "{{user `packer_vcenter_net`}}",
+      "insecure" : "{{user `packer_vcenter_insecure`}}"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds base and vsphere-nocm packer templates. The vSphere artifact is meant to be used with the vmpooler.