### PR TITLE
(MAINT) Set headless operation

### DIFF
--- a/templates/windows-2012r2/x86_64.vmware.base.json
+++ b/templates/windows-2012r2/x86_64.vmware.base.json
@@ -6,7 +6,7 @@
     "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/en_windows_server_2012_r2_with_update_x64_dvd_6052708.iso",
     "iso_checksum_type": "md5",
     "iso_checksum": "78bff6565f178ed08ab534397fe44845",
-    "headless": "false",
+    "headless": "true",
     "tools_iso": "/Applications/VMware Fusion.app/Contents//Library/isoimages/windows.iso"
   },
 

--- a/templates/windows-2012r2/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-2012r2/x86_64.vmware.vsphere.cygwin.json
@@ -4,7 +4,7 @@
     "version": "0.0.1",
 
     "provisioner": "vmware",
-    "headless": "false",
+    "headless": "true",
 
     "qa_root_passwd": "{{env `QA_ROOT_PASSWD_PLAIN`}}",
     "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",


### PR DESCRIPTION
This is required to build under packer on the Mac OS build machines.