### PR TITLE
(WIP) (RE-7458) Install Chrome, Notepad and Sysinternals

### DIFF
--- a/scripts/windows/install-win-packages.ps1
+++ b/scripts/windows/install-win-packages.ps1
@@ -23,3 +23,44 @@ Write-Host "Installing Sysinternal Tools"
 chocolatey install procexp --yes --force
 chocolatey install procmon --yes --force
 chocolatey install pstools --yes --force
+
+# Put in registry keys to suppress the EULA popup on first use.
+# (since puppet modules don't support HKCU)
+# First a helper function
+
+function AcceptSysInternalsEULA {
+param (
+  [string]$regkeyroot
+ )
+   Write-Host "Setting Sysinternals Registry Keys for $regkeyroot"
+
+   reg.exe ADD "$regkeyroot\Software\Sysinternals\Process Explorer" /v EulaAccepted /t REG_DWORD /d 1 /f
+   reg.exe ADD "$regkeyroot\Software\Sysinternals\Process Monitor"  /v EulaAccepted /t REG_DWORD /d 1 /f
+   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsExec"           /v EulaAccepted /t REG_DWORD /d 1 /f
+   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsFile"           /v EulaAccepted /t REG_DWORD /d 1 /f
+   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsGetSid"         /v EulaAccepted /t REG_DWORD /d 1 /f
+   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsInfo"           /v EulaAccepted /t REG_DWORD /d 1 /f
+   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsKill"           /v EulaAccepted /t REG_DWORD /d 1 /f
+   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsList"           /v EulaAccepted /t REG_DWORD /d 1 /f
+   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsLoggedOn"       /v EulaAccepted /t REG_DWORD /d 1 /f
+   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsLogList"        /v EulaAccepted /t REG_DWORD /d 1 /f
+   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsPasswd"         /v EulaAccepted /t REG_DWORD /d 1 /f
+   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsService"        /v EulaAccepted /t REG_DWORD /d 1 /f
+   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsShutdown"       /v EulaAccepted /t REG_DWORD /d 1 /f
+   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsSuspend"        /v EulaAccepted /t REG_DWORD /d 1 /f
+   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsTools"          /v EulaAccepted /t REG_DWORD /d 1 /f
+}
+
+# Accept for current user.
+AcceptSysInternalsEULA HKCU
+
+# Same for the Default User
+reg.exe load HKLM\DEFUSER c:\users\default\ntuser.dat
+AcceptSysInternalsEULA HKLM\DEFUSER
+reg.exe unload HKLM\DEFUSER
+
+# Same for puppet User as profile already exists
+# Note - Realise this is not ideal, so will be tidied once we figure out how remove profiles.
+reg.exe load HKLM\PUPPET c:\users\puppet\ntuser.dat
+AcceptSysInternalsEULA HKLM\PUPPET
+reg.exe unload HKLM\PUPPET

--- a/scripts/windows/install-win-packages.ps1
+++ b/scripts/windows/install-win-packages.ps1
@@ -4,13 +4,22 @@
 
 $ErrorActionPreference = 'Stop'
 
-$scriptDirectory = (Split-Path -parent $MyInvocation.MyCommand.Definition);
 . A:\windows-env.ps1
 
-
 Write-Host "Installing Puppet Agent..."
-
-(new-object net.webclient).DownloadFile('https://downloads.puppetlabs.com/windows/puppet-agent-x64-latest.msi',"C:\Packer\Downloads\puppet-agent.msi")
-
-Start-Process -Wait "msiexec" -ArgumentList "/i C:\Packer\Downloads\puppet-agent.msi /qn /norestart PUPPET_AGENT_STARTUP_MODE=manual"
+chocolatey install puppet-agent --yes --force
 Write-Host "Installed Puppet Agent..."
+
+# Install Chrome
+Write-Host "Installing Google Chrome Browser"
+chocolatey install googlechrome --yes --force
+
+# Install Notepad++
+Write-Host "Installing Notepad++"
+chocolatey install notepadplusplus --yes --force
+
+# Install Sysinternals.
+Write-Host "Installing Sysinternal Tools"
+chocolatey install procexp --yes --force
+chocolatey install procmon --yes --force
+chocolatey install pstools --yes --force

--- a/scripts/windows/windows-env.ps1
+++ b/scripts/windows/windows-env.ps1
@@ -2,3 +2,10 @@
 $ErrorActionPreference = 'Stop'
 
 # TODO Define variables in later tickets.
+
+# Common variable definitions for packer installations and staging
+
+$PackerStaging = "C:\Packer"
+$PackerDownloads = "$PackerStaging\Downloads"
+$PackerLogs = "$PackerStaging\Logs"
+$PackerPuppet = "$PackerStaging\puppet"

--- a/templates/windows-2012r2/files/windows-2012r2-x86_64-vmware-vsphere-cygwin.package.ps1
+++ b/templates/windows-2012r2/files/windows-2012r2-x86_64-vmware-vsphere-cygwin.package.ps1
@@ -1,5 +1,7 @@
 $ErrorActionPreference = "Stop"
 
+. A:\windows-env.ps1
+
 # Boxstarter options
 $Boxstarter.RebootOk=$true # Allow reboots?
 $Boxstarter.NoPassword=$true # Is this a machine with no login password?
@@ -13,7 +15,6 @@ Set-ItemProperty -Path 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Power' -
 
 # TODO intend to move this to the common windows environment file.
 
-$PackerPuppet = "C:\Packer\puppet"
 $ModulesPath = ''
 $PuppetPath = 'C:\Program Files\Puppet Labs\Puppet\bin\puppet.bat'
 

--- a/templates/windows-2012r2/files/windows-2012r2-x86_64-vmware.package.ps1
+++ b/templates/windows-2012r2/files/windows-2012r2-x86_64-vmware.package.ps1
@@ -1,5 +1,7 @@
 $ErrorActionPreference = "Stop"
 
+. A:\windows-env.ps1
+
 # Boxstarter options
 $Boxstarter.RebootOk=$true # Allow reboots?
 $Boxstarter.NoPassword=$true # Is this a machine with no login password?


### PR DESCRIPTION
Use chocolatey to install packages including Sysinternals packages [RE-7457](https://tickets.puppetlabs.com/browse/RE-7457)
At the moment, the chocolatey.org repo is used.
We may move this to using our local nexus repository in the future (will be handled in separate ticket).