### PR TITLE
(RE-7514) Enable Bootlog and other Configuration Fixes

### DIFF
--- a/manifests/windows/windows_template/manifests/configure_services.pp
+++ b/manifests/windows/windows_template/manifests/configure_services.pp
@@ -1,7 +1,12 @@
-class windows_template::disable_services()
+class windows_template::configure_services()
 {
     # TODO Disable Windows Search Service if it exists
 
+    # Configure WinRM service
+    service { 'WinRM':
+      ensure => 'running',
+      enable => true,
+    }
 
     # Disable Windows Update service
     service { 'wuauserv':

--- a/manifests/windows/windows_template/manifests/configure_services.pp
+++ b/manifests/windows/windows_template/manifests/configure_services.pp
@@ -8,6 +8,15 @@ class windows_template::configure_services()
       enable => true,
     }
 
+    # Disable Netbios and relates services
+    service { 'lmhosts':
+      ensure => 'stopped',
+      enable => false,
+    }
+    service { 'netbt':
+      ensure => 'stopped',
+      enable => false,
+    }
     # Disable Windows Update service
     service { 'wuauserv':
       ensure => 'stopped',

--- a/manifests/windows/windows_template/manifests/disable_services.pp
+++ b/manifests/windows/windows_template/manifests/disable_services.pp
@@ -1,4 +1,11 @@
 class windows_template::disable_services()
 {
-    # TODO Disable Windows Search Service if it exists    
+    # TODO Disable Windows Search Service if it exists
+
+
+    # Disable Windows Update service
+    service { 'wuauserv':
+      ensure => 'stopped',
+      enable => false,
+    }
 }

--- a/manifests/windows/windows_template/manifests/local_group_policies.pp
+++ b/manifests/windows/windows_template/manifests/local_group_policies.pp
@@ -175,5 +175,13 @@ class windows_template::local_group_policies ()
         type  => 'dword'
     }
 
-    # TODO up to Set IE Home Page to "Blank"
+    # Disable Windows Update
+    windows_group_policy::local::machine { 'DisableWindowsUpdate':
+        key   => 'Software\Policies\Microsoft\Windows\WindowsUpdate\AU',
+        value => 'NoAutoUpdate',
+        data  => 1,
+        type  => 'REG_DWORD',
+        notify => Windows_group_policy::Gpupdate['GPUpdate'],
+    }
+
 }

--- a/templates/windows-2012r2/files/config-vmware-vsphere-cygwin.ps1
+++ b/templates/windows-2012r2/files/config-vmware-vsphere-cygwin.ps1
@@ -28,3 +28,11 @@ reg.exe ADD "HKLM\DEFUSER\Software\Microsoft\Internet Explorer\Main" /v "Start P
 
 # Unload default user.
 reg.exe unload HKLM\DEFUSER
+
+# Configure WinRM - (Final configuration)
+Write-Host "Configuring WinRM"
+winrm quickconfig -force
+winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="512"}'
+winrm set winrm/config '@{MaxTimeoutms="1800000"}'
+winrm set winrm/config/service '@{AllowUnencrypted="true"}'
+winrm set winrm/config/service/auth '@{Basic="true"}'

--- a/templates/windows-2012r2/files/config-vmware-vsphere-cygwin.ps1
+++ b/templates/windows-2012r2/files/config-vmware-vsphere-cygwin.ps1
@@ -9,6 +9,10 @@ $ErrorActionPreference = "Stop"
 # Although this is no longer run under boxstarter, we are still able to use it's cmdlets.
 Write-Host "Other Stuff......."
 
+# Enable Bootlog
+Write-Host "Enable Bootlog"
+cmd /c "bcdedit /set {current} bootlog yes"
+
 # Load Default User for registry to accomodate changes.
 reg.exe load HKLM\DEFUSER c:\users\default\ntuser.dat
 

--- a/templates/windows-2012r2/files/win-2012r2-x86_64-std.pp
+++ b/templates/windows-2012r2/files/win-2012r2-x86_64-std.pp
@@ -1,4 +1,4 @@
 include windows_template::local_group_policies
-include windows_template::disable_services
+include windows_template::configure_services
 include windows_template::disable_sounds
 #include windows_template::vagrant

--- a/templates/windows-2012r2/files/windows-2012r2-x86_64-vmware.package.ps1
+++ b/templates/windows-2012r2/files/windows-2012r2-x86_64-vmware.package.ps1
@@ -21,10 +21,8 @@ netsh advfirewall firewall add rule name="Remote Desktop" dir=in localport=3389 
 choco install dotnet4.5 -y
 if (Test-PendingReboot) { Invoke-Reboot }
 
-
-# Install Updates
-# TODO Reenable after debugging
-#Install-WindowsUpdate -AcceptEula
+# Install Updates and reboot until this is completed.
+Install-WindowsUpdate -AcceptEula
 if (Test-PendingReboot) { Invoke-Reboot }
 
 # Remove the pagefile


### PR DESCRIPTION
Apply a number of configuration updates to the image including:

1. [RE-7514](https://tickets.puppetlabs.com/browse/RE-7514) - Enable Bootlog
2. [RE-7589](https://tickets.puppetlabs.com/browse/RE-7514) - Apply windows update
3. [RE-7517](https://tickets.puppetlabs.com/browse/RE-7517) - Disable Windows Update
4. [RE-7523](https://tickets.puppetlabs.com/browse/RE-7523) - Configure WinRM
5. [RE-7683](https://tickets.puppetlabs.com/browse/RE-7683) - Disable NetBios and other services
