### PR TITLE
(maint) Update 2016 templates to include latest windows work

### DIFF
--- a/templates/windows-2016tp5/files/autounattend.xml
+++ b/templates/windows-2016tp5/files/autounattend.xml
@@ -30,10 +30,12 @@
                             <Size>128</Size>
                         </CreatePartition>
                         <!-- Windows partition -->
+                        <!-- Only Allocate 20G initially - rest will be allocated near end of prep -->
                         <CreatePartition wcm:action="add">
                             <Order>3</Order>
                             <Type>Primary</Type>
-                            <Extend>true</Extend>
+                            <Extend>false</Extend>
+                            <Size>21475</Size>
                         </CreatePartition>
                     </CreatePartitions>
                     <ModifyPartitions>

--- a/templates/windows-2016tp5/files/windows-2016tp5-x86_64-vmware.package.ps1
+++ b/templates/windows-2016tp5/files/windows-2016tp5-x86_64-vmware.package.ps1
@@ -25,21 +25,6 @@ if (Test-PendingReboot) { Invoke-Reboot }
 Install-WindowsUpdate -AcceptEula
 if (Test-PendingReboot) { Invoke-Reboot }
 
-# Cleanup Windows Update area after all that (may need reboot)
-Write-BoxstarterMessage "Cleaning up WinxSx updates"
-dism /online /Cleanup-Image /StartComponentCleanup /ResetBase
-if (Test-PendingReboot) { Invoke-Reboot }
-
-# Zeroing cleaned disk space
-Write-BoxstarterMessage "Zeroing cleaned disk space using sdelete"
-choco install sdelete --yes --force
-if ($ARCH -eq 'x86') {
-  $Sdelete = "sdelete"
-} else {
-  $Sdelete = "sdelete64"
-}
-& $Sdelete -z -accepteula c:
-
 # Remove the pagefile
 Write-BoxstarterMessage "Removing page file.  Recreates on next boot"
 $pageFileMemoryKey = "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management"

--- a/templates/windows-2016tp5/x86_64.vmware.base.json
+++ b/templates/windows-2016tp5/x86_64.vmware.base.json
@@ -7,9 +7,7 @@
     "iso_checksum_type": "md5",
     "iso_checksum": "6417ba460f95bd91ded05dfacd553783",
     "headless": "true",
-    "tools_iso": "/Applications/VMware Fusion.app/Contents//Library/isoimages/windows.iso",
-
-    "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}"
+    "tools_iso": "{{env `VMWARE_TOOLS_ISO`}}/windows.iso"
   },
 
   "description": "Builds a Windows Server 2016 Technical Preview template VM for use in VMware",
@@ -44,6 +42,7 @@
         "../../scripts/windows/windows-env.ps1",
         "../../scripts/windows/shutdown-packer.bat",
         "../../scripts/windows/generalize-packer.bat",
+        "../../scripts/windows/clean-disk-dism.ps1",
         "files/generalize-packer.autounattend.xml",
         "files/{{build_name}}.package.ps1"
       ],
@@ -83,6 +82,14 @@
         "scsi0:1.devicetype":  "",
         "scsi0:1.filename": ""
       }
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "powershell",
+      "inline": [
+        "A:\\clean-disk-dism.ps1"
+      ]
     }
   ]
 }

--- a/templates/windows-2016tp5/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-2016tp5/x86_64.vmware.vsphere.cygwin.json
@@ -6,10 +6,16 @@
     "provisioner": "vmware",
     "headless": "true",
 
-    "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
+    "qa_root_passwd": "{{env `QA_ROOT_PASSWD_PLAIN`}}",
     "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",
     "packer_vcenter_username": "{{env `PACKER_VCENTER_USERNAME`}}",
-    "packer_vcenter_password": "{{env `PACKER_VCENTER_PASSWORD`}}"
+    "packer_vcenter_password": "{{env `PACKER_VCENTER_PASSWORD`}}",
+    "packer_vcenter_dc": "{{env `PACKER_VCENTER_DC`}}",
+    "packer_vcenter_cluster": "{{env `PACKER_VCENTER_CLUSTER`}}",
+    "packer_vcenter_datastore": "{{env `PACKER_VCENTER_DATASTORE`}}",
+    "packer_vcenter_folder": "{{env `PACKER_VCENTER_FOLDER`}}",
+    "packer_vcenter_net": "{{env `PACKER_VCENTER_NET`}}",
+    "packer_vcenter_insecure": "{{env `PACKER_VCENTER_INSECURE`}}"
   },
 
   "description": "Builds a Windows Server 2016 Technical Preview 5 template VM for use in VMware",
@@ -148,6 +154,20 @@
         "C:\\Packer\\Init\\vmpooler-arm-host.ps1"
       ]
     }
+  ],
+  "post-processors": [
+    {
+      "type": "vsphere",
+      "host": "{{user `packer_vcenter_host`}}",
+      "username": "{{user `packer_vcenter_username`}}",
+      "password": "{{user `packer_vcenter_password`}}",
+      "datacenter": "{{user `packer_vcenter_dc`}}",
+      "cluster": "{{user `packer_vcenter_cluster`}}",
+      "datastore": "{{user `packer_vcenter_datastore`}}",
+      "vm_folder": "{{user `packer_vcenter_folder`}}",
+      "vm_name": "{{user `template_name`}}-{{user `version`}}",
+      "vm_network": "{{user `packer_vcenter_net`}}",
+      "insecure" : "{{user `packer_vcenter_insecure`}}"
+    }
   ]
-
 }


### PR DESCRIPTION
We recently changed the way windows 2012 builds work to reduce the image size
dramatically. This PR pulls 2016 in line with that as well as adds the post
processor to push up to vsphere