### PR TITLE
(MAINT) Ignore drivers directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ packer_cache
 output-*
 *.bak
 hiera/*
+drivers/


### PR DESCRIPTION
This directory will go away shortly, but ignore to avoid clutter or
dodgy checkins.