### PR TITLE
(RE-7682) Add Chrome Default User Preferences

### DIFF
--- a/manifests/windows/windows_template/files/master_preferences
+++ b/manifests/windows/windows_template/files/master_preferences
@@ -1,0 +1,21 @@
+{
+  "homepage_is_newtabpage" : false,
+  "browser": {
+    "show_home_button": true,
+     "check_default_browser" : false
+  },
+  "homepage": "about:blank",
+  "distribution": {
+    "skip_first_run_ui": true,
+    "show_welcome_page": false,
+    "make_chrome_default": false,
+    "suppress_first_run_default_browser_prompt": true
+  },
+  "sync_promo" : {
+    "user_skipped" : true,
+    "show_on_first_run_allowed" : false
+  },
+  "first_run_tabs" : [
+    "about:blank"
+  ]
+}

--- a/manifests/windows/windows_template/manifests/chrome.pp
+++ b/manifests/windows/windows_template/manifests/chrome.pp
@@ -1,0 +1,9 @@
+class windows_template::chrome()
+{
+  file { "${chrome_root}\\Application\\master_preferences":
+    owner  => 'Administrator',
+    group  => 'Administrator',
+    mode   => '0775',
+    source  => "${modules_path}\\windows_template\\files\\master_preferences",
+  }
+}

--- a/scripts/windows/puppet-configure.ps1
+++ b/scripts/windows/puppet-configure.ps1
@@ -72,6 +72,10 @@ else {
 Write-Host "Loading Default User hive to HKLM\DEFUSER..."
 & reg load HKLM\DEFUSER C:\Users\Default\NTUSER.DAT
 
+# Set "facts" that we need for the Puppet Run.
+$ENV:FACTER_chrome_root="$ENV:ProgramFiles `(x86`)\Google\Chrome"
+$ENV:FACTER_modules_path="$ModulesPath"
+
 # Loop through all Manifest Files in A:\ and process them
 # Keep reapplying until no resources are modified, or MaxAttempts is hit
 Write-Host "Puppet Manifest Processing Starting"

--- a/templates/windows-2012r2/files/win-2012r2-x86_64-std.pp
+++ b/templates/windows-2012r2/files/win-2012r2-x86_64-std.pp
@@ -1,2 +1,3 @@
 include windows_template::local_group_policies
+include windows_template::chrome
 include windows_template::configure_services


### PR DESCRIPTION
This allows the blank page (and other Chrome default settings) to be
defined. Also prevent the Chrome First Run dialogues.

Note - there is a bug in Chrome which causes the Chrome first run prompt
to run unless you use special incantations in the master_preferences
file. This edition of the file *seems* to work.

Note also the extra FACTER_xxx facts that need to be added. There may
still be a localisation issue lurking in this w.r.t. Program Files.
O btw - Google installs the 64 bit version into (x86)