### PR TITLE
(RE-7993) Change Disk Handling

### DIFF
--- a/scripts/windows/clean-disk-dism.ps1
+++ b/scripts/windows/clean-disk-dism.ps1
@@ -1,0 +1,17 @@
+$ErrorActionPreference = 'Stop'
+
+. A:\windows-env.ps1
+
+# Cleanup Windows Update area after all that (may need reboot)
+Write-Host "Cleaning up WinxSx updates"
+dism /online /Cleanup-Image /StartComponentCleanup /ResetBase
+
+# Zeroing cleaned disk space
+Write-Host "Zeroing cleaned disk space using sdelete"
+choco install sdelete --yes --force
+if ($ARCH -eq 'x86') {
+  $Sdelete = "sdelete"
+} else {
+  $Sdelete = "sdelete64"
+}
+& $Sdelete -z -accepteula c:

--- a/scripts/windows/cleanup-host.ps1
+++ b/scripts/windows/cleanup-host.ps1
@@ -68,6 +68,16 @@ wevtutil clear-log Security
 wevtutil clear-log Setup
 wevtutil clear-log System
 
+# TODO run sdelete a final time - only a suggestion as it may be useful to pare out the
+# extra space released by the delete commands above.
+
+# Extend C: partition to full extend - this is predicated on the
+$size = (Get-PartitionSupportedSize -DriveLetter C)
+$sizemax = $size.SizeMax
+Write-Host "Setting Drive C partition size to $sizemax"
+Resize-Partition -DriveLetter C -Size $sizemax
+
+
 # Sleep to let console log catch up (and get captured by packer)
 Start-Sleep -Seconds 20
 #End

--- a/templates/windows-2012r2/files/autounattend.xml
+++ b/templates/windows-2012r2/files/autounattend.xml
@@ -30,10 +30,12 @@
                             <Size>128</Size>
                         </CreatePartition>
                         <!-- Windows partition -->
+                        <!-- Only Allocate 20G initially - rest will be allocated near end of prep -->
                         <CreatePartition wcm:action="add">
                             <Order>3</Order>
                             <Type>Primary</Type>
-                            <Extend>true</Extend>
+                            <Extend>false</Extend>
+                            <Size>21475</Size>
                         </CreatePartition>
                     </CreatePartitions>
                     <ModifyPartitions>

--- a/templates/windows-2012r2/files/windows-2012r2-x86_64-vmware.package.ps1
+++ b/templates/windows-2012r2/files/windows-2012r2-x86_64-vmware.package.ps1
@@ -27,21 +27,6 @@ if (Test-PendingReboot) { Invoke-Reboot }
 Install-WindowsUpdate -AcceptEula
 if (Test-PendingReboot) { Invoke-Reboot }
 
-# Cleanup Windows Update area after all that (may need reboot)
-Write-BoxstarterMessage "Cleaning up WinxSx updates"
-dism /online /Cleanup-Image /StartComponentCleanup /ResetBase
-if (Test-PendingReboot) { Invoke-Reboot }
-
-# Zeroing cleaned disk space
-Write-BoxstarterMessage "Zeroing cleaned disk space using sdelete"
-choco install sdelete --yes --force
-if ($ARCH -eq 'x86') {
-  $Sdelete = "sdelete"
-} else {
-  $Sdelete = "sdelete64"
-}
-& $Sdelete -z -accepteula c:
-
 # Remove the pagefile
 Write-BoxstarterMessage "Removing page file.  Recreates on next boot"
 $pageFileMemoryKey = "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management"

--- a/templates/windows-2012r2/x86_64.vmware.base.json
+++ b/templates/windows-2012r2/x86_64.vmware.base.json
@@ -34,6 +34,7 @@
       "shutdown_timeout": "1h",
       "guest_os_type": "windows8srv-64",
       "disk_size": 61440,
+      "disk_type_id": "0",
       "floppy_files": [
         "files/autounattend.xml",
         "../../scripts/windows/bootstrap-base.bat",
@@ -41,6 +42,7 @@
         "../../scripts/windows/windows-env.ps1",
         "../../scripts/windows/shutdown-packer.bat",
         "../../scripts/windows/generalize-packer.bat",
+        "../../scripts/windows/clean-disk-dism.ps1",
         "files/generalize-packer.autounattend.xml",
         "files/{{build_name}}.package.ps1"
       ],
@@ -80,6 +82,14 @@
         "scsi0:1.devicetype":  "",
         "scsi0:1.filename": ""
       }
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "powershell",
+      "inline": [
+        "A:\\clean-disk-dism.ps1"
+      ]
     }
   ]
 }


### PR DESCRIPTION
A series of changes to the disk handling - the main one is to reduce the amount of disc traversed by ```sdelete``` to reduce the overall build time. 

(RE-7993) Change Disk Handling
1. Change disk type to Sparse Monolothic (Type 0), https://www.vmware.com/pdf/VirtualDiskManager.pdf
2. Move DISM cleanup to winrm section.
3. Limit initial disk size to 20G (to limit sdelete)
4. Extend partition to full size at final system preparation.