### PR TITLE
(maint) trusty fixups

### DIFF
--- a/templates/ubuntu-14.04/files/preseed.cfg
+++ b/templates/ubuntu-14.04/files/preseed.cfg
@@ -28,6 +28,5 @@ d-i pkgsel/upgrade select full-upgrade
 d-i time/zone string US/Pacific
 tasksel tasksel/first multiselect standard, ubuntu-server
 d-i preseed/late_command string \
-in-target sed -i 's/PermitRootLogin.*/PermitRootLogin yes/g' /etc/ssh/sshd_config ; \
-in-target apt-get -y upgrade
+in-target sed -i 's/PermitRootLogin.*/PermitRootLogin yes/g' /etc/ssh/sshd_config
 

--- a/templates/ubuntu-14.04/i386.virtualbox.base.json
+++ b/templates/ubuntu-14.04/i386.virtualbox.base.json
@@ -5,8 +5,8 @@
       "template_name": "ubuntu-14.04-i386",
       "template_os": "Ubuntu",
 
-      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/ubuntu-14.04.4-server-i386.iso",
-      "iso_checksum": "e20cf9e0812b52287ca22ac1815bc933c0cfef2be88191110b697d8943bef19e",
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/ubuntu-14.04.2-server-i386.iso",
+      "iso_checksum": "76524ab9502a34b983ed56af2d5a72835ce41aec1e2b4c0cb7788ef596958ed6",
       "iso_checksum_type": "sha256",
 
       "memory_size": "512",

--- a/templates/ubuntu-14.04/i386.vmware.base.json
+++ b/templates/ubuntu-14.04/i386.vmware.base.json
@@ -5,8 +5,8 @@
       "template_name": "ubuntu-14.04-i386",
       "template_os": "ubuntu",
 
-      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/ubuntu-14.04.4-server-i386.iso",
-      "iso_checksum": "e20cf9e0812b52287ca22ac1815bc933c0cfef2be88191110b697d8943bef19e",
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/ubuntu-14.04.2-server-i386.iso",
+      "iso_checksum": "76524ab9502a34b983ed56af2d5a72835ce41aec1e2b4c0cb7788ef596958ed6",
       "iso_checksum_type": "sha256", 
 
       "memory_size": "512",

--- a/templates/ubuntu-14.04/x86_64.virtualbox.base.json
+++ b/templates/ubuntu-14.04/x86_64.virtualbox.base.json
@@ -5,8 +5,8 @@
       "template_name": "ubuntu-14.04-x86_64",
       "template_os": "Ubuntu_64",
 
-      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/ubuntu-14.04.4-server-amd64.iso",
-      "iso_checksum": "07e4bb5569814eab41fafac882ba127893e3ff0bdb7ec931c9b2d040e3e94e7a",
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/ubuntu-14.04.2-server-amd64.iso",
+      "iso_checksum": "8acd2f56bfcba2f7ac74a7e4a5e565ce68c024c38525c0285573e41c86ae90c0",
       "iso_checksum_type": "sha256",
 
       "memory_size": "512",

--- a/templates/ubuntu-14.04/x86_64.vmware.base.json
+++ b/templates/ubuntu-14.04/x86_64.vmware.base.json
@@ -5,8 +5,8 @@
       "template_name": "ubuntu-14.04-x86_64",
       "template_os": "ubuntu-64",
 
-      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/ubuntu-14.04.4-server-amd64.iso",
-      "iso_checksum": "07e4bb5569814eab41fafac882ba127893e3ff0bdb7ec931c9b2d040e3e94e7a",
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/ubuntu-14.04.2-server-amd64.iso",
+      "iso_checksum": "8acd2f56bfcba2f7ac74a7e4a5e565ce68c024c38525c0285573e41c86ae90c0",
       "iso_checksum_type": "sha256",      
 
       "memory_size": "512",


### PR DESCRIPTION
trusty was unintentionally bumped a point release during the previous
box update commits.  this reverts back to the original point release
and updates the preseed to prevent it being upgraded to the latest point.