### PR TITLE
(RE-6581) Update Ubuntu 16.04 to Release

### DIFF
--- a/templates/ubuntu-16.04/files/preseed.cfg
+++ b/templates/ubuntu-16.04/files/preseed.cfg
@@ -28,6 +28,8 @@ d-i pkgsel/upgrade select full-upgrade
 d-i time/zone string US/Pacific
 tasksel tasksel/first multiselect standard, ubuntu-server
 d-i preseed/late_command string \
+sed -i 's/\(GRUB_CMDLINE_LINUX_DEFAULT=\).*/\1\"\"/g' /target/etc/default/grub; \
+in-target bash -c 'update-grub2'; \
 in-target sed -i 's/PermitRootLogin.*/PermitRootLogin yes/g' /etc/ssh/sshd_config ; \
 in-target apt-get -y upgrade
 

--- a/templates/ubuntu-16.04/i386.vmware.base.json
+++ b/templates/ubuntu-16.04/i386.vmware.base.json
@@ -5,8 +5,8 @@
       "template_name": "ubuntu-16.04-i386",
       "template_os": "ubuntu",
 
-      "iso_url": "http://cdimage.ubuntu.com/ubuntu-server/daily/current/xenial-server-i386.iso",
-      "iso_checksum": "c3892e5e3f634ef42c454bfbfb20fb891d2c2215a738582828aed84d9c67a7d1",
+      "iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04-server-i386.iso",
+      "iso_checksum": "8d52f3127f2b7ffa97698913b722e3219187476a9b936055d737f3e00aecd24d",
       "iso_checksum_type": "sha256",
 
       "memory_size": "512",
@@ -50,6 +50,7 @@
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
       "http_directory": "files",
+      "headless": true,
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `iso_url`}}",

--- a/templates/ubuntu-16.04/i386.vsphere.nocm.json
+++ b/templates/ubuntu-16.04/i386.vsphere.nocm.json
@@ -3,7 +3,7 @@
   "variables":
     {
       "template_name": "ubuntu-16.04-i386",
-      "version": "0.0.2",
+      "version": "0.0.3",
 
       "provisioner": "vmware",
       "required_modules": "puppetlabs-stdlib example42-network puppetlabs-apt",
@@ -29,6 +29,7 @@
       "name": "{{user `template_name`}}-{{user `provisioner`}}-vsphere-nocm",
       "vm_name": "packer-{{build_name}}",
       "type": "vmware-vmx",
+      "headless": true,
       "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
       "ssh_username": "root",
       "ssh_password": "puppet",

--- a/templates/ubuntu-16.04/x86_64.vmware.base.json
+++ b/templates/ubuntu-16.04/x86_64.vmware.base.json
@@ -5,8 +5,8 @@
       "template_name": "ubuntu-16.04-x86_64",
       "template_os": "ubuntu-64",
 
-      "iso_url": "http://cdimage.ubuntu.com/ubuntu-server/daily/current/xenial-server-amd64.iso",
-      "iso_checksum": "d362c324b88b20e0e9015ec29df8b1d25898733dad04f529b861aaa894d9fce9",
+      "iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04-server-amd64.iso",
+      "iso_checksum": "b8b172cbdf04f5ff8adc8c2c1b4007ccf66f00fc6a324a6da6eba67de71746f6",
       "iso_checksum_type": "sha256",
 
       "memory_size": "512",
@@ -50,6 +50,7 @@
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
       "http_directory": "files",
+      "headless": true,
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `iso_url`}}",

--- a/templates/ubuntu-16.04/x86_64.vsphere.nocm.json
+++ b/templates/ubuntu-16.04/x86_64.vsphere.nocm.json
@@ -3,7 +3,7 @@
   "variables":
     {
       "template_name": "ubuntu-16.04-x86_64",
-      "version": "0.0.2",
+      "version": "0.0.3",
 
       "provisioner": "vmware",
       "required_modules": "puppetlabs-stdlib example42-network puppetlabs-apt",
@@ -29,6 +29,7 @@
       "name": "{{user `template_name`}}-{{user `provisioner`}}-vsphere-nocm",
       "vm_name": "packer-{{build_name}}",
       "type": "vmware-vmx",
+      "headless": true,
       "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
       "ssh_username": "root",
       "ssh_password": "puppet",


### PR DESCRIPTION
Prior images were based on nightly builds.  This is now the official release version. \o/
Also there was an issue with GRUB_CMDLINE_LINUX_DEFAULT="quiet" preventing tty1 coming up on boot - fixed that per: https://bugs.launchpad.net/ubuntu/+source/grub-installer/+bug/581796
Lastly set templates to headless.  The builders are choking on gui and the ability to just monitor over VNC is way better.