### PR TITLE
(RE-7330) Update Fedora 24 Gold RC + Use AIO to provision

### DIFF
--- a/manifests/modules/packer/files/vsphere/dhclient.conf
+++ b/manifests/modules/packer/files/vsphere/dhclient.conf
@@ -1,0 +1,1 @@
+send host-name = pick-first-value(gethostname(), "ISC-dhclient");

--- a/manifests/modules/packer/manifests/networking/params.pp
+++ b/manifests/modules/packer/manifests/networking/params.pp
@@ -23,7 +23,7 @@ class packer::networking::params {
           $udev_rule        = '/etc/udev/rules.d/70-persistent-net.rules'
         }
 
-        '21', '22', '23': {
+        /2\d/: {
           case $::provisioner {
             'virtualbox': { $interface_script = '/etc/sysconfig/network-scripts/ifcfg-enp0s3' }
             'vmware':     { $interface_script = '/etc/sysconfig/network-scripts/ifcfg-ens33' }

--- a/manifests/modules/packer/manifests/vsphere.pp
+++ b/manifests/modules/packer/manifests/vsphere.pp
@@ -9,6 +9,23 @@ class packer::vsphere inherits packer::vsphere::params {
     password => "$qa_root_passwd"
   }
 
+  case $::osfamily {
+    redhat: {
+      if $::operatingsystemrelease in ['24', '25'] {
+        Package {
+          provider => 'dnf',
+        }
+
+        file { '/etc/dhclient.conf':
+          owner   => 'root',
+          group   => 'root',
+          mode    => '0644',
+          source  => 'puppet:///modules/packer/vsphere/dhclient.conf',
+        }
+      }
+    }
+  }
+
   package { $ruby_package:
     ensure => present,
   }

--- a/manifests/modules/packer/manifests/vsphere/networking.pp
+++ b/manifests/modules/packer/manifests/vsphere/networking.pp
@@ -24,6 +24,13 @@ class packer::vsphere::networking inherits packer::networking::params {
           enable_dhcp   => true,
         }
       }
+      if ($::operatingsystem == 'Fedora') {
+        if ( $interface_script != undef ) {
+          file { $interface_script:
+            ensure => absent,
+          }
+        }
+      }
     }
   }
 }

--- a/manifests/modules/packer/manifests/vsphere/params.pp
+++ b/manifests/modules/packer/manifests/vsphere/params.pp
@@ -44,7 +44,7 @@ class packer::vsphere::params {
       $startup_file_source   = 'rc.local'
       $bootstrap_file        = '/etc/vsphere-bootstrap.rb'
       $bootstrap_file_source = 'redhat.rb.erb'
-      $ruby_package          = [ 'ruby' ]
+      $ruby_package          = [ 'ruby', 'rubygems' ]
       $gpgkey                = "RPM-GPG-KEY-${::operatingsystemmajrelease}-${loweros}"
     }
 

--- a/manifests/modules/packer/templates/vsphere/redhat.rb.erb
+++ b/manifests/modules/packer/templates/vsphere/redhat.rb.erb
@@ -47,12 +47,7 @@ puts '- Re-obtaining DHCP lease...'
 <% end -%>
 
 <% if @operatingsystem == 'Fedora' -%>
-  File.open('/var/lib/NetworkManager/dhclient-ens32.conf', 'a') do |f|
-    f << "send host-name #{hostname}"
-  end
   Kernel.system('/sbin/service NetworkManager restart')
-  Kernel.system('/usr/bin/nmcli con down id ens32')
-  Kernel.system('/usr/bin/nmcli con up id ens32')
 <% end -%>
 
 puts '- Cleaning up...'

--- a/scripts/bootstrap-aio.sh
+++ b/scripts/bootstrap-aio.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+if [[ ${TEMPLATE} == "fedora-22"* ]]; then
+  echo "Updating rpcbind..."
+  dnf -y upgrade rpcbind
+  systemctl enable rpcbind.socket
+  systemctl restart rpcbind.service
+fi
+
+# Create mount point and required directories
+mkdir -p /opt/puppetlabs
+mkdir /var/cache/puppet
+
+if [ -n "${PUPPET_NFS}" ]; then
+  # Mount NFS share if PUPPET_NFS set
+  echo "Mounting AIO via NFS..."
+  mount -o ro -t nfs "${PUPPET_NFS}/${TEMPLATE}/opt/puppetlabs" /opt/puppetlabs
+else
+  echo "The environment variables PUPPET_NFS must be provided to provision AIO." >&2
+  exit 1
+fi
+
+# Show Puppet version
+printf 'Puppet ' ; /opt/puppetlabs/puppet/bin/puppet --version
+
+# Installed required modules
+for i in "$@"
+do
+  /opt/puppetlabs/puppet/bin/puppet module install $i --modulepath=/tmp/packer-puppet-masterless/manifests/modules --vardir='/var/cache/puppet' >/dev/null 2>&1
+done
+
+printf 'Modules installed in ' ; /opt/puppetlabs/puppet/bin/puppet module list --modulepath=/tmp/packer-puppet-masterless/manifests/modules

--- a/scripts/bootstrap-aio.sh
+++ b/scripts/bootstrap-aio.sh
@@ -1,22 +1,44 @@
 #!/bin/bash
 
-if [[ ${TEMPLATE} == "fedora-22"* ]]; then
-  echo "Updating rpcbind..."
-  dnf -y upgrade rpcbind
-  systemctl enable rpcbind.socket
-  systemctl restart rpcbind.service
-fi
+tmp_dir="/tmp/packer-puppet-masterless"
+mkdir -p "$tmp_dir"
+# Download and install puppet-agent
 
-# Create mount point and required directories
-mkdir -p /opt/puppetlabs
-mkdir /var/cache/puppet
-
-if [ -n "${PUPPET_NFS}" ]; then
-  # Mount NFS share if PUPPET_NFS set
-  echo "Mounting AIO via NFS..."
-  mount -o ro -t nfs "${PUPPET_NFS}/${TEMPLATE}/opt/puppetlabs" /opt/puppetlabs
+if [ -n "${PC_REPO}" ]; then
+  echo "Downloading and installing AIO from repo..."
+  # Determin if this is RPM or DEB and Do the Right Thing (tm)
+  if [[ ${PC_REPO} == *".rpm"* ]] ; then
+    curl --silent "${PC_REPO}" -o $tmp_dir/pc-repo.rpm
+    rpm -Uhv $tmp_dir/pc-repo.rpm
+    if type dnf >/dev/null ; then
+      dnf install -y puppet-agent
+    else
+      yum install -y puppet-agent
+    fi
+  elif [[ ${PC_REPO} == *".deb"* ]] ; then
+    curl --silent "${PC_REPO}" -o $tmp_dir/pc-repo.deb
+    dpkg -i $tmp_dir/pc-repo.deb
+    apt-get update
+    apt-get install -y puppet-agent
+  else
+    echo "Unsupported AIO package format" >&2
+    exit 1
+  fi
+elif [ -n "${PUPPET_AIO}" ]; then
+  echo "Downloading and installing AIO..."
+  # Determin if this is RPM or DEB and Do the Right Thing (tm)
+  if [[ ${PUPPET_AIO} == *".rpm"* ]] ; then
+    curl --silent "${PUPPET_AIO}" -o $tmp_dir/puppet-agent.rpm
+    rpm -Uhv $tmp_dir/puppet-agent.rpm
+  elif [[ ${PUPPET_AIO} == *".deb"* ]] ; then
+    curl --silent "${PUPPET_AIO}" -o $tmp_dir/puppet-agent.deb
+    dpkg -i $tmp_dir/puppet-agent.deb
+  else
+    echo "Unsupported AIO package format" >&2
+    exit 1
+  fi
 else
-  echo "The environment variables PUPPET_NFS must be provided to provision AIO." >&2
+  echo "The environment variables PC_REPO or PUPPET_AIO must be provided to provision AIO." >&2
   exit 1
 fi
 
@@ -26,7 +48,7 @@ printf 'Puppet ' ; /opt/puppetlabs/puppet/bin/puppet --version
 # Installed required modules
 for i in "$@"
 do
-  /opt/puppetlabs/puppet/bin/puppet module install $i --modulepath=/tmp/packer-puppet-masterless/manifests/modules --vardir='/var/cache/puppet' >/dev/null 2>&1
+  /opt/puppetlabs/puppet/bin/puppet module install $i --modulepath=/tmp/packer-puppet-masterless/manifests/modules >/dev/null 2>&1
 done
 
 printf 'Modules installed in ' ; /opt/puppetlabs/puppet/bin/puppet module list --modulepath=/tmp/packer-puppet-masterless/manifests/modules

--- a/scripts/bootstrap-puppet.sh
+++ b/scripts/bootstrap-puppet.sh
@@ -36,7 +36,8 @@ do
   /opt/puppet/bin/puppet module install $i --modulepath=/tmp/packer-puppet-masterless/manifests/modules >/dev/null 2>&1
 done
 
-if [[ ${TEMPLATE} == "fedora-23"* ]]; then
+# Any supported Fedora now needs this
+if [[ ${TEMPLATE} == "fedora-2"* ]]; then
   dnf -y install git
   git clone https://github.com/nibalizer/puppet-dnf /tmp/packer-puppet-masterless/manifests/modules/puppet-dnf
   dnf -y remove git

--- a/scripts/cleanup-aio.sh
+++ b/scripts/cleanup-aio.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# AIO puppet-agent is currently used to provision nocm and puppet boxes.
+# This script cleans up directories that may be left around
+# as part of that process.
+
+# Unmount NFS share if PUPPET_NFS provided
+if [ -n "${PUPPET_NFS}" ]; then
+  umount -l /opt/puppetlabs
+fi
+
+# Remove other Puppet-related files and directories
+rm -rf /opt/puppetlabs
+rm -rf /var/cache/puppet

--- a/scripts/cleanup-aio.sh
+++ b/scripts/cleanup-aio.sh
@@ -4,11 +4,15 @@
 # This script cleans up directories that may be left around
 # as part of that process.
 
-# Unmount NFS share if PUPPET_NFS provided
-if [ -n "${PUPPET_NFS}" ]; then
-  umount -l /opt/puppetlabs
+# Uninstall the AIO
+if [[ ${PUPPET_AIO} == *".rpm"* ]] ; then
+  rpm -e puppet-agent
+elif [[ ${PUPPET_AIO} == *".deb"* ]] ; then
+  dpkg -P puppet-agent
+else
+  echo "Unsupported AIO package format" >&2
+  exit 1
 fi
-
-# Remove other Puppet-related files and directories
+# Remove any Puppet-related files and directories
+rm -rf /etc/puppetlabs
 rm -rf /opt/puppetlabs
-rm -rf /var/cache/puppet

--- a/templates/fedora-24/files/ks.cfg
+++ b/templates/fedora-24/files/ks.cfg
@@ -1,0 +1,35 @@
+install
+cdrom
+lang en_US.UTF-8
+keyboard us
+network --bootproto=dhcp
+rootpw puppet
+firewall --disabled
+authconfig --enableshadow --passalgo=sha512
+selinux --disabled
+timezone UTC
+bootloader --location=mbr
+text
+skipx
+zerombr
+clearpart --all --initlabel
+autopart
+auth  --useshadow  --enablemd5
+firstboot --disabled
+reboot
+
+%packages --ignoremissing
+bzip2
+kernel-devel
+kernel-headers
+tar
+wget
+nfs-utils
+net-tools
+-linux-firmware
+-plymouth
+-plymouth-core-libs
+%end
+
+%post
+%end

--- a/templates/fedora-24/i386.vmware.base.json
+++ b/templates/fedora-24/i386.vmware.base.json
@@ -14,7 +14,7 @@
 
       "provisioner": "vmware",
       "required_modules": "puppetlabs-stdlib saz-ssh",
-      "puppet_nfs": "{{env `PUPPET_NFS`}}"
+      "puppet_aio": "http://yum.puppetlabs.com/fedora/f23/PC1/i386/puppet-agent-1.5.2-1.fedoraf23.i386.rpm"
     },
 
   "builders": [
@@ -57,7 +57,7 @@
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
-        "PUPPET_NFS={{user `puppet_nfs`}}"
+        "PUPPET_AIO={{user `puppet_aio`}}"
       ],
       "scripts": [
         "../../scripts/bootstrap-aio.sh"
@@ -66,7 +66,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppetlabs/bin /opt/puppetlabs/puppet/bin/puppet apply --verbose --detailed-exitcodes --vardir='/var/cache/puppet' --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppetlabs/bin /opt/puppetlabs/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },
@@ -79,7 +79,7 @@
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
-        "PUPPET_NFS={{user `puppet_nfs`}}"
+        "PUPPET_AIO={{user `puppet_aio`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-aio.sh",

--- a/templates/fedora-24/i386.vmware.base.json
+++ b/templates/fedora-24/i386.vmware.base.json
@@ -5,8 +5,8 @@
       "template_name": "fedora-24-i386",
       "template_os": "fedora",
 
-      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/Fedora-Server-dvd-i386-24_Beta-1.6.iso",
-      "iso_checksum": "39ef9a523ccc429cbdedc8461afa2eb0019abd068d5090d4e8a830b771149da4",
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/Fedora-Server-dvd-i386-24-1.2.iso",
+      "iso_checksum": "93c0bfe6e6bf23ca22cc1a85636ed15834336ee40a57bfe374f0044ad2d864b0",
       "iso_checksum_type": "sha256",
 
       "memory_size": "512",
@@ -21,13 +21,16 @@
     {
       "name": "{{user `template_name`}}-{{user `provisioner`}}",
       "type": "vmware-iso",
+      "headless": true,
       "boot_command": [
         "<tab> <wait>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "quiet <wait>",
         "text <wait>",
         "ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg <wait>",
         "<enter>"
       ],
-      "boot_wait": "10s",
+      "boot_wait": "45s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
       "http_directory": "files",
@@ -57,13 +60,13 @@
         "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
-        "../../scripts/bootstrap-puppet.sh"
+        "../../scripts/bootstrap-aio.sh"
       ]
     },
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --parser=future --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppetlabs/bin /opt/puppetlabs/puppet/bin/puppet apply --verbose --detailed-exitcodes --vardir='/var/cache/puppet' --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },
@@ -79,7 +82,7 @@
         "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
-        "../../scripts/cleanup-puppet.sh",
+        "../../scripts/cleanup-aio.sh",
         "../../scripts/cleanup-packer.sh"
       ]
     }

--- a/templates/fedora-24/i386.vmware.base.json
+++ b/templates/fedora-24/i386.vmware.base.json
@@ -1,0 +1,88 @@
+{
+
+  "variables":
+    {
+      "template_name": "fedora-24-i386",
+      "template_os": "fedora",
+
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/Fedora-Server-dvd-i386-24_Beta-1.6.iso",
+      "iso_checksum": "39ef9a523ccc429cbdedc8461afa2eb0019abd068d5090d4e8a830b771149da4",
+      "iso_checksum_type": "sha256",
+
+      "memory_size": "512",
+      "cpu_count": "1",
+
+      "provisioner": "vmware",
+      "required_modules": "puppetlabs-stdlib saz-ssh",
+      "puppet_nfs": "{{env `PUPPET_NFS`}}"
+    },
+
+  "builders": [
+    {
+      "name": "{{user `template_name`}}-{{user `provisioner`}}",
+      "type": "vmware-iso",
+      "boot_command": [
+        "<tab> <wait>",
+        "text <wait>",
+        "ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg <wait>",
+        "<enter>"
+      ],
+      "boot_wait": "10s",
+      "disk_size": 20480,
+      "guest_os_type": "{{user `template_os`}}",
+      "http_directory": "files",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `iso_url`}}",
+      "ssh_username": "root",
+      "ssh_password": "puppet",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "/sbin/halt -h -p",
+      "tools_upload_flavor": "linux",
+      "vmx_data": {
+        "memsize": "{{user `memory_size`}}",
+        "numvcpus": "{{user `cpu_count`}}",
+        "cpuid.coresPerSocket": "1"
+      }
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type": "shell",
+      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
+      ],
+      "scripts": [
+        "../../scripts/bootstrap-puppet.sh"
+      ]
+    },
+
+    {
+      "type": "puppet-masterless",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --parser=future --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "facter": {
+        "provisioner": "{{user `provisioner`}}"
+      },
+      "manifest_dir": "../../manifests",
+      "manifest_file": "../../manifests/base.pp"
+    },
+
+    {
+      "type": "shell",
+      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
+      ],
+      "scripts": [
+        "../../scripts/cleanup-puppet.sh",
+        "../../scripts/cleanup-packer.sh"
+      ]
+    }
+  ]
+
+}

--- a/templates/fedora-24/i386.vsphere.nocm.json
+++ b/templates/fedora-24/i386.vsphere.nocm.json
@@ -6,7 +6,7 @@
       "version": "0.0.1",
 
       "provisioner": "vmware",
-      "required_modules": "puppetlabs-stdlib",
+      "required_modules": "puppetlabs-stdlib example42-network",
       "puppet_nfs": "{{env `PUPPET_NFS`}}",
       "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
       "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",
@@ -29,6 +29,7 @@
       "name": "{{user `template_name`}}-{{user `provisioner`}}-vsphere-nocm",
       "vm_name": "packer-{{build_name}}",
       "type": "vmware-vmx",
+      "headless": true,
       "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
       "ssh_username": "root",
       "ssh_password": "puppet",
@@ -38,7 +39,8 @@
       "vmx_data_post": {
         "memsize": "{{user `memory_size`}}",
         "numvcpus": "{{user `cpu_count`}}",
-        "cpuid.coresPerSocket": "1"
+        "cpuid.coresPerSocket": "1",
+        "ethernet0.virtualDev": "vmxnet3"
       }
     }
   ],
@@ -52,7 +54,7 @@
         "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
-        "../../scripts/bootstrap-puppet.sh"
+        "../../scripts/bootstrap-aio.sh"
       ]
     },
 
@@ -64,7 +66,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --parser=future --verbose --detailed-exitcodes --hiera_config='/tmp/packer-puppet-masterless/hiera/hiera.yaml' --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppetlabs/bin /opt/puppetlabs/bin/puppet apply --verbose --detailed-exitcodes --vardir='/var/cache/puppet' --hiera_config='/tmp/packer-puppet-masterless/hiera/hiera.yaml' --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}",
         "qa_root_passwd": "{{user `qa_root_passwd`}}"
@@ -80,7 +82,7 @@
         "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
-        "../../scripts/cleanup-puppet.sh",
+        "../../scripts/cleanup-aio.sh",
         "../../scripts/cleanup-packer.sh",
         "../../scripts/cleanup-scrub.sh"
       ]

--- a/templates/fedora-24/i386.vsphere.nocm.json
+++ b/templates/fedora-24/i386.vsphere.nocm.json
@@ -1,0 +1,105 @@
+{
+
+  "variables":
+    {
+      "template_name": "fedora-24-i386",
+      "version": "0.0.1",
+
+      "provisioner": "vmware",
+      "required_modules": "puppetlabs-stdlib",
+      "puppet_nfs": "{{env `PUPPET_NFS`}}",
+      "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
+      "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",
+      "packer_vcenter_username": "{{env `PACKER_VCENTER_USERNAME`}}",
+      "packer_vcenter_password": "{{env `PACKER_VCENTER_PASSWORD`}}",
+      "packer_vcenter_dc": "{{env `PACKER_VCENTER_DC`}}",
+      "packer_vcenter_cluster": "{{env `PACKER_VCENTER_CLUSTER`}}",
+      "packer_vcenter_datastore": "{{env `PACKER_VCENTER_DATASTORE`}}",
+      "packer_vcenter_folder": "{{env `PACKER_VCENTER_FOLDER`}}",
+      "packer_vcenter_net": "{{env `PACKER_VCENTER_NET`}}",
+      "packer_vcenter_insecure": "{{env `PACKER_VCENTER_INSECURE`}}",
+
+      "memory_size": "2048",
+      "cpu_count": "2"
+
+    },
+
+  "builders": [
+    {
+      "name": "{{user `template_name`}}-{{user `provisioner`}}-vsphere-nocm",
+      "vm_name": "packer-{{build_name}}",
+      "type": "vmware-vmx",
+      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
+      "ssh_username": "root",
+      "ssh_password": "puppet",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "/sbin/halt -h -p",
+      "vmx_data_post": {
+        "memsize": "{{user `memory_size`}}",
+        "numvcpus": "{{user `cpu_count`}}",
+        "cpuid.coresPerSocket": "1"
+      }
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type": "shell",
+      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
+      ],
+      "scripts": [
+        "../../scripts/bootstrap-puppet.sh"
+      ]
+    },
+
+    {
+      "type": "file",
+      "source": "../../hiera",
+      "destination": "/tmp/packer-puppet-masterless"
+    },
+
+    {
+      "type": "puppet-masterless",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --parser=future --verbose --detailed-exitcodes --hiera_config='/tmp/packer-puppet-masterless/hiera/hiera.yaml' --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "facter": {
+        "provisioner": "{{user `provisioner`}}",
+        "qa_root_passwd": "{{user `qa_root_passwd`}}"
+      },
+      "manifest_dir": "../../manifests",
+      "manifest_file": "../../manifests/vsphere/nocm.pp"
+    },
+
+    {
+      "type": "shell",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
+      ],
+      "scripts": [
+        "../../scripts/cleanup-puppet.sh",
+        "../../scripts/cleanup-packer.sh",
+        "../../scripts/cleanup-scrub.sh"
+      ]
+    }
+  ],
+
+  "post-processors": [
+    {
+      "type": "vsphere",
+      "host": "{{user `packer_vcenter_host`}}",
+      "username": "{{user `packer_vcenter_username`}}",
+      "password": "{{user `packer_vcenter_password`}}",
+      "datacenter": "{{user `packer_vcenter_dc`}}",
+      "cluster": "{{user `packer_vcenter_cluster`}}",
+      "datastore": "{{user `packer_vcenter_datastore`}}",
+      "vm_folder": "{{user `packer_vcenter_folder`}}",
+      "vm_name": "{{user `template_name`}}-{{user `version`}}",
+      "vm_network": "{{user `packer_vcenter_net`}}",
+      "insecure" : "{{user `packer_vcenter_insecure`}}"
+    }
+  ]
+}

--- a/templates/fedora-24/i386.vsphere.nocm.json
+++ b/templates/fedora-24/i386.vsphere.nocm.json
@@ -3,11 +3,11 @@
   "variables":
     {
       "template_name": "fedora-24-i386",
-      "version": "0.0.1",
+      "version": "0.0.3",
 
       "provisioner": "vmware",
       "required_modules": "puppetlabs-stdlib example42-network",
-      "puppet_nfs": "{{env `PUPPET_NFS`}}",
+      "puppet_aio": "http://yum.puppetlabs.com/fedora/f23/PC1/i386/puppet-agent-1.5.2-1.fedoraf23.i386.rpm",
       "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
       "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",
       "packer_vcenter_username": "{{env `PACKER_VCENTER_USERNAME`}}",
@@ -36,6 +36,9 @@
       "ssh_port": 22,
       "ssh_wait_timeout": "10000s",
       "shutdown_command": "/sbin/halt -h -p",
+      "vmx_data": {
+        "annotation": "{{user `template_name`}}-{{user `version`}} built {{isotime}}"
+      },
       "vmx_data_post": {
         "memsize": "{{user `memory_size`}}",
         "numvcpus": "{{user `cpu_count`}}",
@@ -51,7 +54,7 @@
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
-        "PUPPET_NFS={{user `puppet_nfs`}}"
+        "PUPPET_AIO={{user `puppet_aio`}}"
       ],
       "scripts": [
         "../../scripts/bootstrap-aio.sh"
@@ -66,7 +69,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppetlabs/bin /opt/puppetlabs/bin/puppet apply --verbose --detailed-exitcodes --vardir='/var/cache/puppet' --hiera_config='/tmp/packer-puppet-masterless/hiera/hiera.yaml' --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppetlabs/bin /opt/puppetlabs/bin/puppet apply --verbose --detailed-exitcodes --hiera_config='/tmp/packer-puppet-masterless/hiera/hiera.yaml' --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}",
         "qa_root_passwd": "{{user `qa_root_passwd`}}"
@@ -79,7 +82,7 @@
       "type": "shell",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
-        "PUPPET_NFS={{user `puppet_nfs`}}"
+        "PUPPET_AIO={{user `puppet_aio`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-aio.sh",

--- a/templates/fedora-24/x86_64.vmware.base.json
+++ b/templates/fedora-24/x86_64.vmware.base.json
@@ -5,8 +5,8 @@
       "template_name": "fedora-24-x86_64",
       "template_os": "fedora-64",
 
-      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/Fedora-Server-dvd-x86_64-24_Beta-1.6.iso",
-      "iso_checksum": "0af2aaa17f26cb03c4644f5983045e7eb969d91e7135d435568989109214edcb",
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/Fedora-Server-dvd-x86_64-24-1.2.iso",
+      "iso_checksum": "1c0971d4c1a37bb06ec603ed3ded0af79e22069499443bb2d47e501c9ef42ae8",
       "iso_checksum_type": "sha256",
 
       "memory_size": "512",
@@ -21,13 +21,16 @@
     {
       "name": "{{user `template_name`}}-{{user `provisioner`}}",
       "type": "vmware-iso",
+      "headless": true,
       "boot_command": [
         "<tab> <wait>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "quiet <wait>",
         "text <wait>",
         "ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg <wait>",
         "<enter>"
       ],
-      "boot_wait": "10s",
+      "boot_wait": "45s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
       "http_directory": "files",
@@ -57,13 +60,13 @@
         "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
-        "../../scripts/bootstrap-puppet.sh"
+        "../../scripts/bootstrap-aio.sh"
       ]
     },
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --parser=future --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppetlabs/bin /opt/puppetlabs/puppet/bin/puppet apply --verbose --detailed-exitcodes --vardir='/var/cache/puppet' --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },
@@ -79,7 +82,7 @@
         "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
-        "../../scripts/cleanup-puppet.sh",
+        "../../scripts/cleanup-aio.sh",
         "../../scripts/cleanup-packer.sh"
       ]
     }

--- a/templates/fedora-24/x86_64.vmware.base.json
+++ b/templates/fedora-24/x86_64.vmware.base.json
@@ -14,7 +14,7 @@
 
       "provisioner": "vmware",
       "required_modules": "puppetlabs-stdlib saz-ssh",
-      "puppet_nfs": "{{env `PUPPET_NFS`}}"
+      "puppet_aio": "http://yum.puppetlabs.com/fedora/f23/PC1/x86_64/puppet-agent-1.5.2-1.fedoraf23.x86_64.rpm"
     },
 
   "builders": [
@@ -57,7 +57,7 @@
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
-        "PUPPET_NFS={{user `puppet_nfs`}}"
+        "PUPPET_AIO={{user `puppet_aio`}}"
       ],
       "scripts": [
         "../../scripts/bootstrap-aio.sh"
@@ -66,7 +66,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppetlabs/bin /opt/puppetlabs/puppet/bin/puppet apply --verbose --detailed-exitcodes --vardir='/var/cache/puppet' --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppetlabs/bin /opt/puppetlabs/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },
@@ -79,7 +79,7 @@
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
-        "PUPPET_NFS={{user `puppet_nfs`}}"
+        "PUPPET_AIO={{user `puppet_aio`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-aio.sh",

--- a/templates/fedora-24/x86_64.vmware.base.json
+++ b/templates/fedora-24/x86_64.vmware.base.json
@@ -1,0 +1,88 @@
+{
+
+  "variables":
+    {
+      "template_name": "fedora-24-x86_64",
+      "template_os": "fedora-64",
+
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/Fedora-Server-dvd-x86_64-24_Beta-1.6.iso",
+      "iso_checksum": "0af2aaa17f26cb03c4644f5983045e7eb969d91e7135d435568989109214edcb",
+      "iso_checksum_type": "sha256",
+
+      "memory_size": "512",
+      "cpu_count": "1",
+
+      "provisioner": "vmware",
+      "required_modules": "puppetlabs-stdlib saz-ssh",
+      "puppet_nfs": "{{env `PUPPET_NFS`}}"
+    },
+
+  "builders": [
+    {
+      "name": "{{user `template_name`}}-{{user `provisioner`}}",
+      "type": "vmware-iso",
+      "boot_command": [
+        "<tab> <wait>",
+        "text <wait>",
+        "ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg <wait>",
+        "<enter>"
+      ],
+      "boot_wait": "10s",
+      "disk_size": 20480,
+      "guest_os_type": "{{user `template_os`}}",
+      "http_directory": "files",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `iso_url`}}",
+      "ssh_username": "root",
+      "ssh_password": "puppet",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "/sbin/halt -h -p",
+      "tools_upload_flavor": "linux",
+      "vmx_data": {
+        "memsize": "{{user `memory_size`}}",
+        "numvcpus": "{{user `cpu_count`}}",
+        "cpuid.coresPerSocket": "1"
+      }
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type": "shell",
+      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
+      ],
+      "scripts": [
+        "../../scripts/bootstrap-puppet.sh"
+      ]
+    },
+
+    {
+      "type": "puppet-masterless",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --parser=future --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "facter": {
+        "provisioner": "{{user `provisioner`}}"
+      },
+      "manifest_dir": "../../manifests",
+      "manifest_file": "../../manifests/base.pp"
+    },
+
+    {
+      "type": "shell",
+      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
+      ],
+      "scripts": [
+        "../../scripts/cleanup-puppet.sh",
+        "../../scripts/cleanup-packer.sh"
+      ]
+    }
+  ]
+
+}

--- a/templates/fedora-24/x86_64.vsphere.nocm.json
+++ b/templates/fedora-24/x86_64.vsphere.nocm.json
@@ -3,11 +3,11 @@
   "variables":
     {
       "template_name": "fedora-24-x86_64",
-      "version": "0.0.1",
+      "version": "0.0.3",
 
       "provisioner": "vmware",
       "required_modules": "puppetlabs-stdlib example42-network",
-      "puppet_nfs": "{{env `PUPPET_NFS`}}",
+      "puppet_aio": "http://yum.puppetlabs.com/fedora/f23/PC1/x86_64/puppet-agent-1.5.2-1.fedoraf23.x86_64.rpm",
       "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
       "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",
       "packer_vcenter_username": "{{env `PACKER_VCENTER_USERNAME`}}",
@@ -36,6 +36,9 @@
       "ssh_port": 22,
       "ssh_wait_timeout": "10000s",
       "shutdown_command": "/sbin/halt -h -p",
+      "vmx_data": {
+        "annotation": "{{user `template_name`}}-{{user `version`}} built {{isotime}}"
+      },
       "vmx_data_post": {
         "memsize": "{{user `memory_size`}}",
         "numvcpus": "{{user `cpu_count`}}",
@@ -51,7 +54,7 @@
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
-        "PUPPET_NFS={{user `puppet_nfs`}}"
+        "PUPPET_AIO={{user `puppet_aio`}}"
       ],
       "scripts": [
         "../../scripts/bootstrap-aio.sh"
@@ -66,7 +69,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppetlabs/bin /opt/puppetlabs/bin/puppet apply --verbose --detailed-exitcodes --vardir='/var/cache/puppet' --hiera_config='/tmp/packer-puppet-masterless/hiera/hiera.yaml' --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppetlabs/bin /opt/puppetlabs/bin/puppet apply --verbose --detailed-exitcodes --hiera_config='/tmp/packer-puppet-masterless/hiera/hiera.yaml' --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}",
         "qa_root_passwd": "{{user `qa_root_passwd`}}"
@@ -79,7 +82,7 @@
       "type": "shell",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
-        "PUPPET_NFS={{user `puppet_nfs`}}"
+        "PUPPET_AIO={{user `puppet_aio`}}"
       ],
       "scripts": [
         "../../scripts/cleanup-aio.sh",

--- a/templates/fedora-24/x86_64.vsphere.nocm.json
+++ b/templates/fedora-24/x86_64.vsphere.nocm.json
@@ -6,7 +6,7 @@
       "version": "0.0.1",
 
       "provisioner": "vmware",
-      "required_modules": "puppetlabs-stdlib",
+      "required_modules": "puppetlabs-stdlib example42-network",
       "puppet_nfs": "{{env `PUPPET_NFS`}}",
       "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
       "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",
@@ -29,6 +29,7 @@
       "name": "{{user `template_name`}}-{{user `provisioner`}}-vsphere-nocm",
       "vm_name": "packer-{{build_name}}",
       "type": "vmware-vmx",
+      "headless": true,
       "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
       "ssh_username": "root",
       "ssh_password": "puppet",
@@ -38,7 +39,8 @@
       "vmx_data_post": {
         "memsize": "{{user `memory_size`}}",
         "numvcpus": "{{user `cpu_count`}}",
-        "cpuid.coresPerSocket": "1"
+        "cpuid.coresPerSocket": "1",
+        "ethernet0.virtualDev": "vmxnet3"
       }
     }
   ],
@@ -52,7 +54,7 @@
         "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
-        "../../scripts/bootstrap-puppet.sh"
+        "../../scripts/bootstrap-aio.sh"
       ]
     },
 
@@ -64,7 +66,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --parser=future --verbose --detailed-exitcodes --hiera_config='/tmp/packer-puppet-masterless/hiera/hiera.yaml' --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppetlabs/bin /opt/puppetlabs/bin/puppet apply --verbose --detailed-exitcodes --vardir='/var/cache/puppet' --hiera_config='/tmp/packer-puppet-masterless/hiera/hiera.yaml' --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}",
         "qa_root_passwd": "{{user `qa_root_passwd`}}"
@@ -80,7 +82,7 @@
         "PUPPET_NFS={{user `puppet_nfs`}}"
       ],
       "scripts": [
-        "../../scripts/cleanup-puppet.sh",
+        "../../scripts/cleanup-aio.sh",
         "../../scripts/cleanup-packer.sh",
         "../../scripts/cleanup-scrub.sh"
       ]

--- a/templates/fedora-24/x86_64.vsphere.nocm.json
+++ b/templates/fedora-24/x86_64.vsphere.nocm.json
@@ -1,0 +1,105 @@
+{
+
+  "variables":
+    {
+      "template_name": "fedora-24-x86_64",
+      "version": "0.0.1",
+
+      "provisioner": "vmware",
+      "required_modules": "puppetlabs-stdlib",
+      "puppet_nfs": "{{env `PUPPET_NFS`}}",
+      "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
+      "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",
+      "packer_vcenter_username": "{{env `PACKER_VCENTER_USERNAME`}}",
+      "packer_vcenter_password": "{{env `PACKER_VCENTER_PASSWORD`}}",
+      "packer_vcenter_dc": "{{env `PACKER_VCENTER_DC`}}",
+      "packer_vcenter_cluster": "{{env `PACKER_VCENTER_CLUSTER`}}",
+      "packer_vcenter_datastore": "{{env `PACKER_VCENTER_DATASTORE`}}",
+      "packer_vcenter_folder": "{{env `PACKER_VCENTER_FOLDER`}}",
+      "packer_vcenter_net": "{{env `PACKER_VCENTER_NET`}}",
+      "packer_vcenter_insecure": "{{env `PACKER_VCENTER_INSECURE`}}",
+
+      "memory_size": "4096",
+      "cpu_count": "2"
+
+    },
+
+  "builders": [
+    {
+      "name": "{{user `template_name`}}-{{user `provisioner`}}-vsphere-nocm",
+      "vm_name": "packer-{{build_name}}",
+      "type": "vmware-vmx",
+      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
+      "ssh_username": "root",
+      "ssh_password": "puppet",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "/sbin/halt -h -p",
+      "vmx_data_post": {
+        "memsize": "{{user `memory_size`}}",
+        "numvcpus": "{{user `cpu_count`}}",
+        "cpuid.coresPerSocket": "1"
+      }
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type": "shell",
+      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
+      ],
+      "scripts": [
+        "../../scripts/bootstrap-puppet.sh"
+      ]
+    },
+
+    {
+      "type": "file",
+      "source": "../../hiera",
+      "destination": "/tmp/packer-puppet-masterless"
+    },
+
+    {
+      "type": "puppet-masterless",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --parser=future --verbose --detailed-exitcodes --hiera_config='/tmp/packer-puppet-masterless/hiera/hiera.yaml' --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "facter": {
+        "provisioner": "{{user `provisioner`}}",
+        "qa_root_passwd": "{{user `qa_root_passwd`}}"
+      },
+      "manifest_dir": "../../manifests",
+      "manifest_file": "../../manifests/vsphere/nocm.pp"
+    },
+
+    {
+      "type": "shell",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_NFS={{user `puppet_nfs`}}"
+      ],
+      "scripts": [
+        "../../scripts/cleanup-puppet.sh",
+        "../../scripts/cleanup-packer.sh",
+        "../../scripts/cleanup-scrub.sh"
+      ]
+    }
+  ],
+
+  "post-processors": [
+    {
+      "type": "vsphere",
+      "host": "{{user `packer_vcenter_host`}}",
+      "username": "{{user `packer_vcenter_username`}}",
+      "password": "{{user `packer_vcenter_password`}}",
+      "datacenter": "{{user `packer_vcenter_dc`}}",
+      "cluster": "{{user `packer_vcenter_cluster`}}",
+      "datastore": "{{user `packer_vcenter_datastore`}}",
+      "vm_folder": "{{user `packer_vcenter_folder`}}",
+      "vm_name": "{{user `template_name`}}-{{user `version`}}",
+      "vm_network": "{{user `packer_vcenter_net`}}",
+      "insecure" : "{{user `packer_vcenter_insecure`}}"
+    }
+  ]
+}


### PR DESCRIPTION
The time has come to use the AIO vs older 3.8 binary.  This is necessary as default providers and library support has changed in modern operating systems, such as DNF and Python3
(Note we'll update this soonish to remove NFS all together and just do the fun stuff locally - better for the community and our sanity).

Added headless as monitoring the build over VNC is great for troubleshooting.

Set target vsphere NIC to vmxnet3 and removed dependency on specifying interface in bootstrap