### PR TITLE
Clean windows update leftovers / only use one virtual disk file

### DIFF
--- a/templates/windows-2016tp5/files/windows-2016tp5-x86_64-vmware.package.ps1
+++ b/templates/windows-2016tp5/files/windows-2016tp5-x86_64-vmware.package.ps1
@@ -24,9 +24,21 @@ if (Test-PendingReboot) { Invoke-Reboot }
 # Install Updates and reboot until this is completed.
 Install-WindowsUpdate -AcceptEula
 if (Test-PendingReboot) { Invoke-Reboot }
-# Write-Host Staring CMD.exe
-# & cmd.exe /c Start cmd.exe
-# Read-Host "Press enter"
+
+# Cleanup Windows Update area after all that (may need reboot)
+Write-BoxstarterMessage "Cleaning up WinxSx updates"
+dism /online /Cleanup-Image /StartComponentCleanup /ResetBase
+if (Test-PendingReboot) { Invoke-Reboot }
+
+# Zeroing cleaned disk space
+Write-BoxstarterMessage "Zeroing cleaned disk space using sdelete"
+choco install sdelete --yes --force
+if ($ARCH -eq 'x86') {
+  $Sdelete = "sdelete"
+} else {
+  $Sdelete = "sdelete64"
+}
+& $Sdelete -z -accepteula c:
 
 # Remove the pagefile
 Write-BoxstarterMessage "Removing page file.  Recreates on next boot"

--- a/templates/windows-2016tp5/x86_64.vmware.base.json
+++ b/templates/windows-2016tp5/x86_64.vmware.base.json
@@ -36,6 +36,7 @@
       "shutdown_timeout": "1h",
       "guest_os_type": "windows8srv-64",
       "disk_size": 61440,
+      "disk_type_id": "0",
       "floppy_files": [
         "files/autounattend.xml",
         "../../scripts/windows/bootstrap-base.bat",


### PR DESCRIPTION
These commits will clean out files leftover from windows updates, and update the build scripts to only create one virtual disk file.