### PR TITLE
(RE-7663) Don't use boxstarter for later packer configuration

### DIFF
--- a/scripts/windows/cleanup-host.ps1
+++ b/scripts/windows/cleanup-host.ps1
@@ -6,18 +6,21 @@ $ErrorActionPreference = 'Stop'
 
 
 Write-Host "Uninstalling Puppet Agent..."
-Start-Process -Wait "msiexec" -ArgumentList "/x C:\Packer\Downloads\puppet-agent.msi /qn /norestart PUPPET_AGENT_STARTUP_MODE=manual"
+choco uninstall puppet-agent --yes
 
-# TODO Remove Boxstarter?
-# TODO Remove Chocolatey?
+# Remove Boxstarter
+Write-Host "Uninstalling boxstarter..."
+choco uninstall boxstarter --yes
 
+# TODO Remove Chocolatey - probably not as it will poleaxe Sysinternals?
+# Need to discuss with Rob - suspect ok to leave on machine.
 
 # Remove Directories
 
 cmd.exe /C RD C:\ProgramData\PuppetLabs /s /q
 
 # Remove the pagefile
-Write-BoxstarterMessage "Removing page file.  Recreates on next boot"
+Write-Host "Removing page file.  Recreates on next boot"
 $pageFileMemoryKey = "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management"
 Set-ItemProperty -Path $pageFileMemoryKey -Name PagingFiles -Value ""
 

--- a/scripts/windows/generalize-packer.autounattend.xml
+++ b/scripts/windows/generalize-packer.autounattend.xml
@@ -89,34 +89,24 @@
                 <LocalAccounts>
                     <LocalAccount wcm:action="add">
                         <Password>
-                            <Value>UQB1AEAAbABpAHQAeQAhAFAAYQBzAHMAdwBvAHIAZAA=</Value>
-                            <PlainText>false</PlainText>
+                            <Value>PackerAdmin</Value>
+                            <PlainText>true</PlainText>
                         </Password>
                         <Description>Local Administrator</Description>
                         <DisplayName>Administrator</DisplayName>
                         <Group>Administrators</Group>
                         <Name>Administrator</Name>
                     </LocalAccount>
-                    <LocalAccount wcm:action="add">
-                        <Password>
-                            <Value>cAB1AHAAcABlAHQAUABhAHMAcwB3AG8AcgBkAA==</Value>
-                            <PlainText>false</PlainText>
-                        </Password>
-                        <DisplayName>puppet</DisplayName>
-                        <Description>Puppet User</Description>
-                        <Group>Administrators</Group>
-                        <Name>puppet</Name>
-                    </LocalAccount>
                 </LocalAccounts>
                 <AdministratorPassword>
-                    <Value>UQB1AEAAbABpAHQAeQAhAEEAZABtAGkAbgBpAHMAdAByAGEAdABvAHIAUABhAHMAcwB3AG8AcgBkAA==</Value>
-                    <PlainText>false</PlainText>
+                    <Value>PackerAdmin</Value>
+                    <PlainText>true</PlainText>
                 </AdministratorPassword>
             </UserAccounts>
             <AutoLogon>
                 <Password>
-                    <Value>UQB1AEAAbABpAHQAeQAhAFAAYQBzAHMAdwBvAHIAZAA=</Value>
-                    <PlainText>false</PlainText>
+                    <Value>PackerAdmin</Value>
+                    <PlainText>true</PlainText>
                 </Password>
                 <Domain>.</Domain>
                 <Enabled>true</Enabled>

--- a/scripts/windows/install-win-packages.ps1
+++ b/scripts/windows/install-win-packages.ps1
@@ -23,3 +23,44 @@ Write-Host "Installing Sysinternal Tools"
 chocolatey install procexp --yes --force
 chocolatey install procmon --yes --force
 chocolatey install pstools --yes --force
+
+# Put in registry keys to suppress the EULA popup on first use.
+# (since puppet modules don't support HKCU)
+# First a helper function
+
+function AcceptSysInternalsEULA {
+param (
+  [string]$regkeyroot
+ )
+   Write-Host "Setting Sysinternals Registry Keys for $regkeyroot"
+
+   reg.exe ADD "$regkeyroot\Software\Sysinternals\Process Explorer" /v EulaAccepted /t REG_DWORD /d 1 /f
+   reg.exe ADD "$regkeyroot\Software\Sysinternals\Process Monitor"  /v EulaAccepted /t REG_DWORD /d 1 /f
+   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsExec"           /v EulaAccepted /t REG_DWORD /d 1 /f
+   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsFile"           /v EulaAccepted /t REG_DWORD /d 1 /f
+   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsGetSid"         /v EulaAccepted /t REG_DWORD /d 1 /f
+   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsInfo"           /v EulaAccepted /t REG_DWORD /d 1 /f
+   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsKill"           /v EulaAccepted /t REG_DWORD /d 1 /f
+   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsList"           /v EulaAccepted /t REG_DWORD /d 1 /f
+   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsLoggedOn"       /v EulaAccepted /t REG_DWORD /d 1 /f
+   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsLogList"        /v EulaAccepted /t REG_DWORD /d 1 /f
+   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsPasswd"         /v EulaAccepted /t REG_DWORD /d 1 /f
+   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsService"        /v EulaAccepted /t REG_DWORD /d 1 /f
+   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsShutdown"       /v EulaAccepted /t REG_DWORD /d 1 /f
+   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsSuspend"        /v EulaAccepted /t REG_DWORD /d 1 /f
+   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsTools"          /v EulaAccepted /t REG_DWORD /d 1 /f
+}
+
+# Accept for current user.
+AcceptSysInternalsEULA HKCU
+
+# Same for the Default User
+reg.exe load HKLM\DEFUSER c:\users\default\ntuser.dat
+AcceptSysInternalsEULA HKLM\DEFUSER
+reg.exe unload HKLM\DEFUSER
+
+# Same for puppet User as profile already exists
+# Note - Realise this is not ideal, so will be tidied once we figure out how remove profiles.
+reg.exe load HKLM\PUPPET c:\users\puppet\ntuser.dat
+AcceptSysInternalsEULA HKLM\PUPPET
+reg.exe unload HKLM\PUPPET

--- a/scripts/windows/install-win-packages.ps1
+++ b/scripts/windows/install-win-packages.ps1
@@ -7,7 +7,7 @@ $ErrorActionPreference = 'Stop'
 . A:\windows-env.ps1
 
 Write-Host "Installing Puppet Agent..."
-chocolatey install puppet-agent --yes --force
+chocolatey install puppet-agent --yes --force -installArgs '"PUPPET_AGENT_STARTUP_MODE=manual"'
 Write-Host "Installed Puppet Agent..."
 
 # Install Chrome
@@ -18,7 +18,7 @@ chocolatey install googlechrome --yes --force
 Write-Host "Installing Notepad++"
 chocolatey install notepadplusplus --yes --force
 
-# Install Sysinternals.
+# Install Sysinternals - to special tools directory as we may want to remove chocolatey
 Write-Host "Installing Sysinternal Tools"
 chocolatey install procexp --yes --force
 chocolatey install procmon --yes --force

--- a/scripts/windows/install-win-packages.ps1
+++ b/scripts/windows/install-win-packages.ps1
@@ -4,13 +4,22 @@
 
 $ErrorActionPreference = 'Stop'
 
-$scriptDirectory = (Split-Path -parent $MyInvocation.MyCommand.Definition);
 . A:\windows-env.ps1
 
-
 Write-Host "Installing Puppet Agent..."
-
-(new-object net.webclient).DownloadFile('https://downloads.puppetlabs.com/windows/puppet-agent-x64-latest.msi',"C:\Packer\Downloads\puppet-agent.msi")
-
-Start-Process -Wait "msiexec" -ArgumentList "/i C:\Packer\Downloads\puppet-agent.msi /qn /norestart PUPPET_AGENT_STARTUP_MODE=manual"
+chocolatey install puppet-agent --yes --force
 Write-Host "Installed Puppet Agent..."
+
+# Install Chrome
+Write-Host "Installing Google Chrome Browser"
+chocolatey install googlechrome --yes --force
+
+# Install Notepad++
+Write-Host "Installing Notepad++"
+chocolatey install notepadplusplus --yes --force
+
+# Install Sysinternals.
+Write-Host "Installing Sysinternal Tools"
+chocolatey install procexp --yes --force
+chocolatey install procmon --yes --force
+chocolatey install pstools --yes --force

--- a/scripts/windows/install-win-packages.ps1
+++ b/scripts/windows/install-win-packages.ps1
@@ -26,8 +26,8 @@ chocolatey install pstools --yes --force
 
 # Put in registry keys to suppress the EULA popup on first use.
 # (since puppet modules don't support HKCU)
-# First a helper function
 
+# First a helper function
 function AcceptSysInternalsEULA {
 param (
   [string]$regkeyroot
@@ -58,9 +58,3 @@ AcceptSysInternalsEULA HKCU
 reg.exe load HKLM\DEFUSER c:\users\default\ntuser.dat
 AcceptSysInternalsEULA HKLM\DEFUSER
 reg.exe unload HKLM\DEFUSER
-
-# Same for puppet User as profile already exists
-# Note - Realise this is not ideal, so will be tidied once we figure out how remove profiles.
-reg.exe load HKLM\PUPPET c:\users\puppet\ntuser.dat
-AcceptSysInternalsEULA HKLM\PUPPET
-reg.exe unload HKLM\PUPPET

--- a/scripts/windows/shutdown-packer.bat
+++ b/scripts/windows/shutdown-packer.bat
@@ -1,7 +1,7 @@
 @ECHO OFF
 SETLOCAL
 
-SET LOGFILE=C:\Packer\Logs\shutdown-packer.bat.log
+SET LOGFILE=%SYSTEMROOT%\TEMP\shutdown-packer.bat.log
 
 ECHO shutdown-packer.bat started %date% %time% >> %LOGFILE%
 

--- a/scripts/windows/start-boxstarter.ps1
+++ b/scripts/windows/start-boxstarter.ps1
@@ -1,8 +1,12 @@
 $ErrorActionPreference = 'Stop'
 
 . A:\windows-env.ps1
-
 $PackageDir = 'A:\'
+
+# Remove AutoLogin for Packer - will be re-instated at end if required.
+$WinlogonPath = "HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Winlogon"
+Remove-ItemProperty -Path $WinlogonPath -Name AutoAdminLogon -ErrorAction SilentlyContinue
+Remove-ItemProperty -Path $WinlogonPath -Name DefaultUserName -ErrorAction SilentlyContinue
 
 $packageFile = Get-ChildItem -Path $PackageDir | ? { $_.Name -match '.package.ps1$'} | Select-Object -First 1
 if ($packageFile -eq $null) {
@@ -17,5 +21,9 @@ Get-Boxstarter -Force
 Remove-Item -Path "$($Env:USERPROFILE)\Desktop\Boxstarter Shell.lnk" -Confirm:$false -Force -ErrorAction SilentlyContinue | Out-Null
 Remove-Item -Path "$($Env:APPDATA)\Microsoft\Windows\Start Menu\Programs\Boxstarter" -Recurse -Confirm:$false -Force -ErrorAction SilentlyContinue | Out-Null
 
+# Use Admin Plaintext password for this phase of configuration
+$secpasswd = ConvertTo-SecureString "PackerAdmin" -AsPlainText -Force
+$cred = New-Object System.Management.Automation.PSCredential ("Administrator", $secpasswd)
+
 Import-Module $env:appdata\boxstarter\boxstarter.chocolatey\boxstarter.chocolatey.psd1
-Install-BoxstarterPackage -PackageName ($packageFile.Fullname)
+Install-BoxstarterPackage -PackageName ($packageFile.Fullname) -Credential $cred

--- a/scripts/windows/windows-env.ps1
+++ b/scripts/windows/windows-env.ps1
@@ -2,3 +2,10 @@
 $ErrorActionPreference = 'Stop'
 
 # TODO Define variables in later tickets.
+
+# Common variable definitions for packer installations and staging
+
+$PackerStaging = "C:\Packer"
+$PackerDownloads = "$PackerStaging\Downloads"
+$PackerLogs = "$PackerStaging\Logs"
+$PackerPuppet = "$PackerStaging\puppet"

--- a/scripts/windows/windows-env.ps1
+++ b/scripts/windows/windows-env.ps1
@@ -7,5 +7,8 @@ $ErrorActionPreference = 'Stop'
 
 $PackerStaging = "C:\Packer"
 $PackerDownloads = "$PackerStaging\Downloads"
-$PackerLogs = "$PackerStaging\Logs"
 $PackerPuppet = "$PackerStaging\puppet"
+
+# For Puppet modules configuration
+$ModulesPath = ''
+$PuppetPath = 'C:\Program Files\Puppet Labs\Puppet\bin\puppet.bat'

--- a/templates/windows-2012r2/files/autounattend.xml
+++ b/templates/windows-2012r2/files/autounattend.xml
@@ -94,11 +94,11 @@
             <RegisteredOwner />
             <AutoLogon>
                 <Password>
-                    <Value>cAB1AHAAcABlAHQAUABhAHMAcwB3AG8AcgBkAA==</Value>
-                    <PlainText>false</PlainText>
+                    <Value>PackerAdmin</Value>
+                    <PlainText>true</PlainText>
                 </Password>
                 <Enabled>true</Enabled>
-                <Username>puppet</Username>
+                <Username>Administrator</Username>
                 <Domain>.</Domain>
                 <LogonCount>999</LogonCount>
             </AutoLogon>
@@ -120,13 +120,13 @@
                 <LocalAccounts>
                     <LocalAccount wcm:action="add">
                         <Password>
-                            <Value>cAB1AHAAcABlAHQAUABhAHMAcwB3AG8AcgBkAA==</Value>
-                            <PlainText>false</PlainText>
+                            <Value>PackerAdmin</Value>
+                            <PlainText>true</PlainText>
                         </Password>
-                        <Group>administrators</Group>
-                        <DisplayName>Puppet</DisplayName>
-                        <Name>puppet</Name>
-                        <Description>Puppet Build User</Description>
+                        <Group>Administrators</Group>
+                        <DisplayName>Administrator</DisplayName>
+                        <Name>Administrator</Name>
+                        <Description>Local Administrator</Description>
                     </LocalAccount>
                 </LocalAccounts>
             </UserAccounts>
@@ -181,14 +181,14 @@
         <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <UserAccounts>
                 <AdministratorPassword>
-                    <Value>UQB1AEAAbABpAHQAeQAhAEEAZABtAGkAbgBpAHMAdAByAGEAdABvAHIAUABhAHMAcwB3AG8AcgBkAA==</Value>
-                    <PlainText>false</PlainText>
+                    <Value>PackerAdmin</Value>
+                    <PlainText>true</PlainText>
                 </AdministratorPassword>
             </UserAccounts>
             <AutoLogon>
                 <Password>
-                    <Value>UQB1AEAAbABpAHQAeQAhAFAAYQBzAHMAdwBvAHIAZAA=</Value>
-                    <PlainText>false</PlainText>
+                    <Value>PackerAdmin</Value>
+                    <PlainText>true</PlainText>
                 </Password>
                 <Domain>.</Domain>
                 <Enabled>true</Enabled>

--- a/templates/windows-2012r2/files/config-vmware-vsphere-cygwin.ps1
+++ b/templates/windows-2012r2/files/config-vmware-vsphere-cygwin.ps1
@@ -1,22 +1,14 @@
+# Main script to run puppet to configure host.
+# This script no longer runs under Boxstarter as the reboot sequence doesn't play well with packer once winrm is up
+#
 $ErrorActionPreference = "Stop"
 
 . A:\windows-env.ps1
 
-# Boxstarter options
-$Boxstarter.RebootOk=$true # Allow reboots?
-$Boxstarter.NoPassword=$false # Is this a machine with no login password?
-$Boxstarter.AutoLogin=$true # Save my password securely and auto-login after a reboot
-
-if (Test-PendingReboot){ Invoke-Reboot }
-
-Write-BoxstarterMessage "Disabling Hibernation..."
+# TODO don't think these are needed here so move them into puppet code if still needed.
+Write-Host "Disabling Hibernation..."
 Set-ItemProperty -Path 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Power' -Name 'HibernateFileSizePercent' -Value 0
 Set-ItemProperty -Path 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Power' -Name 'HibernateEnabled' -Value 0
-
-# TODO intend to move this to the common windows environment file.
-
-$ModulesPath = ''
-$PuppetPath = 'C:\Program Files\Puppet Labs\Puppet\bin\puppet.bat'
 
 # Locate Packer Puppet Modules
 if (Test-Path -Path $PackerPuppet) {
@@ -27,10 +19,10 @@ if (Test-Path -Path $PackerPuppet) {
   if (($ModulesPath -eq '') -and (Test-Path -Path $modPath)) {$ModulesPath = $modpath}
   # Throw if no Modules directory
   if ($ModulesPath -eq '') { Throw "No Modules Directory found in $PackerPuppet" }
-  Write-BoxstarterMessage "Found Modules directory $ModulesPath"
+  Write-Host "Found Modules directory $ModulesPath"
 }
 else {
-  Write-BoxstarterMessage "No Puppet files found at $PackerPuppet"
+  Write-Host "No Puppet files found at $PackerPuppet"
 }
 
 # Download and install listed FOrge modules if a relevant forge-modules.txt file is found
@@ -41,56 +33,55 @@ If ((Test-Path -path $ForgeMods) -and ($ModulesPath -ne '')) {
     if ($modulename.IndexOf('#') -gt -1) { $modulename = $modulename.Substring(0,$modulename.IndexOf('#')) }
     $modulename = $modulename.Trim()
     if ($modulename -ne '') {
-      Write-BoxstarterMessage "Installing the $modulename module from the Forge..."
+      Write-Host "Installing the $modulename module from the Forge..."
 
       & $PuppetPath module install "$modulename" --verbose --target-dir $ModulesPath
       $EC = $LASTEXITCODE
       if ($EC -ne 0) {
-        Write-BoxstarterMessage "Installing puppet module $modulename returned exit code $EC"
+        Write-Host "Installing puppet module $modulename returned exit code $EC"
         Throw "Installing puppet module $modulename returned exit code $EC"
       }
       else
       {
-        Write-BoxstarterMessage "Module $modulename installed"
+        Write-Host "Module $modulename installed"
       }
     }
   }
 }
 else {
-  Write-BoxstarterMessage "No modules were required to be downloaded from the forge $ForgeMods"
+  Write-Host "No modules were required to be downloaded from the forge $ForgeMods"
 }
 
 # TODO What about custom facts?
 
-Write-BoxStarterMessage "Loading Default User hive to HKLM\DEFUSER..."
+Write-Host "Loading Default User hive to HKLM\DEFUSER..."
 & reg load HKLM\DEFUSER C:\Users\Default\NTUSER.DAT
 
 # Loop through all Manifest Files in A:\ and process them
 # Keep reapplying until no resources are modified, or MaxAttempts is hit
-Write-BoxStarterMessage "Puppet Manifest Processing Starting"
+Write-Host "Puppet Manifest Processing Starting"
 Get-ChildItem -Path $PackerPuppet -Filter '*.pp' | ? { -not $_.PSIsContainer } | % {
   $MaxAttempts = 20
   $Attempt = 1
   $Manifest = $_
   $AllDone = $false
   do {
-    Write-BoxstarterMessage "Applying $($Manifest.Name).  Attempt $Attempt of $MaxAttempts ..."
+    Write-Host "Applying $($Manifest.Name).  Attempt $Attempt of $MaxAttempts ..."
 
     & $PuppetPath apply ($Manifest.Fullname) "--modulepath=$ModulesPath" --verbose --detailed-exitcodes
     $EC = $LASTEXITCODE
     switch ($EC) {
       0 {
-        Write-BoxstarterMessage "$($Manifest.Name) completed and no resources were modified.  Can exit now"
+        Write-Host "$($Manifest.Name) completed and no resources were modified.  Can exit now"
         $AllDone = $true
         break
       }
       2 {
-        Write-BoxstarterMessage "$($Manifest.Name) completed but some resources were modified.  Will retry"
-        if (Test-PendingReboot) { Invoke-Reboot }
+        Write-Host "$($Manifest.Name) completed but some resources were modified.  Will retry"
         break
       }
       default {
-        Write-BoxstarterMessage "$($Manifest.Name) failed with exit code $EC"
+        Write-Host "$($Manifest.Name) failed with exit code $EC"
         throw "Puppet manifest $($Manifest.Name) failed with exit code $EC"
       }
     }
@@ -98,21 +89,17 @@ Get-ChildItem -Path $PackerPuppet -Filter '*.pp' | ? { -not $_.PSIsContainer } |
   } while ( -not $AllDone -and ($Attempt -lt $MaxAttempts) )
   if (-not $AllDone) { throw "Failed to converge $($Manifest.Name).  Max attempts exceeded"}
 }
-Write-BoxStarterMessage "Puppet Manifest Processing Finished"
+Write-Host "Puppet Manifest Processing Finished"
 
-Write-BoxStarterMessage "Unloading Default User hive from HKLM\DEFUSER..."
+Write-Host "Unloading Default User hive from HKLM\DEFUSER..."
 & reg unload HKLM\DEFUSER
 
-Write-BoxStarterMessage "Test for Reboot....."
-if (Test-PendingReboot) { Invoke-Reboot }
-
-Write-BoxStarterMessage "Other Stuff......."
 # Some other quick win settings provided by Boxstarter
+# Although this is no longer run under boxstarter, we are still able to use it's cmdlets.
+Write-Host "Other Stuff......."
 
 #Disable UAC for Windows-2012
 Disable-UAC
 
 # Enable Remote Desktop (with reduce authentication resetting here again)
 Enable-RemoteDesktop -DoNotRequireUserLevelAuthentication
-
-# TODO May need to add some ps-remote/winrm configuration here

--- a/templates/windows-2012r2/files/windows-2012r2-x86_64-vmware-vsphere-cygwin.package.ps1
+++ b/templates/windows-2012r2/files/windows-2012r2-x86_64-vmware-vsphere-cygwin.package.ps1
@@ -1,5 +1,7 @@
 $ErrorActionPreference = "Stop"
 
+. A:\windows-env.ps1
+
 # Boxstarter options
 $Boxstarter.RebootOk=$true # Allow reboots?
 $Boxstarter.NoPassword=$true # Is this a machine with no login password?
@@ -13,7 +15,6 @@ Set-ItemProperty -Path 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Power' -
 
 # TODO intend to move this to the common windows environment file.
 
-$PackerPuppet = "C:\Packer\puppet"
 $ModulesPath = ''
 $PuppetPath = 'C:\Program Files\Puppet Labs\Puppet\bin\puppet.bat'
 

--- a/templates/windows-2012r2/files/windows-2012r2-x86_64-vmware-vsphere-cygwin.package.ps1
+++ b/templates/windows-2012r2/files/windows-2012r2-x86_64-vmware-vsphere-cygwin.package.ps1
@@ -4,7 +4,7 @@ $ErrorActionPreference = "Stop"
 
 # Boxstarter options
 $Boxstarter.RebootOk=$true # Allow reboots?
-$Boxstarter.NoPassword=$true # Is this a machine with no login password?
+$Boxstarter.NoPassword=$false # Is this a machine with no login password?
 $Boxstarter.AutoLogin=$true # Save my password securely and auto-login after a reboot
 
 if (Test-PendingReboot){ Invoke-Reboot }

--- a/templates/windows-2012r2/files/windows-2012r2-x86_64-vmware.package.ps1
+++ b/templates/windows-2012r2/files/windows-2012r2-x86_64-vmware.package.ps1
@@ -4,7 +4,7 @@ $ErrorActionPreference = "Stop"
 
 # Boxstarter options
 $Boxstarter.RebootOk=$true # Allow reboots?
-$Boxstarter.NoPassword=$true # Is this a machine with no login password?
+$Boxstarter.NoPassword=$false # Is this a machine with no login password?
 $Boxstarter.AutoLogin=$true # Save my password securely and auto-login after a reboot
 
 if (Test-PendingReboot){ Invoke-Reboot }

--- a/templates/windows-2012r2/files/windows-2012r2-x86_64-vmware.package.ps1
+++ b/templates/windows-2012r2/files/windows-2012r2-x86_64-vmware.package.ps1
@@ -1,5 +1,7 @@
 $ErrorActionPreference = "Stop"
 
+. A:\windows-env.ps1
+
 # Boxstarter options
 $Boxstarter.RebootOk=$true # Allow reboots?
 $Boxstarter.NoPassword=$true # Is this a machine with no login password?

--- a/templates/windows-2012r2/x86_64.vmware.base.json
+++ b/templates/windows-2012r2/x86_64.vmware.base.json
@@ -29,7 +29,7 @@
 
       "communicator": "winrm",
       "winrm_username": "Administrator",
-      "winrm_password": "{{user `qa_root_passwd`}}",
+      "winrm_password": "PackerAdmin",
       "winrm_timeout": "8h",
 
       "shutdown_command": "shutdown /s /t 1 /c \"Packer Shutdown\" /f /d p:4:1",

--- a/templates/windows-2012r2/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-2012r2/x86_64.vmware.vsphere.cygwin.json
@@ -39,7 +39,7 @@
         "../../scripts/windows/cleanup-host.ps1",
         "../../scripts/windows/windows-env.ps1",
         "../../scripts/windows/shutdown-packer.bat",
-        "files/{{build_name}}.package.ps1"
+        "files/config-vmware-vsphere-cygwin.ps1"
       ],
 
       "vmx_data": {
@@ -72,10 +72,13 @@
       "inline": [
         "md -Path C:\\Packer\\puppet\\modules",
         "md -Path C:\\Packer\\Downloads",
-        "md -Path C:\\Packer\\Logs",
+        "md -Path C:\\Packer\\Initialisation",
         "A:\\install-win-packages.ps1"
       ],
       "valid_exit_codes": [0,1]
+    },
+    {
+      "type": "windows-restart"
     },
     {
       "type": "file",
@@ -90,7 +93,16 @@
     {
       "type": "powershell",
       "inline": [
-        "A:\\start-boxstarter.ps1",
+        "A:\\config-vmware-vsphere-cygwin.ps1"
+      ],
+      "valid_exit_codes": [0,1]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "powershell",
+      "inline": [
         "A:\\cleanup-host.ps1"
       ],
       "valid_exit_codes": [0,1]

--- a/templates/windows-2012r2/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-2012r2/x86_64.vmware.vsphere.cygwin.json
@@ -25,7 +25,7 @@
 
       "communicator": "winrm",
       "winrm_username": "Administrator",
-      "winrm_password": "{{user `qa_root_passwd`}}",
+      "winrm_password": "PackerAdmin",
       "winrm_timeout": "8h",
 
       "shutdown_command": "A:\\shutdown-packer.bat",


### PR DESCRIPTION
Boxstarter (Restart) does not play well with packer once winrm is
enabled, so change the second phase configuration to work without
boxstarter.

This means adding some additional restarts into the packer provisioning
sequence.

This also incorporates #88 which will be closed.

Tickets addressed:

1. [RE-7663](https://tickets.puppetlabs.com/browse/RE-7663) - Fix Boxstarter restart issue
2. [RE-7458](https://tickets.puppetlabs.com/browse/RE-7458) - Install Chrome, Notepad and other utils
3. [RE-7457](https://tickets.puppetlabs.com/browse/RE-7457) - Install and license Sysinternals.