### PR TITLE
(RE-6532) vangrant box updates

### DIFF
--- a/bin/vagrantclouder
+++ b/bin/vagrantclouder
@@ -115,13 +115,11 @@ $config['arches'].each do |arch|
             config['s3'] = 'nocm'
         end
 
-        ['virtualbox', 'vmware_desktop', 'vmware_fusion'].each do |hyper|
+        ['virtualbox', 'vmware_desktop'].each do |hyper|
           case hyper
             when 'virtualbox'
               hyperlink = 'virtualbox'
             when 'vmware_desktop'
-              hyperlink = 'vmware'
-            when 'vmware_fusion'
               hyperlink = 'vmware'
           end
 

--- a/manifests/modules/packer/manifests/networking/params.pp
+++ b/manifests/modules/packer/manifests/networking/params.pp
@@ -18,12 +18,12 @@ class packer::networking::params {
           $udev_rule_gen    = '/lib/udev/rules.d/75-persistent-net-generator.rules'
         }
 
-        5.10, 5.11: {
+        '5.11': {
           $interface_script = '/etc/sysconfig/network-scripts/ifcfg-eth0'
           $udev_rule        = '/etc/udev/rules.d/70-persistent-net.rules'
         }
 
-        21, 22, 23: {
+        '21', '22', '23': {
           case $::provisioner {
             'virtualbox': { $interface_script = '/etc/sysconfig/network-scripts/ifcfg-enp0s3' }
             'vmware':     { $interface_script = '/etc/sysconfig/network-scripts/ifcfg-ens33' }

--- a/templates/centos-5.11/CHANGELOG
+++ b/templates/centos-5.11/CHANGELOG
@@ -1,3 +1,8 @@
+### 1.0.3
+
+* Bump version for Puppet and PE
+* CentOS package updates to address security vulnerabilities
+
 ### 1.0.2
 
 * Switch to puppet-agent packaging

--- a/templates/centos-5.11/i386.vmware.base.json
+++ b/templates/centos-5.11/i386.vmware.base.json
@@ -27,7 +27,7 @@
         "ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/i386.ks <wait>",
         "<enter>"
       ],
-      "boot_wait": "10s",
+      "boot_wait": "45s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
       "http_directory": "files",

--- a/templates/centos-5.11/vagrantcloud.yaml
+++ b/templates/centos-5.11/vagrantcloud.yaml
@@ -1,7 +1,7 @@
 ---
 name: 'centos-5.11'
 description: 'CentOS 5.11'
-version: '1.0.2'
+version: '1.0.3'
 
 arches:
   - name: '32'
@@ -13,6 +13,6 @@ configs:
   - name: 'nocm'
     description: 'no configuration management software'
   - name: 'puppet'
-    description: 'Puppet 4.2.1'
+    description: 'Puppet 4.3.2'
   - name: 'puppet-enterprise'
-    description: 'Puppet Enterprise 3.8.1 (agent-only)'
+    description: 'Puppet Enterprise 3.8.4 (agent-only)'

--- a/templates/centos-5.11/x86_64.vmware.base.json
+++ b/templates/centos-5.11/x86_64.vmware.base.json
@@ -27,7 +27,7 @@
         "ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/x86_64.ks <wait>",
         "<enter>"
       ],
-      "boot_wait": "10s",
+      "boot_wait": "45s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
       "http_directory": "files",

--- a/templates/centos-6.6/CHANGELOG
+++ b/templates/centos-6.6/CHANGELOG
@@ -1,3 +1,8 @@
+### 1.0.3
+
+* Bump version for Puppet and PE
+* CentOS package updates to address security vulnerabilities
+
 ### 1.0.2
 
 * Switch to puppet-agent packaging

--- a/templates/centos-6.6/i386.vmware.base.json
+++ b/templates/centos-6.6/i386.vmware.base.json
@@ -27,7 +27,7 @@
         "ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/i386.ks <wait>",
         "<enter>"
       ],
-      "boot_wait": "10s",
+      "boot_wait": "45s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
       "http_directory": "files",

--- a/templates/centos-6.6/vagrantcloud.yaml
+++ b/templates/centos-6.6/vagrantcloud.yaml
@@ -1,7 +1,7 @@
 ---
 name: 'centos-6.6'
 description: 'CentOS 6.6'
-version: '1.0.2'
+version: '1.0.3'
 
 arches:
   - name: '32'
@@ -13,6 +13,6 @@ configs:
   - name: 'nocm'
     description: 'no configuration management software'
   - name: 'puppet'
-    description: 'Puppet 4.2.1'
+    description: 'Puppet 4.3.2'
   - name: 'puppet-enterprise'
-    description: 'Puppet Enterprise 3.8.1 (agent-only)'
+    description: 'Puppet Enterprise 3.8.4 (agent-only)'

--- a/templates/centos-6.6/x86_64.vmware.base.json
+++ b/templates/centos-6.6/x86_64.vmware.base.json
@@ -27,7 +27,7 @@
         "ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/x86_64.ks <wait>",
         "<enter>"
       ],
-      "boot_wait": "10s",
+      "boot_wait": "45s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
       "http_directory": "files",

--- a/templates/centos-7.2/CHANGELOG
+++ b/templates/centos-7.2/CHANGELOG
@@ -1,3 +1,9 @@
+### 1.0.1
+
+* Bump version for Puppet
+* Add PE box
+* CentOS package updates to address security vulnerabilities
+
 ### 1.0.0
 
 * Initial release

--- a/templates/centos-7.2/vagrantcloud.yaml
+++ b/templates/centos-7.2/vagrantcloud.yaml
@@ -1,7 +1,7 @@
 ---
 name: 'centos-7.2'
 description: 'CentOS 7.2'
-version: '1.0.0'
+version: '1.0.1'
 
 arches:
   - name: '64'
@@ -11,4 +11,6 @@ configs:
   - name: 'nocm'
     description: 'no configuration management software'
   - name: 'puppet'
-    description: 'Puppet 4.3.1'
+    description: 'Puppet 4.3.2'
+  - name: 'puppet-enterprise'
+    description: 'Puppet Enterprise 3.8.4 (agent-only)'

--- a/templates/centos-7.2/x86_64.virtualbox.vagrant.pe.json
+++ b/templates/centos-7.2/x86_64.virtualbox.vagrant.pe.json
@@ -1,0 +1,68 @@
+{
+
+  "variables":
+    {
+      "template_name": "centos-7.2-x86_64",
+
+      "provisioner": "virtualbox",
+      "required_modules": "puppetlabs-stdlib saz-sudo"
+    },
+
+  "builders": [
+    {
+      "name": "{{user `template_name`}}-{{user `provisioner`}}-vagrant-pe",
+      "type": "virtualbox-ovf",
+      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.ovf",
+      "ssh_username": "root",
+      "ssh_password": "puppet",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "/sbin/halt -h -p"
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type": "shell",
+      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "OPERATINGSYSTEM=redhat",
+        "ARCHITECTURE=x86_64"
+      ],
+      "scripts": [
+        "../../scripts/install-puppet-enterprise.sh"
+      ]
+    },
+
+    {
+      "type": "puppet-masterless",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --parser=future --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "facter": {
+        "provisioner": "{{user `provisioner`}}"
+      },
+      "manifest_dir": "../../manifests",
+      "manifest_file": "../../manifests/vagrant/nocm.pp"
+    },
+
+    {
+      "type": "shell",
+      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}"
+      ],
+      "scripts": [
+        "../../scripts/cleanup-packer.sh",
+        "../../scripts/cleanup-scrub.sh"
+      ]
+    }
+  ],
+
+  "post-processors": [
+    {
+      "type": "vagrant",
+      "output": "/opt/output/{{.Provider}}/{{user `template_name`}}-{{.Provider}}-pe.box"
+    }
+  ]
+
+}

--- a/templates/centos-7.2/x86_64.vmware.base.json
+++ b/templates/centos-7.2/x86_64.vmware.base.json
@@ -27,7 +27,7 @@
         "ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/x86_64.ks <wait>",
         "<enter>"
       ],
-      "boot_wait": "10s",
+      "boot_wait": "45s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
       "http_directory": "files",

--- a/templates/centos-7.2/x86_64.vmware.vagrant.pe.json
+++ b/templates/centos-7.2/x86_64.vmware.vagrant.pe.json
@@ -1,0 +1,68 @@
+{
+
+  "variables":
+    {
+      "template_name": "centos-7.2-x86_64",
+
+      "provisioner": "vmware",
+      "required_modules": "puppetlabs-stdlib saz-sudo"
+    },
+
+  "builders": [
+    {
+      "name": "{{user `template_name`}}-{{user `provisioner`}}-vagrant-pe",
+      "type": "vmware-vmx",
+      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
+      "ssh_username": "root",
+      "ssh_password": "puppet",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "/sbin/halt -h -p"
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type": "shell",
+      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "OPERATINGSYSTEM=redhat",
+        "ARCHITECTURE=x86_64"
+      ],
+      "scripts": [
+        "../../scripts/install-puppet-enterprise.sh"
+      ]
+    },
+
+    {
+      "type": "puppet-masterless",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --parser=future --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "facter": {
+        "provisioner": "{{user `provisioner`}}"
+      },
+      "manifest_dir": "../../manifests",
+      "manifest_file": "../../manifests/vagrant/nocm.pp"
+    },
+
+    {
+      "type": "shell",
+      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}"
+      ],
+      "scripts": [
+        "../../scripts/cleanup-packer.sh",
+        "../../scripts/cleanup-scrub.sh"
+      ]
+    }
+  ],
+
+  "post-processors": [
+    {
+      "type": "vagrant",
+      "output": "/opt/output/{{.Provider}}/{{user `template_name`}}-{{.Provider}}-pe.box"
+    }
+  ]
+
+}

--- a/templates/debian-7.8/CHANGELOG
+++ b/templates/debian-7.8/CHANGELOG
@@ -1,3 +1,8 @@
+### 1.0.4
+
+* Bump version for Puppet and PE
+* Debian package updates to address security vulnerabilities 
+
 ### 1.0.3
 
 * Switch to puppet-agent packaging

--- a/templates/debian-7.8/files/preseed.cfg
+++ b/templates/debian-7.8/files/preseed.cfg
@@ -20,7 +20,7 @@ d-i partman/confirm boolean true
 d-i partman/confirm_nooverwrite boolean true
 apt-cdrom-setup apt-setup/cdrom/set-first boolean false
 d-i mirror/country string manual
-d-i mirror/http/hostname string http.us.debian.org
+d-i mirror/http/hostname string httpredir.debian.org
 d-i mirror/http/directory string /debian
 d-i mirror/http/proxy string
 d-i apt-setup/use_mirror boolean true
@@ -29,6 +29,7 @@ tasksel tasksel/first multiselect standard
 d-i grub-installer/only_debian boolean true
 d-i finish-install/reboot_in_progress note
 d-i pkgsel/include string curl ntp openssh-server perl sudo wget build-essential
+d-i pkgsel/upgrade select none
 d-i preseed/early_command string sed -i \
   '/in-target/idiscover(){/sbin/discover|grep -v VirtualBox;}' \
   /usr/lib/pre-pkgsel.d/20install-hwpackages

--- a/templates/debian-7.8/i386.virtualbox.base.json
+++ b/templates/debian-7.8/i386.virtualbox.base.json
@@ -5,8 +5,8 @@
       "template_name": "debian-7.8-i386",
       "template_os": "Debian",
 
-      "iso_url": "http://cdimage.debian.org/cdimage/archive/7.8.0/i386/iso-cd/debian-7.8.0-i386-netinst.iso",
-      "iso_checksum": "0d2f88d23a9d5945f5bc0276830c7d2c",
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/debian-7.8.0-i386-CD-1.iso",
+      "iso_checksum": "3bc593912773795dce735dfbbecd3cb2",
       "iso_checksum_type": "md5",
 
       "memory_size": "512",

--- a/templates/debian-7.8/i386.vmware.base.json
+++ b/templates/debian-7.8/i386.vmware.base.json
@@ -5,8 +5,8 @@
       "template_name": "debian-7.8-i386",
       "template_os": "debian7",
 
-      "iso_url": "http://cdimage.debian.org/debian-cd/7.8.0/i386/iso-cd/debian-7.8.0-i386-netinst.iso",
-      "iso_checksum": "0d2f88d23a9d5945f5bc0276830c7d2c",
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/debian-7.8.0-i386-CD-1.iso",
+      "iso_checksum": "3bc593912773795dce735dfbbecd3cb2", 
       "iso_checksum_type": "md5",
 
       "memory_size": "512",
@@ -33,7 +33,7 @@
         "netcfg/get_hostname=localhost <wait>",
         "<enter>"
       ],
-      "boot_wait": "10s",
+      "boot_wait": "45s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
       "http_directory": "files",
@@ -90,7 +90,6 @@
         "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
-        "scripts/patch-tools.sh",
         "../../scripts/cleanup-puppet.sh",
         "../../scripts/cleanup-packer.sh"
       ]

--- a/templates/debian-7.8/vagrantcloud.yaml
+++ b/templates/debian-7.8/vagrantcloud.yaml
@@ -1,7 +1,7 @@
 ---
 name: 'debian-7.8'
 description: 'Debian 7.8 (wheezy)'
-version: '1.0.3'
+version: '1.0.4'
 
 arches:
   - name: '32'
@@ -13,6 +13,6 @@ configs:
   - name: 'nocm'
     description: 'no configuration management software'
   - name: 'puppet'
-    description: 'Puppet 4.2.1'
+    description: 'Puppet 4.3.2'
   - name: 'puppet-enterprise'
-    description: 'Puppet Enterprise 3.8.1 (agent-only)'
+    description: 'Puppet Enterprise 3.8.4 (agent-only)'

--- a/templates/debian-7.8/x86_64.virtualbox.base.json
+++ b/templates/debian-7.8/x86_64.virtualbox.base.json
@@ -4,8 +4,9 @@
     {
       "template_name": "debian-7.8-x86_64",
       "template_os": "Debian_64",
-      "iso_url": "http://cdimage.debian.org/cdimage/archive/7.8.0/amd64/iso-cd/debian-7.8.0-amd64-netinst.iso",
-      "iso_checksum": "a91fba5001cf0fbccb44a7ae38c63b6e",
+
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/debian-7.8.0-amd64-CD-1.iso",
+      "iso_checksum": "0e3d2e7bc3cd7c97f76a4ee8fb335e43",
       "iso_checksum_type": "md5",
 
       "memory_size": "512",

--- a/templates/debian-7.8/x86_64.vmware.base.json
+++ b/templates/debian-7.8/x86_64.vmware.base.json
@@ -5,8 +5,8 @@
       "template_name": "debian-7.8-x86_64",
       "template_os": "debian7-64",
 
-      "iso_url": "http://cdimage.debian.org/debian-cd/7.8.0/amd64/iso-cd/debian-7.8.0-amd64-netinst.iso",
-      "iso_checksum": "a91fba5001cf0fbccb44a7ae38c63b6e",
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/debian-7.8.0-amd64-CD-1.iso",
+      "iso_checksum": "0e3d2e7bc3cd7c97f76a4ee8fb335e43",
       "iso_checksum_type": "md5",
 
       "memory_size": "512",
@@ -33,7 +33,7 @@
         "netcfg/get_hostname=localhost <wait>",
         "<enter>"
       ],
-      "boot_wait": "10s",
+      "boot_wait": "45s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
       "http_directory": "files",
@@ -90,7 +90,6 @@
         "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
-        "scripts/patch-tools.sh",
         "../../scripts/cleanup-puppet.sh",
         "../../scripts/cleanup-packer.sh"
       ]

--- a/templates/debian-8.2/CHANGELOG
+++ b/templates/debian-8.2/CHANGELOG
@@ -1,3 +1,8 @@
+### 1.0.1
+
+* Bump version for Puppet
+* Debian package updates to address security vulnerabilities
+
 ### 1.0.0
 
 * Initial release

--- a/templates/debian-8.2/files/preseed.cfg
+++ b/templates/debian-8.2/files/preseed.cfg
@@ -19,7 +19,7 @@ d-i partman/confirm_wirte_new_label boolean true
 d-i partman/confirm boolean true
 d-i partman/confirm_nooverwrite boolean true
 d-i mirror/country string manual
-d-i mirror/http/hostname string http.us.debian.org
+d-i mirror/http/hostname string httpredir.debian.org
 d-i mirror/http/directory string /debian
 d-i mirror/http/proxy string
 d-i apt-setup/use_mirror boolean true
@@ -29,6 +29,7 @@ d-i grub-installer/bootdev string
 d-i grub-installer/choose_bootdev  select /dev/sda
 d-i finish-install/reboot_in_progress note
 d-i pkgsel/include string curl ntp openssh-server perl sudo wget build-essential
+d-i pkgsel/upgrade select none
 d-i preseed/early_command string sed -i \
   '/in-target/idiscover(){/sbin/discover|grep -v VirtualBox;}' \
   /usr/lib/pre-pkgsel.d/20install-hwpackages

--- a/templates/debian-8.2/i386.virtualbox.base.json
+++ b/templates/debian-8.2/i386.virtualbox.base.json
@@ -5,7 +5,7 @@
       "template_name": "debian-8.2-i386",
       "template_os": "Debian",
 
-      "iso_url": "http://cdimage.debian.org/debian-cd/8.2.0/i386/iso-cd/debian-8.2.0-i386-CD-1.iso",
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/debian-8.2.0-i386-CD-1.iso",
       "iso_checksum": "87060c2777f55806e313db22ba8a78aee9f7119b6321448a1dfdaf0bbfcb67ce",
       "iso_checksum_type": "sha256",
 

--- a/templates/debian-8.2/i386.vmware.base.json
+++ b/templates/debian-8.2/i386.vmware.base.json
@@ -5,7 +5,7 @@
       "template_name": "debian-8.2-i386",
       "template_os": "debian8",
 
-      "iso_url": "http://cdimage.debian.org/debian-cd/8.2.0/i386/iso-cd/debian-8.2.0-i386-CD-1.iso",
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/debian-8.2.0-i386-CD-1.iso",
       "iso_checksum": "87060c2777f55806e313db22ba8a78aee9f7119b6321448a1dfdaf0bbfcb67ce",
       "iso_checksum_type": "sha256",
 
@@ -33,7 +33,7 @@
         "netcfg/get_hostname=localhost <wait>",
         "<enter>"
       ],
-      "boot_wait": "10s",
+      "boot_wait": "45s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
       "http_directory": "files",

--- a/templates/debian-8.2/vagrantcloud.yaml
+++ b/templates/debian-8.2/vagrantcloud.yaml
@@ -1,7 +1,7 @@
 ---
 name: 'debian-8.2'
 description: 'Debian 8.2 (jessie)'
-version: '1.0.0'
+version: '1.0.1'
 
 arches:
   - name: '32'
@@ -13,4 +13,4 @@ configs:
   - name: 'nocm'
     description: 'no configuration management software'
   - name: 'puppet'
-    description: 'Puppet 4.3.1'
+    description: 'Puppet 4.3.2'

--- a/templates/debian-8.2/x86_64.virtualbox.base.json
+++ b/templates/debian-8.2/x86_64.virtualbox.base.json
@@ -4,7 +4,7 @@
     {
       "template_name": "debian-8.2-x86_64",
       "template_os": "Debian_64",
-      "iso_url": "http://cdimage.debian.org/debian-cd/8.2.0/amd64/iso-cd/debian-8.2.0-amd64-CD-1.iso",
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/debian-8.2.0-amd64-CD-1.iso",
       "iso_checksum": "d3ac88ec064f9e941ee5d9cbfaa87ac48929b81471f96073305ccd7bd71ff521",
       "iso_checksum_type": "sha256",
 

--- a/templates/debian-8.2/x86_64.vmware.base.json
+++ b/templates/debian-8.2/x86_64.vmware.base.json
@@ -5,7 +5,7 @@
       "template_name": "debian-8.2-x86_64",
       "template_os": "debian8-64",
 
-      "iso_url": "http://cdimage.debian.org/debian-cd/8.2.0/amd64/iso-cd/debian-8.2.0-amd64-CD-1.iso",
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/debian-8.2.0-amd64-CD-1.iso",
       "iso_checksum": "d3ac88ec064f9e941ee5d9cbfaa87ac48929b81471f96073305ccd7bd71ff521",
       "iso_checksum_type": "sha256",
 
@@ -33,7 +33,7 @@
         "netcfg/get_hostname=localhost <wait>",
         "<enter>"
       ],
-      "boot_wait": "10s",
+      "boot_wait": "45s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
       "http_directory": "files",

--- a/templates/ubuntu-12.04/CHANGELOG
+++ b/templates/ubuntu-12.04/CHANGELOG
@@ -1,3 +1,8 @@
+### 1.0.3
+
+* Bump version for Puppet and PE
+* Ubuntu package updates to address security vulnerabilities
+
 ### 1.0.2
 
 * Switch to puppet-agent packaging

--- a/templates/ubuntu-12.04/i386.virtualbox.base.json
+++ b/templates/ubuntu-12.04/i386.virtualbox.base.json
@@ -5,9 +5,9 @@
       "template_name": "ubuntu-12.04-i386",
       "template_os": "Ubuntu",
 
-      "iso_url": "http://releases.ubuntu.com/precise/ubuntu-12.04.5-server-i386.iso",
-      "iso_checksum": "1214cd22448338b60bb24f583dd8741a",
-      "iso_checksum_type": "md5",
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/ubuntu-12.04.5-server-i386.iso",
+      "iso_checksum": "bec39e79664aa189dea338993f636e54c5eda2f84c27def7b06bd6373ab87628",
+      "iso_checksum_type": "sha256",
 
       "memory_size": "512",
       "cpu_count": "1",

--- a/templates/ubuntu-12.04/i386.vmware.base.json
+++ b/templates/ubuntu-12.04/i386.vmware.base.json
@@ -5,9 +5,9 @@
       "template_name": "ubuntu-12.04-i386",
       "template_os": "ubuntu",
 
-      "iso_url": "http://releases.ubuntu.com/precise/ubuntu-12.04.5-server-i386.iso",
-      "iso_checksum": "1214cd22448338b60bb24f583dd8741a",
-      "iso_checksum_type": "md5",
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/ubuntu-12.04.5-server-i386.iso",
+      "iso_checksum": "bec39e79664aa189dea338993f636e54c5eda2f84c27def7b06bd6373ab87628",
+      "iso_checksum_type": "sha256",
 
       "memory_size": "512",
       "cpu_count": "1",
@@ -42,7 +42,7 @@
         "-- <wait>",
         "<enter>"
       ],
-      "boot_wait": "10s",
+      "boot_wait": "45s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
       "http_directory": "files",

--- a/templates/ubuntu-12.04/vagrantcloud.yaml
+++ b/templates/ubuntu-12.04/vagrantcloud.yaml
@@ -1,7 +1,7 @@
 ---
 name: 'ubuntu-12.04'
 description: 'Ubuntu 12.04 (precise)'
-version: '1.0.2'
+version: '1.0.3'
 
 arches:
   - name: '32'
@@ -13,6 +13,6 @@ configs:
   - name: 'nocm'
     description: 'no configuration management software'
   - name: 'puppet'
-    description: 'Puppet 4.2.1'
+    description: 'Puppet 4.3.2'
   - name: 'puppet-enterprise'
-    description: 'Puppet Enterprise 3.8.1 (agent-only)'
+    description: 'Puppet Enterprise 3.8.4 (agent-only)'

--- a/templates/ubuntu-12.04/x86_64.virtualbox.base.json
+++ b/templates/ubuntu-12.04/x86_64.virtualbox.base.json
@@ -5,9 +5,9 @@
       "template_name": "ubuntu-12.04-x86_64",
       "template_os": "Ubuntu_64",
 
-      "iso_url": "http://releases.ubuntu.com/12.04/ubuntu-12.04.5-server-amd64.iso",
-      "iso_checksum": "769474248a3897f4865817446f9a4a53",
-      "iso_checksum_type": "md5",
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/ubuntu-12.04.5-server-amd64.iso",
+      "iso_checksum": "af224223de99e2a730b67d7785b657f549be0d63221188e105445f75fb8305c9",
+      "iso_checksum_type": "sha256",
 
       "memory_size": "512",
       "cpu_count": "1",

--- a/templates/ubuntu-12.04/x86_64.vmware.base.json
+++ b/templates/ubuntu-12.04/x86_64.vmware.base.json
@@ -5,9 +5,9 @@
       "template_name": "ubuntu-12.04-x86_64",
       "template_os": "ubuntu-64",
 
-      "iso_url": "http://releases.ubuntu.com/12.04/ubuntu-12.04.5-server-amd64.iso",
-      "iso_checksum": "769474248a3897f4865817446f9a4a53",
-      "iso_checksum_type": "md5",
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/ubuntu-12.04.5-server-amd64.iso",
+      "iso_checksum": "af224223de99e2a730b67d7785b657f549be0d63221188e105445f75fb8305c9",
+      "iso_checksum_type": "sha256",
 
       "memory_size": "512",
       "cpu_count": "1",
@@ -42,7 +42,7 @@
         "-- <wait>",
         "<enter>"
       ],
-      "boot_wait": "10s",
+      "boot_wait": "45s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
       "http_directory": "files",

--- a/templates/ubuntu-14.04/CHANGELOG
+++ b/templates/ubuntu-14.04/CHANGELOG
@@ -1,3 +1,8 @@
+### 1.0.3
+
+* Bump version for Puppet and PE
+* Ubuntu package updates to address security vulnerabilities
+
 ### 1.0.2
 
 * Switch to puppet-agent packaging

--- a/templates/ubuntu-14.04/i386.virtualbox.base.json
+++ b/templates/ubuntu-14.04/i386.virtualbox.base.json
@@ -5,9 +5,9 @@
       "template_name": "ubuntu-14.04-i386",
       "template_os": "Ubuntu",
 
-      "iso_url": "http://releases.ubuntu.com/trusty/ubuntu-14.04.2-server-i386.iso",
-      "iso_checksum": "6478187442f331631b65f886cdd229ce",
-      "iso_checksum_type": "md5",
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/ubuntu-14.04.4-server-i386.iso",
+      "iso_checksum": "e20cf9e0812b52287ca22ac1815bc933c0cfef2be88191110b697d8943bef19e",
+      "iso_checksum_type": "sha256",
 
       "memory_size": "512",
       "cpu_count": "1",

--- a/templates/ubuntu-14.04/i386.vmware.base.json
+++ b/templates/ubuntu-14.04/i386.vmware.base.json
@@ -5,9 +5,9 @@
       "template_name": "ubuntu-14.04-i386",
       "template_os": "ubuntu",
 
-      "iso_url": "http://releases.ubuntu.com/trusty/ubuntu-14.04.2-server-i386.iso",
-      "iso_checksum": "6478187442f331631b65f886cdd229ce",
-      "iso_checksum_type": "md5",
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/ubuntu-14.04.4-server-i386.iso",
+      "iso_checksum": "e20cf9e0812b52287ca22ac1815bc933c0cfef2be88191110b697d8943bef19e",
+      "iso_checksum_type": "sha256", 
 
       "memory_size": "512",
       "cpu_count": "1",
@@ -42,7 +42,7 @@
         "-- <wait>",
         "<enter>"
       ],
-      "boot_wait": "10s",
+      "boot_wait": "45s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
       "http_directory": "files",

--- a/templates/ubuntu-14.04/vagrantcloud.yaml
+++ b/templates/ubuntu-14.04/vagrantcloud.yaml
@@ -1,7 +1,7 @@
 ---
 name: 'ubuntu-14.04'
 description: 'Ubuntu 14.04 (trusty)'
-version: '1.0.2'
+version: '1.0.3'
 
 arches:
   - name: '32'
@@ -13,6 +13,6 @@ configs:
   - name: 'nocm'
     description: 'no configuration management software'
   - name: 'puppet'
-    description: 'Puppet 4.2.1'
+    description: 'Puppet 4.3.2'
   - name: 'puppet-enterprise'
-    description: 'Puppet Enterprise 3.8.1 (agent-only)'
+    description: 'Puppet Enterprise 3.8.4 (agent-only)'

--- a/templates/ubuntu-14.04/x86_64.virtualbox.base.json
+++ b/templates/ubuntu-14.04/x86_64.virtualbox.base.json
@@ -5,9 +5,9 @@
       "template_name": "ubuntu-14.04-x86_64",
       "template_os": "Ubuntu_64",
 
-      "iso_url": "http://releases.ubuntu.com/14.04/ubuntu-14.04.2-server-amd64.iso",
-      "iso_checksum": "83aabd8dcf1e8f469f3c72fff2375195",
-      "iso_checksum_type": "md5",
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/ubuntu-14.04.4-server-amd64.iso",
+      "iso_checksum": "07e4bb5569814eab41fafac882ba127893e3ff0bdb7ec931c9b2d040e3e94e7a",
+      "iso_checksum_type": "sha256",
 
       "memory_size": "512",
       "cpu_count": "1",

--- a/templates/ubuntu-14.04/x86_64.vmware.base.json
+++ b/templates/ubuntu-14.04/x86_64.vmware.base.json
@@ -5,9 +5,9 @@
       "template_name": "ubuntu-14.04-x86_64",
       "template_os": "ubuntu-64",
 
-      "iso_url": "http://releases.ubuntu.com/14.04/ubuntu-14.04.2-server-amd64.iso",
-      "iso_checksum": "83aabd8dcf1e8f469f3c72fff2375195",
-      "iso_checksum_type": "md5",
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/ubuntu-14.04.4-server-amd64.iso",
+      "iso_checksum": "07e4bb5569814eab41fafac882ba127893e3ff0bdb7ec931c9b2d040e3e94e7a",
+      "iso_checksum_type": "sha256",      
 
       "memory_size": "512",
       "cpu_count": "1",
@@ -42,7 +42,7 @@
         "-- <wait>",
         "<enter>"
       ],
-      "boot_wait": "10s",
+      "boot_wait": "45s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
       "http_directory": "files",


### PR DESCRIPTION
These commits bump the version of most of our publicly hosted Debian, CentOS, and Ubuntu vagrant boxes on Atlas.  The boxes get an updated version of puppet, an updated version of the PE 3.8 agent-only install, as well as OS updates to address recent security vulnerabilities.  The automation used to release boxes on Atlas has also been updated -- vmware_fusion should not be specified as a provider and vmware_desktop should be used instead.