### PR TITLE
(RE-7831) Add windows 2016 t.p. 5 vshpere/cygwin image

### DIFF
--- a/templates/windows-2016tp5/files/win-2016tp5-x86_64-std.pp
+++ b/templates/windows-2016tp5/files/win-2016tp5-x86_64-std.pp
@@ -1,0 +1,2 @@
+include windows_template::local_group_policies
+include windows_template::configure_services

--- a/templates/windows-2016tp5/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-2016tp5/x86_64.vmware.vsphere.cygwin.json
@@ -1,0 +1,153 @@
+{
+  "variables": {
+    "template_name": "windows-2016tp5-x86_64",
+    "version": "0.0.1",
+
+    "provisioner": "vmware",
+    "headless": "false",
+
+    "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
+    "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",
+    "packer_vcenter_username": "{{env `PACKER_VCENTER_USERNAME`}}",
+    "packer_vcenter_password": "{{env `PACKER_VCENTER_PASSWORD`}}"
+  },
+
+  "description": "Builds a Windows Server 2016 Technical Preview 5 template VM for use in VMware",
+
+  "builders": [
+    {
+      "name": "{{user `template_name`}}-{{user `provisioner`}}-vsphere-cygwin",
+      "vm_name": "packer-{{build_name}}",
+      "type": "vmware-vmx",
+      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
+
+      "headless": "{{user `headless`}}",
+
+      "communicator": "winrm",
+      "winrm_username": "Administrator",
+      "winrm_password": "PackerAdmin",
+      "winrm_timeout": "8h",
+
+      "shutdown_command": "A:\\shutdown-packer.bat",
+      "shutdown_timeout": "1h",
+
+
+      "floppy_files": [
+        "../../scripts/windows/bootstrap-base.bat",
+        "../../scripts/windows/cleanup-host.ps1",
+        "../../scripts/windows/install-win-packages.ps1",
+        "../../scripts/windows/install-cygwin.ps1",
+        "../../scripts/windows/cygwin-packages",
+        "../../scripts/windows/authorized_keys",
+        "../../scripts/windows/puppet-configure.ps1",
+        "../../scripts/windows/shutdown-packer.bat",
+        "../../scripts/windows/windows-env.ps1",
+        "../../scripts/windows/Low-SecurityPasswordPolicy.inf",
+        "files/config-vmware-vsphere-cygwin.ps1"
+      ],
+
+      "vmx_data": {
+        "gui.fitguestusingnativedisplayresolution": "FALSE",
+
+        "firmware": "efi",
+        "memsize": "4096",
+        "numvcpus": "2",
+        "ethernet0.virtualdev" : "vmxnet3",
+        "scsi0.virtualdev": "lsisas1068",
+        "virtualHW.version": "10",
+
+        "vcpu.hotadd": "TRUE",
+        "mem.hotadd": "TRUE",
+
+        "tools.syncTime": "0",
+        "time.synchronize.continue": "1",
+        "time.synchronize.restore": "1",
+        "time.synchronize.resume.disk": "1",
+        "time.synchronize.shrink": "1",
+        "time.synchronize.tools.startup": "1",
+        "time.synchronize.tools.enable": "1",
+        "time.synchronize.resume.host": "1"
+      }
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "powershell",
+      "inline": [
+        "md -Path C:\\Packer\\puppet\\modules",
+        "md -Path C:\\Packer\\Downloads",
+        "md -Path C:\\Packer\\Downloads\\Cygwin",
+        "md -Path C:\\Packer\\Init",
+        "md -Path C:\\Packer\\Logs",
+        "md -Path C:\\Packer\\Sysinternals"
+      ]
+    },
+    {
+      "type": "powershell",
+      "inline": [
+        "A:\\install-win-packages.ps1"
+      ]
+    },
+    {
+      "type": "powershell",
+      "inline": [
+        "A:\\install-cygwin.ps1"
+      ],
+      "environment_vars": [
+        "QA_ROOT_PASSWD={{user `qa_root_passwd`}}"
+      ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "file",
+      "source": "../../manifests/windows",
+      "destination": "C:\\Packer\\puppet\\modules"
+    },
+    {
+      "type": "file",
+      "source": "files/win-2016tp5-x86_64-std.pp",
+      "destination": "C:\\Packer\\puppet\\win-2016tp5-x86_64-std.pp"
+    },
+    {
+      "type": "powershell",
+      "inline": [
+        "A:\\puppet-configure.ps1"
+      ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "powershell",
+      "inline": [
+        "A:\\config-vmware-vsphere-cygwin.ps1"
+      ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "powershell",
+      "inline": [
+        "A:\\cleanup-host.ps1"
+      ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "file",
+      "source": "../../scripts/windows/Init",
+      "destination": "C:\\Packer\\Init"
+    },
+    {
+      "type": "powershell",
+      "inline": [
+        "C:\\Packer\\Init\\vmpooler-arm-host.ps1"
+      ]
+    }
+  ]
+
+}


### PR DESCRIPTION
This adds work to create the vsphere/cygwin packer image build scripts for
windows 2016 t.p. 5. This is a carbon copy of the 2012 work with some names changed.