### PR TITLE
(RE-7618) Add vSphere Provisioner

### DIFF
--- a/templates/windows-2012r2/x86_64.vmware.base.json
+++ b/templates/windows-2012r2/x86_64.vmware.base.json
@@ -8,8 +8,6 @@
     "iso_checksum": "78bff6565f178ed08ab534397fe44845",
     "headless": "false",
     "tools_iso": "/Applications/VMware Fusion.app/Contents//Library/isoimages/windows.iso",
-
-    "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}"
   },
 
   "description": "Builds a Windows Server 2012 R2 template VM for use in VMware",
@@ -30,7 +28,7 @@
       "communicator": "winrm",
       "winrm_username": "Administrator",
       "winrm_password": "PackerAdmin",
-      "winrm_timeout": "8h",
+      "winrm_timeout": "16h",
 
       "shutdown_command": "shutdown /s /t 1 /c \"Packer Shutdown\" /f /d p:4:1",
       "shutdown_timeout": "1h",

--- a/templates/windows-2012r2/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-2012r2/x86_64.vmware.vsphere.cygwin.json
@@ -6,10 +6,16 @@
     "provisioner": "vmware",
     "headless": "false",
 
-    "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
+    "qa_root_passwd": "{{env `QA_ROOT_PASSWD_PLAIN`}}",
     "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",
     "packer_vcenter_username": "{{env `PACKER_VCENTER_USERNAME`}}",
-    "packer_vcenter_password": "{{env `PACKER_VCENTER_PASSWORD`}}"
+    "packer_vcenter_password": "{{env `PACKER_VCENTER_PASSWORD`}}",
+    "packer_vcenter_dc": "{{env `PACKER_VCENTER_DC`}}",
+    "packer_vcenter_cluster": "{{env `PACKER_VCENTER_CLUSTER`}}",
+    "packer_vcenter_datastore": "{{env `PACKER_VCENTER_DATASTORE`}}",
+    "packer_vcenter_folder": "{{env `PACKER_VCENTER_FOLDER`}}",
+    "packer_vcenter_net": "{{env `PACKER_VCENTER_NET`}}",
+    "packer_vcenter_insecure": "{{env `PACKER_VCENTER_INSECURE`}}"
   },
 
   "description": "Builds a Windows Server 2012 R2 template VM for use in VMware",
@@ -48,6 +54,7 @@
 
       "vmx_data": {
         "gui.fitguestusingnativedisplayresolution": "FALSE",
+        "annotation": "{{user `template_name`}}-{{user `version`}} built {{isotime}}",
 
         "firmware": "efi",
         "memsize": "4096",
@@ -148,6 +155,20 @@
         "C:\\Packer\\Init\\vmpooler-arm-host.ps1"
       ]
     }
+  ],
+  "post-processors": [
+    {
+      "type": "vsphere",
+      "host": "{{user `packer_vcenter_host`}}",
+      "username": "{{user `packer_vcenter_username`}}",
+      "password": "{{user `packer_vcenter_password`}}",
+      "datacenter": "{{user `packer_vcenter_dc`}}",
+      "cluster": "{{user `packer_vcenter_cluster`}}",
+      "datastore": "{{user `packer_vcenter_datastore`}}",
+      "vm_folder": "{{user `packer_vcenter_folder`}}",
+      "vm_name": "{{user `template_name`}}-{{user `version`}}",
+      "vm_network": "{{user `packer_vcenter_net`}}",
+      "insecure" : "{{user `packer_vcenter_insecure`}}"
+    }
   ]
-
 }


### PR DESCRIPTION
This pushes the built image up to the vmpooler vSphere Cluster.

Some MAINT modifications were also needed to the base image to allow it to run successfully on nelson/rodgers.
