### PR TITLE
(RE-7926) Set Install Image correctly

### DIFF
--- a/templates/windows-2016rtm/files/autounattend.xml
+++ b/templates/windows-2016rtm/files/autounattend.xml
@@ -63,7 +63,7 @@
                     <InstallFrom>
                         <MetaData wcm:action="add">
                             <Key>/IMAGE/NAME </Key>
-                            <Value>Windows Server 2016 Technical Preview 5 SERVERDATACENTER</Value>
+                            <Value>Windows Server 2016 SERVERSTANDARD</Value>
                         </MetaData>
                     </InstallFrom>
                     <InstallTo>

--- a/templates/windows-2016rtm/x86_64.vmware.base.json
+++ b/templates/windows-2016rtm/x86_64.vmware.base.json
@@ -47,7 +47,7 @@
         "files/{{build_name}}.package.ps1"
       ],
 
-      "boot_command": [ "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><wait><wait><wait><wait><wait><wait><wait><wait><wait><wait><wait><wait><wait><wait><wait><wait><wait><wait><wait><wait><wait><wait><wait><wait><wait><wait><wait><wait><wait><down><enter>"],
+      "boot_command": [ "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter>"],
       "boot_wait": "1s",
 
       "vmx_data": {

--- a/templates/windows-2016rtm/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-2016rtm/x86_64.vmware.vsphere.cygwin.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "template_name": "windows-2016tp5-x86_64",
+    "template_name": "windows-2016rtm-x86_64",
     "version": "0.0.1",
 
     "provisioner": "vmware",


### PR DESCRIPTION
Set the Windows Server Edition in the Unattend.xml so that we don't have
to use buggy boot-prompts.

This is an amendment to #115 

