### PR TITLE
(maint) bump the xenial daily build sha

### DIFF
--- a/manifests/modules/packer/manifests/vsphere/networking.pp
+++ b/manifests/modules/packer/manifests/vsphere/networking.pp
@@ -1,16 +1,17 @@
 class packer::vsphere::networking inherits packer::networking::params {
 
   class { 'network':
-      config_file_notify => '',
+    config_file_notify => '',
   }
 
   case $::osfamily {
     debian: {
       if $::operatingsystemrelease in ['15.10', '16.04'] {
-        debnet::iface::loopback { 'lo': }
-        debnet::iface::dhcp { 'ens32': }
+        network::interface { 'ens32':
+          enable_dhcp   => true,
       }
     }
+  }
 
     redhat: {
       if ($::operatingsystem == 'Scientific') and ($::operatingsystemmajrelease == '7') {

--- a/templates/debian-6.0.10/i386.vsphere.nocm.json
+++ b/templates/debian-6.0.10/i386.vsphere.nocm.json
@@ -6,7 +6,7 @@
       "version": "0.0.3",
 
       "provisioner": "vmware",
-      "required_modules": "puppetlabs-stdlib trepasi-debnet puppetlabs-apt",
+      "required_modules": "puppetlabs-stdlib example42-network puppetlabs-apt",
       "puppet_nfs": "{{env `PUPPET_NFS`}}",
       "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
       "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",

--- a/templates/debian-6.0.10/x86_64.vsphere.nocm.json
+++ b/templates/debian-6.0.10/x86_64.vsphere.nocm.json
@@ -6,7 +6,7 @@
       "version": "0.0.3",
 
       "provisioner": "vmware",
-      "required_modules": "puppetlabs-stdlib trepasi-debnet puppetlabs-apt",
+      "required_modules": "puppetlabs-stdlib example42-network puppetlabs-apt",
       "puppet_nfs": "{{env `PUPPET_NFS`}}",
       "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
       "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",

--- a/templates/debian-7.8/i386.vsphere.nocm.json
+++ b/templates/debian-7.8/i386.vsphere.nocm.json
@@ -6,7 +6,7 @@
       "version": "0.0.2",
 
       "provisioner": "vmware",
-      "required_modules": "puppetlabs-stdlib trepasi-debnet puppetlabs-apt",
+      "required_modules": "puppetlabs-stdlib example42-network puppetlabs-apt",
       "puppet_nfs": "{{env `PUPPET_NFS`}}",
       "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
       "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",

--- a/templates/debian-7.8/x86_64.vsphere.nocm.json
+++ b/templates/debian-7.8/x86_64.vsphere.nocm.json
@@ -6,7 +6,7 @@
       "version": "0.0.2",
 
       "provisioner": "vmware",
-      "required_modules": "puppetlabs-stdlib trepasi-debnet puppetlabs-apt",
+      "required_modules": "puppetlabs-stdlib example42-network puppetlabs-apt",
       "puppet_nfs": "{{env `PUPPET_NFS`}}",
       "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
       "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",

--- a/templates/debian-8.0/i386.vsphere.nocm.json
+++ b/templates/debian-8.0/i386.vsphere.nocm.json
@@ -6,7 +6,7 @@
       "version": "0.0.1",
 
       "provisioner": "vmware",
-      "required_modules": "puppetlabs-stdlib trepasi-debnet puppetlabs-apt",
+      "required_modules": "puppetlabs-stdlib example42-network puppetlabs-apt",
       "puppet_nfs": "{{env `PUPPET_NFS`}}",
       "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
       "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",

--- a/templates/debian-8.0/x86_64.vsphere.nocm.json
+++ b/templates/debian-8.0/x86_64.vsphere.nocm.json
@@ -6,7 +6,7 @@
       "version": "0.0.1",
 
       "provisioner": "vmware",
-      "required_modules": "puppetlabs-stdlib trepasi-debnet puppetlabs-apt",
+      "required_modules": "puppetlabs-stdlib example42-network puppetlabs-apt",
       "puppet_nfs": "{{env `PUPPET_NFS`}}",
       "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
       "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",

--- a/templates/debian-8.2/i386.vsphere.nocm.json
+++ b/templates/debian-8.2/i386.vsphere.nocm.json
@@ -6,7 +6,7 @@
       "version": "0.0.2",
 
       "provisioner": "vmware",
-      "required_modules": "puppetlabs-stdlib trepasi-debnet puppetlabs-apt",
+      "required_modules": "puppetlabs-stdlib example42-network puppetlabs-apt",
       "puppet_nfs": "{{env `PUPPET_NFS`}}",
       "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
       "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",

--- a/templates/debian-8.2/x86_64.vsphere.nocm.json
+++ b/templates/debian-8.2/x86_64.vsphere.nocm.json
@@ -6,7 +6,7 @@
       "version": "0.0.2",
 
       "provisioner": "vmware",
-      "required_modules": "puppetlabs-stdlib trepasi-debnet puppetlabs-apt",
+      "required_modules": "puppetlabs-stdlib example42-network puppetlabs-apt",
       "puppet_nfs": "{{env `PUPPET_NFS`}}",
       "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
       "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",

--- a/templates/ubuntu-12.04/i386.vsphere.nocm.json
+++ b/templates/ubuntu-12.04/i386.vsphere.nocm.json
@@ -6,7 +6,7 @@
       "version": "0.0.2",
 
       "provisioner": "vmware",
-      "required_modules": "puppetlabs-stdlib trepasi-debnet puppetlabs-apt",
+      "required_modules": "puppetlabs-stdlib example42-network puppetlabs-apt",
       "puppet_nfs": "{{env `PUPPET_NFS`}}",
       "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
       "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",

--- a/templates/ubuntu-12.04/x86_64.vsphere.nocm.json
+++ b/templates/ubuntu-12.04/x86_64.vsphere.nocm.json
@@ -6,7 +6,7 @@
       "version": "0.0.2",
 
       "provisioner": "vmware",
-      "required_modules": "puppetlabs-stdlib trepasi-debnet puppetlabs-apt",
+      "required_modules": "puppetlabs-stdlib example42-network puppetlabs-apt",
       "puppet_nfs": "{{env `PUPPET_NFS`}}",
       "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
       "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",

--- a/templates/ubuntu-14.04/i386.vsphere.nocm.json
+++ b/templates/ubuntu-14.04/i386.vsphere.nocm.json
@@ -6,7 +6,7 @@
       "version": "0.0.2",
 
       "provisioner": "vmware",
-      "required_modules": "puppetlabs-stdlib trepasi-debnet puppetlabs-apt",
+      "required_modules": "puppetlabs-stdlib example42-network puppetlabs-apt",
       "puppet_nfs": "{{env `PUPPET_NFS`}}",
       "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
       "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",

--- a/templates/ubuntu-14.04/x86_64.vsphere.nocm.json
+++ b/templates/ubuntu-14.04/x86_64.vsphere.nocm.json
@@ -6,7 +6,7 @@
       "version": "0.0.2",
 
       "provisioner": "vmware",
-      "required_modules": "puppetlabs-stdlib trepasi-debnet puppetlabs-apt",
+      "required_modules": "puppetlabs-stdlib example42-network puppetlabs-apt",
       "puppet_nfs": "{{env `PUPPET_NFS`}}",
       "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
       "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",

--- a/templates/ubuntu-15.10/i386.vsphere.nocm.json
+++ b/templates/ubuntu-15.10/i386.vsphere.nocm.json
@@ -6,7 +6,7 @@
       "version": "0.0.2",
 
       "provisioner": "vmware",
-      "required_modules": "puppetlabs-stdlib trepasi-debnet puppetlabs-apt",
+      "required_modules": "puppetlabs-stdlib example42-network puppetlabs-apt",
       "puppet_nfs": "{{env `PUPPET_NFS`}}",
       "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
       "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",

--- a/templates/ubuntu-15.10/x86_64.vsphere.nocm.json
+++ b/templates/ubuntu-15.10/x86_64.vsphere.nocm.json
@@ -6,7 +6,7 @@
       "version": "0.0.2",
 
       "provisioner": "vmware",
-      "required_modules": "puppetlabs-stdlib trepasi-debnet puppetlabs-apt",
+      "required_modules": "puppetlabs-stdlib example42-network puppetlabs-apt",
       "puppet_nfs": "{{env `PUPPET_NFS`}}",
       "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
       "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",

--- a/templates/ubuntu-16.04/i386.vmware.base.json
+++ b/templates/ubuntu-16.04/i386.vmware.base.json
@@ -3,10 +3,10 @@
   "variables":
     {
       "template_name": "ubuntu-16.04-i386",
-      "template_os": "ubuntu-64",
+      "template_os": "ubuntu",
 
-      "iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04-server-i386.iso",
-      "iso_checksum": "fa97768bdc3f198b82180d39bf0c26f021ab716f5da98094cd220771095e3394",
+      "iso_url": "http://cdimage.ubuntu.com/ubuntu-server/daily/current/xenial-server-i386.iso",
+      "iso_checksum": "c3892e5e3f634ef42c454bfbfb20fb891d2c2215a738582828aed84d9c67a7d1",
       "iso_checksum_type": "sha256",
 
       "memory_size": "512",
@@ -46,7 +46,7 @@
         " -- <wait>",
         "<enter>"
       ],
-      "boot_wait": "10s",
+      "boot_wait": "45s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
       "http_directory": "files",

--- a/templates/ubuntu-16.04/i386.vsphere.nocm.json
+++ b/templates/ubuntu-16.04/i386.vsphere.nocm.json
@@ -3,10 +3,10 @@
   "variables":
     {
       "template_name": "ubuntu-16.04-i386",
-      "version": "0.0.1",
+      "version": "0.0.2",
 
       "provisioner": "vmware",
-      "required_modules": "puppetlabs-stdlib trepasi-debnet puppetlabs-apt",
+      "required_modules": "puppetlabs-stdlib example42-network puppetlabs-apt",
       "puppet_nfs": "{{env `PUPPET_NFS`}}",
       "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
       "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",
@@ -35,6 +35,9 @@
       "ssh_port": 22,
       "ssh_wait_timeout": "10000s",
       "shutdown_command": "/sbin/halt -h -p",
+      "vmx_data": {
+        "annotation": "{{user `template_name`}}-{{user `version`}} built {{isotime}}"
+      },
       "vmx_data_post": {
         "memsize": "{{user `memory_size`}}",
         "numvcpus": "{{user `cpu_count`}}",

--- a/templates/ubuntu-16.04/x86_64.vmware.base.json
+++ b/templates/ubuntu-16.04/x86_64.vmware.base.json
@@ -6,7 +6,7 @@
       "template_os": "ubuntu-64",
 
       "iso_url": "http://cdimage.ubuntu.com/ubuntu-server/daily/current/xenial-server-amd64.iso",
-      "iso_checksum": "079763f6d613d1cc4e8facd5a2ef119f5c523b38d9c78f35a9e0d2ac64ccb7cf",
+      "iso_checksum": "d362c324b88b20e0e9015ec29df8b1d25898733dad04f529b861aaa894d9fce9",
       "iso_checksum_type": "sha256",
 
       "memory_size": "512",
@@ -46,7 +46,7 @@
         " -- <wait>",
         "<enter>"
       ],
-      "boot_wait": "10s",
+      "boot_wait": "45s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
       "http_directory": "files",

--- a/templates/ubuntu-16.04/x86_64.vsphere.nocm.json
+++ b/templates/ubuntu-16.04/x86_64.vsphere.nocm.json
@@ -3,10 +3,10 @@
   "variables":
     {
       "template_name": "ubuntu-16.04-x86_64",
-      "version": "0.0.1",
+      "version": "0.0.2",
 
       "provisioner": "vmware",
-      "required_modules": "puppetlabs-stdlib trepasi-debnet puppetlabs-apt",
+      "required_modules": "puppetlabs-stdlib example42-network puppetlabs-apt",
       "puppet_nfs": "{{env `PUPPET_NFS`}}",
       "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
       "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",
@@ -35,6 +35,9 @@
       "ssh_port": 22,
       "ssh_wait_timeout": "10000s",
       "shutdown_command": "/sbin/halt -h -p",
+      "vmx_data": {
+        "annotation": "{{user `template_name`}}-{{user `version`}} built {{isotime}}"
+      },
       "vmx_data_post": {
         "memsize": "{{user `memory_size`}}",
         "numvcpus": "{{user `cpu_count`}}",


### PR DESCRIPTION
This should address some issues were seeing with dhcpc on xenial.  Also update the module we're using for vsphere networking fixups ( so it's consistent on both debian and redhat based operating systems ).
