### PR TITLE
initial libvirt templates for centos6-8

### DIFF
--- a/templates/centos-6.8/CHANGELOG
+++ b/templates/centos-6.8/CHANGELOG
@@ -1,0 +1,25 @@
+### 1.0.4
+
+* Bump version to Centos 6.8
+* Bump version for Puppet
+* Add libvirt templates
+
+### 1.0.3
+
+* Bump version for Puppet and PE
+* CentOS package updates to address security vulnerabilities
+
+### 1.0.2
+
+* Switch to puppet-agent packaging
+* Bump version for Puppet and PE
+
+### 1.0.1
+
+* Bump version to CentOS 6.6 
+* Fixups for Virtualbox Guest Additions
+* Bump version for Puppet and PE
+
+### 1.0.0
+
+* Initial release

--- a/templates/centos-6.8/files/Vagrantfile.libvirt
+++ b/templates/centos-6.8/files/Vagrantfile.libvirt
@@ -1,0 +1,64 @@
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+
+  # Example configuration of new VM..
+  # 
+  #config.vm.define :test_vm do |test_vm|
+    # Box name
+    #
+    #test_vm.vm.box = "centos64"
+
+    # Domain Specific Options
+    #
+    # See README for more info.
+    #
+    #test_vm.vm.provider :libvirt do |domain|
+    #  domain.memory = 2048
+    #  domain.cpus = 2
+    #end
+
+    # Interfaces for VM
+    # 
+    # Networking features in the form of `config.vm.network`
+    #
+    #test_vm.vm.network :private_network, :ip => '10.20.30.40'
+    #test_vm.vm.network :public_network, :ip => '10.20.30.41'
+  #end
+
+  # Options for libvirt vagrant provider.
+  config.vm.provider :libvirt do |libvirt|
+
+    # A hypervisor name to access. Different drivers can be specified, but
+    # this version of provider creates KVM machines only. Some examples of
+    # drivers are kvm (qemu hardware accelerated), qemu (qemu emulated),
+    # xen (Xen hypervisor), lxc (Linux Containers),
+    # esx (VMware ESX), vmwarews (VMware Workstation) and more. Refer to
+    # documentation for available drivers (http://libvirt.org/drivers.html).
+    libvirt.driver = "kvm"
+    
+    # On some systems, starting the box seems to be hanging on the messages
+    # 'Waiting for domain to get an IP address...'
+    # this is caused due to a kernel oops during boot. This is solved by following
+    # setting 
+    libvirt.cpu_mode = 'host-passthrough'
+
+    # The name of the server, where libvirtd is running.
+    # libvirt.host = "localhost"
+
+    # If use ssh tunnel to connect to Libvirt.
+    libvirt.connect_via_ssh = false
+
+    # The username and password to access Libvirt. Password is not used when
+    # connecting via ssh.
+    libvirt.username = "root"
+    #libvirt.password = "secret"
+
+    # Libvirt storage pool name, where box image and instance snapshots will
+    # be stored.
+    libvirt.storage_pool_name = "default"
+
+    # Set a prefix for the machines that's different than the project dir name.
+    #libvirt.default_prefix = ''
+  end
+end

--- a/templates/centos-6.8/files/ks.cfg
+++ b/templates/centos-6.8/files/ks.cfg
@@ -1,0 +1,39 @@
+install
+cdrom
+lang en_US.UTF-8
+keyboard us
+network --bootproto=dhcp
+rootpw --iscrypted $1$v4K9E8Wj$gZIHJ5JtQL5ZGZXeqSSsd0
+firewall --enabled --service=ssh
+authconfig --enableshadow --passalgo=sha512
+selinux --disabled
+timezone UTC
+bootloader --location=mbr
+
+text
+skipx
+zerombr
+
+clearpart --all --initlabel
+autopart
+
+auth  --useshadow  --enablemd5
+firstboot --disabled
+reboot --eject
+
+%packages --ignoremissing
+@core
+bzip2
+kernel-devel
+kernel-headers
+gcc
+make
+perl
+curl
+wget
+nfs-utils
+-ipw2100-firmware
+-ipw2200-firmware
+-ivtv-firmware
+%end
+

--- a/templates/centos-6.8/i386.libvirt.base.json
+++ b/templates/centos-6.8/i386.libvirt.base.json
@@ -1,0 +1,95 @@
+{
+
+  "variables":
+    {
+      "template_name": "centos-6.8-i386",
+      "template_os": "centos",
+
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/CentOS-6.8-x86_64-bin-DVD1.iso",
+      "iso_checksum": "720d185fdf063383a4471657076b72fc162d3c3c3bca2e5e5ae13a25b3046519",
+      "iso_checksum_type": "sha256",
+
+      "memory_size": "512",
+      "cpu_count": "1",
+
+      "provisioner": "libvirt",
+      "required_modules": "puppetlabs-stdlib saz-ssh",
+      "puppet_aio": "http://yum.puppetlabs.com/el/6/PC1/i386/puppet-agent-1.6.0-1.el6.i386.rpm"
+    },
+
+  "builders": [
+    {
+      "name": "{{user `template_name`}}-{{user `provisioner`}}",
+      "type": "qemu",
+      "accelerator": "kvm",
+      "format": "qcow2",
+      "headless": true,
+      "net_device": "virtio-net-pci",
+      "disk_interface": "virtio-scsi",
+      "headless": "true",
+      "boot_command": [
+        "<tab> <wait>",
+        "text <wait>",
+        "ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg <wait>",
+        "<enter>"        
+      ],
+      "boot_wait": "45s",
+      "disk_size": 20480,
+      "http_directory": "files",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `iso_url`}}",
+      "ssh_username": "root",
+      "ssh_password": "puppet",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "/sbin/halt -h -p",
+      "qemuargs": [
+        [ "-m", "{{user `memory_size`}}" ],
+        [ "-smp",
+          "cpus={{user `cpu_count`}},",
+          "cores=1",
+          ""
+        ]
+      ]
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type": "shell",
+      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_AIO={{user `puppet_aio`}}"
+      ],
+      "scripts": [
+        "../../scripts/bootstrap-aio.sh"
+      ]
+    },
+
+    {
+      "type": "puppet-masterless",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppetlabs/bin /opt/puppetlabs/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "facter": {
+        "provisioner": "{{user `provisioner`}}"
+      },
+      "manifest_dir": "../../manifests",
+      "manifest_file": "../../manifests/base.pp"
+    },
+
+    {
+      "type": "shell",
+      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_AIO={{user `puppet_aio`}}"
+      ],
+      "scripts": [
+        "../../scripts/cleanup-aio.sh",
+        "../../scripts/cleanup-packer.sh"
+      ]
+    }
+  ]
+
+}

--- a/templates/centos-6.8/i386.libvirt.vagrant.nocm.json
+++ b/templates/centos-6.8/i386.libvirt.vagrant.nocm.json
@@ -1,0 +1,96 @@
+{
+
+  "variables":
+    {
+      "template_name": "centos-6.8-i386",
+      "version": "1.0.4",
+
+      "iso_checksum_type": "none",
+      "iso_checksum": "",
+
+      "memory_size": "512",
+      "cpu_count": "1",
+
+      "provisioner": "libvirt",
+      "required_modules": "puppetlabs-stdlib saz-sudo",
+      "puppet_aio": "http://yum.puppetlabs.com/el/6/PC1/i386/puppet-agent-1.6.0-1.el6.i386.rpm"
+
+    },
+
+  "builders": [
+    {
+      "name": "{{user `template_name`}}-{{user `provisioner`}}-vagrant-nocm",
+      "vm_name": "packer-{{build_name}}",
+      "type": "qemu",
+      "accelerator": "kvm",
+      "format": "qcow2",
+      "headless": true,
+      "net_device": "virtio-net-pci",
+      "disk_interface": "virtio-scsi",
+      "disk_image": "true",
+      "iso_url": "./output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "ssh_username": "root",
+      "ssh_password": "puppet",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "/sbin/halt -h -p",
+      "qemuargs": [
+        [ "-m", "{{user `memory_size`}}" ],
+        [ "-smp",
+          "cpus={{user `cpu_count`}},",
+          "cores=1",
+          ""
+        ]
+      ]
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type": "shell",
+      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_AIO={{user `puppet_aio`}}"
+      ],
+      "scripts": [
+        "../../scripts/bootstrap-aio.sh"
+      ]
+    },
+
+    {
+      "type": "puppet-masterless",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppetlabs/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "facter": {
+        "provisioner": "{{user `provisioner`}}"
+      },
+      "manifest_dir": "../../manifests",
+      "manifest_file": "../../manifests/vagrant/nocm.pp"
+    },
+
+    {
+      "type": "shell",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_AIO={{user `puppet_aio`}}"
+      ],
+      "scripts": [
+        "../../scripts/cleanup-aio.sh",
+        "../../scripts/cleanup-packer.sh",
+        "../../scripts/cleanup-scrub.sh"
+      ]
+    }
+  ],
+  
+  "post-processors": [
+    {
+      "type": "vagrant",
+      "output": "/opt/output/{{.Provider}}/{{user `template_name`}}-{{.Provider}}-nocm.box",
+      "vagrantfile_template": "files/Vagrantfile.libvirt"
+    }
+  ]
+
+
+}

--- a/templates/centos-6.8/i386.libvirt.vagrant.puppet.json
+++ b/templates/centos-6.8/i386.libvirt.vagrant.puppet.json
@@ -1,0 +1,94 @@
+{
+
+  "variables":
+    {
+      "template_name": "centos-6.8-i386",
+      "version": "1.0.4",
+
+      "iso_checksum_type": "none",
+      "iso_checksum": "",
+
+      "memory_size": "512",
+      "cpu_count": "1",
+
+      "provisioner": "libvirt",
+      "required_modules": "puppetlabs-stdlib saz-sudo",
+      "puppet_aio": "http://yum.puppetlabs.com/el/6/PC1/i386/puppet-agent-1.6.0-1.el6.i386.rpm"
+
+    },
+
+  "builders": [
+    {
+      "name": "{{user `template_name`}}-{{user `provisioner`}}-vagrant-puppet",
+      "vm_name": "packer-{{build_name}}",
+      "type": "qemu",
+      "accelerator": "kvm",
+      "format": "qcow2",
+      "headless": true,
+      "net_device": "virtio-net-pci",
+      "disk_interface": "virtio-scsi",
+      "disk_image": "true",
+      "iso_url": "./output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "ssh_username": "root",
+      "ssh_password": "puppet",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "/sbin/halt -h -p",
+      "qemuargs": [
+        [ "-m", "{{user `memory_size`}}" ],
+        [ "-smp",
+          "cpus={{user `cpu_count`}},",
+          "cores=1",
+          ""
+        ]
+      ]
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type": "shell",
+      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_AIO={{user `puppet_aio`}}"
+      ],
+      "scripts": [
+        "../../scripts/bootstrap-aio.sh"
+      ]
+    },
+
+    {
+      "type": "puppet-masterless",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppetlabs/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "facter": {
+        "provisioner": "{{user `provisioner`}}"
+      },
+      "manifest_dir": "../../manifests",
+      "manifest_file": "../../manifests/vagrant/puppet.pp"
+    },
+
+    {
+      "type": "shell",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_AIO={{user `puppet_aio`}}"
+      ],
+      "scripts": [
+        "../../scripts/cleanup-packer.sh",
+        "../../scripts/cleanup-scrub.sh"
+      ]
+    }
+  ],
+
+  "post-processors": [
+    {
+      "type": "vagrant",
+      "output": "/opt/output/{{.Provider}}/{{user `template_name`}}-{{.Provider}}-puppet.box",
+      "vagrantfile_template": "files/Vagrantfile.libvirt"
+    }
+  ]
+
+}

--- a/templates/centos-6.8/vagrantcloud.yaml
+++ b/templates/centos-6.8/vagrantcloud.yaml
@@ -1,0 +1,18 @@
+---
+name: 'centos-6.8'
+description: 'CentOS 6.8'
+version: '0.0.1'
+
+arches:
+  - name: '32'
+    description: '32-bit (i386)'
+  - name: '64'
+    description: '64-bit (amd64/x86_64)'
+
+configs:
+  - name: 'nocm'
+    description: 'no configuration management software'
+  - name: 'puppet'
+    description: 'Puppet 4.3.2 / Puppet Enterprise 2016.2.1(agent)'
+  - name: 'puppet-enterprise'
+    description: 'Puppet Enterprise 3.8.4 (agent)'

--- a/templates/centos-6.8/x86_64.libvirt.base.json
+++ b/templates/centos-6.8/x86_64.libvirt.base.json
@@ -1,0 +1,94 @@
+{
+
+  "variables":
+    {
+      "template_name": "centos-6.8-x86_64",
+      "template_os": "centos",
+
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/CentOS-6.8-x86_64-bin-DVD1.iso",
+      "iso_checksum": "1dda55622614a8b43b448a72f87d6cb7f79de1eff49ee8c5881a7d9db28d4e35",
+      "iso_checksum_type": "sha256",
+
+      "memory_size": "512",
+      "cpu_count": "1",
+
+      "provisioner": "libvirt",
+      "required_modules": "puppetlabs-stdlib saz-ssh",
+      "puppet_aio": "http://yum.puppetlabs.com/el/6/PC1/x86_64/puppet-agent-1.6.0-1.el6.x86_64.rpm"
+    },
+
+  "builders": [
+    {
+      "name": "{{user `template_name`}}-{{user `provisioner`}}",
+      "type": "qemu",
+      "accelerator": "kvm",
+      "format": "qcow2",
+      "net_device": "virtio-net-pci",
+      "disk_interface": "virtio-scsi",
+      "headless": "true",
+      "boot_command": [
+        "<tab> <wait>",
+        "text <wait>",
+        "ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg <wait>",
+        "<enter>"        
+      ],
+      "boot_wait": "45s",
+      "disk_size": 20480,
+      "http_directory": "files",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `iso_url`}}",
+      "ssh_username": "root",
+      "ssh_password": "puppet",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "/sbin/halt -h -p",
+      "qemuargs": [
+        [ "-m", "{{user `memory_size`}}" ],
+        [ "-smp",
+          "cpus={{user `cpu_count`}},",
+          "cores=1",
+          ""
+        ]
+      ]
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type": "shell",
+      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_AIO={{user `puppet_aio`}}"
+      ],
+      "scripts": [
+        "../../scripts/bootstrap-aio.sh"
+      ]
+    },
+
+    {
+      "type": "puppet-masterless",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppetlabs/bin /opt/puppetlabs/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "facter": {
+        "provisioner": "{{user `provisioner`}}"
+      },
+      "manifest_dir": "../../manifests",
+      "manifest_file": "../../manifests/base.pp"
+    },
+
+    {
+      "type": "shell",
+      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_AIO={{user `puppet_aio`}}"
+      ],
+      "scripts": [
+        "../../scripts/cleanup-aio.sh",
+        "../../scripts/cleanup-packer.sh"
+      ]
+    }
+  ]
+
+}

--- a/templates/centos-6.8/x86_64.libvirt.vagrant.nocm.json
+++ b/templates/centos-6.8/x86_64.libvirt.vagrant.nocm.json
@@ -1,0 +1,94 @@
+{
+
+  "variables":
+    {
+      "template_name": "centos-6.8-x86_64",
+      "version": "1.0.4",
+
+      "iso_checksum_type": "none",
+
+      "memory_size": "512",
+      "cpu_count": "1",
+
+      "provisioner": "libvirt",
+      "required_modules": "puppetlabs-stdlib saz-sudo",
+      "puppet_aio": "http://yum.puppetlabs.com/el/6/PC1/x86_64/puppet-agent-1.6.0-1.el6.x86_64.rpm"
+
+    },
+
+  "builders": [
+    {
+      "name": "{{user `template_name`}}-{{user `provisioner`}}-vagrant-nocm",
+      "vm_name": "packer-{{build_name}}",
+      "type": "qemu",
+      "accelerator": "kvm",
+      "format": "qcow2",
+      "headless": true,
+      "net_device": "virtio-net-pci",
+      "disk_interface": "virtio-scsi",
+      "disk_image": "true",
+      "iso_url": "./output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "ssh_username": "root",
+      "ssh_password": "puppet",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "/sbin/halt -h -p",
+      "qemuargs": [
+        [ "-m", "{{user `memory_size`}}" ],
+        [ "-smp",
+          "cpus={{user `cpu_count`}},",
+          "cores=1",
+          ""
+        ]
+      ]
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type": "shell",
+      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_AIO={{user `puppet_aio`}}"
+      ],
+      "scripts": [
+        "../../scripts/bootstrap-aio.sh"
+      ]
+    },
+
+    {
+      "type": "puppet-masterless",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppetlabs/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "facter": {
+        "provisioner": "{{user `provisioner`}}"
+      },
+      "manifest_dir": "../../manifests",
+      "manifest_file": "../../manifests/vagrant/nocm.pp"
+    },
+
+    {
+      "type": "shell",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_AIO={{user `puppet_aio`}}"
+      ],
+      "scripts": [
+        "../../scripts/cleanup-aio.sh",
+        "../../scripts/cleanup-packer.sh",
+        "../../scripts/cleanup-scrub.sh"
+      ]
+    }
+  ],
+  
+  "post-processors": [
+    {
+      "type": "vagrant",
+      "output": "/opt/output/{{.Provider}}/{{user `template_name`}}-{{.Provider}}-nocm.box",
+      "vagrantfile_template": "files/Vagrantfile.libvirt"
+    }
+  ]
+
+}

--- a/templates/centos-6.8/x86_64.libvirt.vagrant.puppet.json
+++ b/templates/centos-6.8/x86_64.libvirt.vagrant.puppet.json
@@ -1,0 +1,94 @@
+{
+
+  "variables":
+    {
+      "template_name": "centos-6.8-x86_64",
+      "version": "1.0.4",
+
+      "iso_checksum_type": "none",
+      "iso_checksum": "",
+
+      "memory_size": "512",
+      "cpu_count": "1",
+
+      "provisioner": "libvirt",
+      "required_modules": "puppetlabs-stdlib saz-sudo",
+      "puppet_aio": "http://yum.puppetlabs.com/el/6/PC1/x86_64/puppet-agent-1.6.0-1.el6.x86_64.rpm"
+
+    },
+
+  "builders": [
+    {
+      "name": "{{user `template_name`}}-{{user `provisioner`}}-vagrant-puppet",
+      "vm_name": "packer-{{build_name}}",
+      "type": "qemu",
+      "accelerator": "kvm",
+      "format": "qcow2",
+      "headless": true,
+      "net_device": "virtio-net-pci",
+      "disk_interface": "virtio-scsi",
+      "disk_image": "true",
+      "iso_url": "./output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "ssh_username": "root",
+      "ssh_password": "puppet",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "/sbin/halt -h -p",
+      "qemuargs": [
+        [ "-m", "{{user `memory_size`}}" ],
+        [ "-smp",
+          "cpus={{user `cpu_count`}},",
+          "cores=1",
+          ""
+        ]
+      ]
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type": "shell",
+      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_AIO={{user `puppet_aio`}}"
+      ],
+      "scripts": [
+        "../../scripts/bootstrap-aio.sh"
+      ]
+    },
+
+    {
+      "type": "puppet-masterless",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppetlabs/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "facter": {
+        "provisioner": "{{user `provisioner`}}"
+      },
+      "manifest_dir": "../../manifests",
+      "manifest_file": "../../manifests/vagrant/puppet.pp"
+    },
+
+    {
+      "type": "shell",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_AIO={{user `puppet_aio`}}"
+      ],
+      "scripts": [
+        "../../scripts/cleanup-packer.sh",
+        "../../scripts/cleanup-scrub.sh"
+      ]
+    }
+  ],
+
+  "post-processors": [
+    {
+      "type": "vagrant",
+      "output": "/opt/output/{{.Provider}}/{{user `template_name`}}-{{.Provider}}-puppet.box",
+      "vagrantfile_template": "files/Vagrantfile.libvirt"
+    }
+  ]
+
+}


### PR DESCRIPTION
I'm thinking about extracting the variables section to there own json file.  Too much copy paste at the moment. 
One should then use the 'packer build -var-file <distro_vars>.json <template>.json'.

Should we still support 3.x PE-agent boxes for enterprise supported distros ?   This PR is just the libvirt templates based on the fc24 ones. 
