### PR TITLE
(maint) vsphere el7 fixups

### DIFF
--- a/manifests/modules/packer/manifests/vsphere.pp
+++ b/manifests/modules/packer/manifests/vsphere.pp
@@ -2,6 +2,7 @@ class packer::vsphere inherits packer::vsphere::params {
 
   include packer::vsphere::repos
   include packer::vsphere::networking
+  include packer::vsphere::fw
 
   user { root:
     ensure   => present,
@@ -40,5 +41,5 @@ class packer::vsphere inherits packer::vsphere::params {
     source  => 'puppet:///modules/packer/vsphere/authorized_keys',
     require => File[ '/root/.ssh' ]
   }
- 
+
 }

--- a/manifests/modules/packer/manifests/vsphere/fw.pp
+++ b/manifests/modules/packer/manifests/vsphere/fw.pp
@@ -1,0 +1,9 @@
+class packer::vsphere::fw {
+
+  if ($::osfamily == 'RedHat')
+  and ($::operatingsystemmajrelease == '7') {
+    class { 'firewall':
+      ensure => stopped,
+    }
+  }
+}

--- a/manifests/modules/packer/manifests/vsphere/networking.pp
+++ b/manifests/modules/packer/manifests/vsphere/networking.pp
@@ -14,7 +14,7 @@ class packer::vsphere::networking inherits packer::networking::params {
   }
 
     redhat: {
-      if ($::operatingsystem == 'Scientific') and ($::operatingsystemmajrelease == '7') {
+      if ($::operatingsystemmajrelease == '7') {
         if ( $interface_script != undef ) {
           file { $interface_script:
             ensure => absent,

--- a/templates/centos-7.2/x86_64.vsphere.nocm.json
+++ b/templates/centos-7.2/x86_64.vsphere.nocm.json
@@ -3,10 +3,10 @@
   "variables":
     {
       "template_name": "centos-7.2-x86_64",
-      "version": "0.0.1",
+      "version": "0.0.2",
 
       "provisioner": "vmware",
-      "required_modules": "puppetlabs-stdlib",
+      "required_modules": "puppetlabs-stdlib example42-network puppetlabs-firewall",
       "puppet_nfs": "{{env `PUPPET_NFS`}}",
       "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
       "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",
@@ -35,6 +35,9 @@
       "ssh_port": 22,
       "ssh_wait_timeout": "10000s",
       "shutdown_command": "/sbin/halt -h -p",
+      "vmx_data": {
+        "annotation": "{{user `template_name`}} built {{isotime}}"
+      },
       "vmx_data_post": {
         "memsize": "{{user `memory_size`}}",
         "numvcpus": "{{user `cpu_count`}}",

--- a/templates/scientific-7.2/x86_64.vsphere.nocm.json
+++ b/templates/scientific-7.2/x86_64.vsphere.nocm.json
@@ -3,10 +3,10 @@
   "variables":
     {
       "template_name": "scientific-7.2-x86_64",
-      "version": "0.0.1",
+      "version": "0.0.2",
 
       "provisioner": "vmware",
-      "required_modules": "puppetlabs-stdlib example42-network",
+      "required_modules": "puppetlabs-stdlib example42-network puppetlabs-firewall",
       "puppet_nfs": "{{env `PUPPET_NFS`}}",
       "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
       "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",


### PR DESCRIPTION
This commit disables the firewall for vsphere/vmpooler el7 artifacts and
extends the networking fixups to all of el7.