### PR TITLE
(RE-7855) Copy Cygwin setup to system32 directory

### DIFF
--- a/scripts/windows/install-cygwin.ps1
+++ b/scripts/windows/install-cygwin.ps1
@@ -41,6 +41,9 @@ $CygWinSetup = "$CygwinDownloads\setup-$ARCH.exe"
 Download-File "http://buildsources.delivery.puppetlabs.net/windows/cygwin/setup-$ARCH.exe" $CygWinSetup
 Download-File "http://buildsources.delivery.puppetlabs.net/windows/cygwin/packages-$ARCH.zip" "$CygwinDownloads\packages_$ARCH.zip"
 
+# Copy setup program to C:\Windows\system32 to deal with beaker issue (RE-7855)
+Copy-Item -Path "C:\Packer\Downloads\Cygwin\setup-$ARCH.exe" -Destination "$ENV:WINDIR\system32\setup-$ARCH.exe"
+
 # Setup Authorised Keys and QA Password for later use
 Copy-Item -Path "A:\authorized_keys" -Destination "$CygwinDownloads\authorized_keys"
 if ($ENV:QA_ROOT_PASSWD.length -le 0 ) {throw "QA_ROOT_PASSWD is not defined"}


### PR DESCRIPTION
This is address a beaker permissions issue.

Need to copy the Cygwin_setup across to C:\Windows\system32 to overcome
an issue with the curl command in beaker testing. The beaker tests do
need fixing, but this is an interim workaround to prevent pipeline
breakages.

NB - this replaces #104 which was titled incorrectly.