### PR TITLE
(RE-7152) Set the Administrator AutoLogon

### DIFF
--- a/scripts/windows/generalize-packer.autounattend.xml
+++ b/scripts/windows/generalize-packer.autounattend.xml
@@ -37,11 +37,6 @@
         <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <RunSynchronous>
                 <RunSynchronousCommand wcm:action="add">
-                    <Credentials>
-                        <Domain>.</Domain>
-                        <Password>Qu@lity!</Password>
-                        <Username>Administrator</Username>
-                    </Credentials>
                     <Path>net user administrator /active:yes</Path>
                     <Order>1</Order>
                 </RunSynchronousCommand>
@@ -73,13 +68,11 @@
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <CommandLine>wmic useraccount where &quot;name=&apos;Administrator&apos;&quot; set PasswordExpires=FALSE</CommandLine>
-                    <RequiresUserInput>false</RequiresUserInput>
                     <Order>2</Order>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd /C start /wait NET ACCOUNTS /MAXPWAGE:UNLIMITED</CommandLine>
                     <Order>3</Order>
-                    <RequiresUserInput>false</RequiresUserInput>
                 </SynchronousCommand>
             </FirstLogonCommands>
             <OOBE>
@@ -104,6 +97,16 @@
                         <Group>Administrators</Group>
                         <Name>Administrator</Name>
                     </LocalAccount>
+                    <LocalAccount wcm:action="add">
+                        <Password>
+                            <Value>cAB1AHAAcABlAHQAUABhAHMAcwB3AG8AcgBkAA==</Value>
+                            <PlainText>false</PlainText>
+                        </Password>
+                        <DisplayName>puppet</DisplayName>
+                        <Description>Puppet User</Description>
+                        <Group>Administrators</Group>
+                        <Name>puppet</Name>
+                    </LocalAccount>
                 </LocalAccounts>
                 <AdministratorPassword>
                     <Value>UQB1AEAAbABpAHQAeQAhAEEAZABtAGkAbgBpAHMAdAByAGEAdABvAHIAUABhAHMAcwB3AG8AcgBkAA==</Value>
@@ -117,7 +120,7 @@
                 </Password>
                 <Domain>.</Domain>
                 <Enabled>true</Enabled>
-                <LogonCount>999</LogonCount>
+                <LogonCount>99999</LogonCount>
                 <Username>Administrator</Username>
             </AutoLogon>
         </component>

--- a/scripts/windows/generalize-packer.autounattend.xml
+++ b/scripts/windows/generalize-packer.autounattend.xml
@@ -24,6 +24,8 @@
             <ComputerName>*</ComputerName>
             <TimeZone>Grenich Mean Time</TimeZone>
             <RegisteredOwner />
+            <ShowWindowsLive>false</ShowWindowsLive>
+            <CopyProfile>true</CopyProfile>
         </component>
         <component name="Microsoft-Windows-ServerManager-SvrMgrNc" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <DoNotOpenServerManagerAtLogon>true</DoNotOpenServerManagerAtLogon>
@@ -31,6 +33,19 @@
         <component name="Microsoft-Windows-IE-ESC" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <IEHardenAdmin>false</IEHardenAdmin>
             <IEHardenUser>false</IEHardenUser>
+        </component>
+        <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <RunSynchronous>
+                <RunSynchronousCommand wcm:action="add">
+                    <Credentials>
+                        <Domain>.</Domain>
+                        <Password>Qu@lity!</Password>
+                        <Username>Administrator</Username>
+                    </Credentials>
+                    <Path>net user administrator /active:yes</Path>
+                    <Order>1</Order>
+                </RunSynchronousCommand>
+            </RunSynchronous>
         </component>
         <component name="Microsoft-Windows-Security-SPP-UX" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <SkipAutoActivation>true</SkipAutoActivation>
@@ -44,26 +59,27 @@
             <UserLocale>en-US</UserLocale>
         </component>
         <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-            <AutoLogon>
-                <Password>
-                    <Value>puppet</Value>
-                    <PlainText>true</PlainText>
-                </Password>
-                <Enabled>true</Enabled>
-                <Username>puppet</Username>
-                <Domain>.</Domain>
-                <LogonCount>999</LogonCount>
-            </AutoLogon>
             <FirstLogonCommands>
                 <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd.exe /c A:\bootstrap-base.bat</CommandLine>
                     <Description>Bootstrap for everything</Description>
                     <Order>1</Order>
+                    <RequiresUserInput>false</RequiresUserInput>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\start-boxstarter.ps1</CommandLine>
                     <Description>Start BoxStarter</Description>
+                    <Order>4</Order>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>wmic useraccount where &quot;name=&apos;Administrator&apos;&quot; set PasswordExpires=FALSE</CommandLine>
+                    <RequiresUserInput>false</RequiresUserInput>
                     <Order>2</Order>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd /C start /wait NET ACCOUNTS /MAXPWAGE:UNLIMITED</CommandLine>
+                    <Order>3</Order>
+                    <RequiresUserInput>false</RequiresUserInput>
                 </SynchronousCommand>
             </FirstLogonCommands>
             <OOBE>
@@ -72,16 +88,38 @@
                 <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>
                 <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
                 <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
-                <NetworkLocation>Home</NetworkLocation>
+                <NetworkLocation>Work</NetworkLocation>
                 <ProtectYourPC>1</ProtectYourPC>
             </OOBE>
+            <RegisteredOwner />
             <UserAccounts>
+                <LocalAccounts>
+                    <LocalAccount wcm:action="add">
+                        <Password>
+                            <Value>UQB1AEAAbABpAHQAeQAhAFAAYQBzAHMAdwBvAHIAZAA=</Value>
+                            <PlainText>false</PlainText>
+                        </Password>
+                        <Description>Local Administrator</Description>
+                        <DisplayName>Administrator</DisplayName>
+                        <Group>Administrators</Group>
+                        <Name>Administrator</Name>
+                    </LocalAccount>
+                </LocalAccounts>
                 <AdministratorPassword>
-                    <Value>dgBhAGcAcgBhAG4AdABBAGQAbQBpAG4AaQBzAHQAcgBhAHQAbwByAFAAYQBzAHMAdwBvAHIAZAA=</Value>
+                    <Value>UQB1AEAAbABpAHQAeQAhAEEAZABtAGkAbgBpAHMAdAByAGEAdABvAHIAUABhAHMAcwB3AG8AcgBkAA==</Value>
                     <PlainText>false</PlainText>
                 </AdministratorPassword>
             </UserAccounts>
-            <RegisteredOwner />
+            <AutoLogon>
+                <Password>
+                    <Value>UQB1AEAAbABpAHQAeQAhAFAAYQBzAHMAdwBvAHIAZAA=</Value>
+                    <PlainText>false</PlainText>
+                </Password>
+                <Domain>.</Domain>
+                <Enabled>true</Enabled>
+                <LogonCount>999</LogonCount>
+                <Username>Administrator</Username>
+            </AutoLogon>
         </component>
     </settings>
     <settings pass="offlineServicing">
@@ -97,5 +135,15 @@
             </DriverPaths>
         </component>
     </settings>
-    <cpi:offlineImage cpi:source="catalog:c:/dev/iso/en_windows_server_2012_r2_x64_dvd_2707946-install_windows server 2012 r2 serverstandard.clg" xmlns:cpi="urn:schemas-microsoft-com:cpi" />
+    <settings pass="auditUser">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <RegisteredOwner />
+        </component>
+    </settings>
+    <settings pass="generalize">
+        <component name="Microsoft-Windows-Security-SPP" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <SkipRearm>8</SkipRearm>
+        </component>
+    </settings>
+    <cpi:offlineImage cpi:source="wim:c:/15bcc9dfbc0eebf6f640cf0419b697269c84eece8486f4531beb4ad606410664/sources/install.wim#Windows Server 2012 R2 SERVERSTANDARD" xmlns:cpi="urn:schemas-microsoft-com:cpi" />
 </unattend>

--- a/scripts/windows/start-boxstarter.ps1
+++ b/scripts/windows/start-boxstarter.ps1
@@ -4,10 +4,6 @@ $ErrorActionPreference = 'Stop'
 
 $PackageDir = 'A:\'
 
-$WinlogonPath = "HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Winlogon"
-Remove-ItemProperty -Path $WinlogonPath -Name AutoAdminLogon -ErrorAction SilentlyContinue
-Remove-ItemProperty -Path $WinlogonPath -Name DefaultUserName -ErrorAction SilentlyContinue
-
 $packageFile = Get-ChildItem -Path $PackageDir | ? { $_.Name -match '.package.ps1$'} | Select-Object -First 1
 if ($packageFile -eq $null) {
   Write-Warning "No boxstarter packages found in $PackageDir"
@@ -21,8 +17,5 @@ Get-Boxstarter -Force
 Remove-Item -Path "$($Env:USERPROFILE)\Desktop\Boxstarter Shell.lnk" -Confirm:$false -Force -ErrorAction SilentlyContinue | Out-Null
 Remove-Item -Path "$($Env:APPDATA)\Microsoft\Windows\Start Menu\Programs\Boxstarter" -Recurse -Confirm:$false -Force -ErrorAction SilentlyContinue | Out-Null
 
-$secpasswd = ConvertTo-SecureString "puppet" -AsPlainText -Force
-$cred = New-Object System.Management.Automation.PSCredential ("puppet", $secpasswd)
-
 Import-Module $env:appdata\boxstarter\boxstarter.chocolatey\boxstarter.chocolatey.psd1
-Install-BoxstarterPackage -PackageName ($packageFile.Fullname) -Credential $cred
+Install-BoxstarterPackage -PackageName ($packageFile.Fullname)

--- a/templates/windows-2012r2/files/autounattend.xml
+++ b/templates/windows-2012r2/files/autounattend.xml
@@ -129,10 +129,6 @@
                         <Description>Puppet Build User</Description>
                     </LocalAccount>
                 </LocalAccounts>
-                <AdministratorPassword>
-                    <Value>UQB1AEAAbABpAHQAeQAhAEEAZABtAGkAbgBpAHMAdAByAGEAdABvAHIAUABhAHMAcwB3AG8AcgBkAA==</Value>
-                    <PlainText>false</PlainText>
-                </AdministratorPassword>
             </UserAccounts>
             <FirstLogonCommands>
                 <SynchronousCommand wcm:action="add">
@@ -146,9 +142,14 @@
                     <Order>2</Order>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c wmic useraccount where "name='Administrator'" set PasswordExpires=FALSE</CommandLine>
+                    <Description>Disable Administrator Password reset</Description>
+                    <Order>3</Order>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
                     <CommandLine>cmd.exe /c A:\generalize-packer.bat</CommandLine>
                     <Description>Sysprep generalize</Description>
-                    <Order>3</Order>
+                    <Order>4</Order>
                 </SynchronousCommand>
             </FirstLogonCommands>
             <OOBE>
@@ -174,6 +175,26 @@
                     <Path>A:\</Path>
                 </PathAndCredentials>
             </DriverPaths>
+        </component>
+    </settings>
+    <settings pass="auditSystem">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <UserAccounts>
+                <AdministratorPassword>
+                    <Value>UQB1AEAAbABpAHQAeQAhAEEAZABtAGkAbgBpAHMAdAByAGEAdABvAHIAUABhAHMAcwB3AG8AcgBkAA==</Value>
+                    <PlainText>false</PlainText>
+                </AdministratorPassword>
+            </UserAccounts>
+            <AutoLogon>
+                <Password>
+                    <Value>UQB1AEAAbABpAHQAeQAhAFAAYQBzAHMAdwBvAHIAZAA=</Value>
+                    <PlainText>false</PlainText>
+                </Password>
+                <Domain>.</Domain>
+                <Enabled>true</Enabled>
+                <LogonCount>999</LogonCount>
+                <Username>Administrator</Username>
+            </AutoLogon>
         </component>
     </settings>
     <cpi:offlineImage cpi:source="wim:c:/15bcc9dfbc0eebf6f640cf0419b697269c84eece8486f4531beb4ad606410664/sources/install.wim#Windows Server 2012 R2 SERVERSTANDARD" xmlns:cpi="urn:schemas-microsoft-com:cpi" />

--- a/templates/windows-2012r2/files/windows-2012r2-x86_64-vmware-vsphere-cygwin.package.ps1
+++ b/templates/windows-2012r2/files/windows-2012r2-x86_64-vmware-vsphere-cygwin.package.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = "Stop"
 
 # Boxstarter options
 $Boxstarter.RebootOk=$true # Allow reboots?
-$Boxstarter.NoPassword=$false # Is this a machine with no login password?
+$Boxstarter.NoPassword=$true # Is this a machine with no login password?
 $Boxstarter.AutoLogin=$true # Save my password securely and auto-login after a reboot
 
 if (Test-PendingReboot){ Invoke-Reboot }
@@ -105,9 +105,6 @@ Write-BoxStarterMessage "Unloading Default User hive from HKLM\DEFUSER..."
 Write-BoxStarterMessage "Test for Reboot....."
 if (Test-PendingReboot) { Invoke-Reboot }
 
-# TODO Set Local Administrators password!
-
-# TODO Apparently I need to setup autologon for Administrator.  I don't like this.  Need to figure out why
 Write-BoxStarterMessage "Other Stuff......."
 
 # TODO May need to add some ps-remote/winrm configuration here

--- a/templates/windows-2012r2/files/windows-2012r2-x86_64-vmware-vsphere-cygwin.package.ps1
+++ b/templates/windows-2012r2/files/windows-2012r2-x86_64-vmware-vsphere-cygwin.package.ps1
@@ -106,5 +106,12 @@ Write-BoxStarterMessage "Test for Reboot....."
 if (Test-PendingReboot) { Invoke-Reboot }
 
 Write-BoxStarterMessage "Other Stuff......."
+# Some other quick win settings provided by Boxstarter
+
+#Disable UAC for Windows-2012
+Disable-UAC
+
+# Enable Remote Desktop (with reduce authentication resetting here again)
+Enable-RemoteDesktop -DoNotRequireUserLevelAuthentication
 
 # TODO May need to add some ps-remote/winrm configuration here

--- a/templates/windows-2012r2/files/windows-2012r2-x86_64-vmware.package.ps1
+++ b/templates/windows-2012r2/files/windows-2012r2-x86_64-vmware.package.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = "Stop"
 
 # Boxstarter options
 $Boxstarter.RebootOk=$true # Allow reboots?
-$Boxstarter.NoPassword=$false # Is this a machine with no login password?
+$Boxstarter.NoPassword=$true # Is this a machine with no login password?
 $Boxstarter.AutoLogin=$true # Save my password securely and auto-login after a reboot
 
 if (Test-PendingReboot){ Invoke-Reboot }

--- a/templates/windows-2012r2/x86_64.vmware.base.json
+++ b/templates/windows-2012r2/x86_64.vmware.base.json
@@ -7,8 +7,9 @@
     "iso_checksum_type": "md5",
     "iso_checksum": "78bff6565f178ed08ab534397fe44845",
     "headless": "false",
-    "tools_iso": "/Applications/VMware Fusion.app/Contents//Library/isoimages/windows.iso"
+    "tools_iso": "/Applications/VMware Fusion.app/Contents//Library/isoimages/windows.iso",
 
+    "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}"
   },
 
   "description": "Builds a Windows Server 2012 R2 template VM for use in VMware",
@@ -27,8 +28,8 @@
       "headless": "{{user `headless`}}",
 
       "communicator": "winrm",
-      "winrm_username": "puppet",
-      "winrm_password": "puppet",
+      "winrm_username": "Administrator",
+      "winrm_password": "{{user `qa_root_passwd`}}",
       "winrm_timeout": "8h",
 
       "shutdown_command": "shutdown /s /t 1 /c \"Packer Shutdown\" /f /d p:4:1",

--- a/templates/windows-2012r2/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-2012r2/x86_64.vmware.vsphere.cygwin.json
@@ -4,7 +4,12 @@
     "version": "0.0.1",
 
     "provisioner": "vmware",
-    "headless": "false"
+    "headless": "false",
+
+    "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
+    "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",
+    "packer_vcenter_username": "{{env `PACKER_VCENTER_USERNAME`}}",
+    "packer_vcenter_password": "{{env `PACKER_VCENTER_PASSWORD`}}"
   },
 
   "description": "Builds a Windows Server 2012 R2 template VM for use in VMware",
@@ -19,8 +24,8 @@
       "headless": "{{user `headless`}}",
 
       "communicator": "winrm",
-      "winrm_username": "puppet",
-      "winrm_password": "puppet",
+      "winrm_username": "Administrator",
+      "winrm_password": "{{user `qa_root_passwd`}}",
       "winrm_timeout": "8h",
 
       "shutdown_command": "A:\\shutdown-packer.bat",


### PR DESCRIPTION
Setting the Autologon for the Administrator using a combination of Unattended installation with some additional registry settings in the box starter script.

This avoids having the show the Admin password in plain-text in the puppet code as originally attempted.

Have also Enabled Remote Desktop and Disabled UAC settings using box starter functions (RE-7513/RE-7383)