### PR TITLE
(RE-7957) Change Powershell module to 1.0.6

### DIFF
--- a/manifests/windows/forge-modules.txt
+++ b/manifests/windows/forge-modules.txt
@@ -1,8 +1,9 @@
 # These modules are downloaded from the forge during a packer build
 # Like most files, anything to the right of a hash (#) is ignored and is considered a comment by the parser
 # Only the latest module is used from the public Forge
-# TODO Support version pinning and custom forge URLs
+# Specific versions are supported now (e.g. we need to stick to Powershell 1.0.6)
+# TODO Support custom forge URLs
 
-puppetlabs-powershell
+puppetlabs-powershell 1.0.6
 puppetlabs-registry
 puppetlabs-stdlib

--- a/scripts/windows/Init/post-clone-run-once.ps1
+++ b/scripts/windows/Init/post-clone-run-once.ps1
@@ -71,10 +71,7 @@ reg import C:\Packer\Init\vmpooler-clone-arm-startup.reg
 # Update machine password (and reset autologin)
 Write-Host "Setting Administrator Password"
 net user Administrator "$qa_root_passwd"
-$WinlogonPath = "HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Winlogon"
-Set-ItemProperty -Path $WinlogonPath -Name AutoAdminLogon -Value "1" -ErrorAction SilentlyContinue
-Set-ItemProperty -Path $WinlogonPath -Name DefaultUserName -Value "Administrator" -ErrorAction SilentlyContinue
-Set-ItemProperty -Path $WinlogonPath -Name DefaultPassword -Value "$qa_root_passwd" -ErrorAction SilentlyContinue
+autologon -AcceptEula Administrator . "$qa_root_passwd"
 
 # NIC Power Management - ignore any errors as need host-rename to proceed.
 Write-Host "Disabling NIC Power Management"

--- a/scripts/windows/install-win-packages.ps1
+++ b/scripts/windows/install-win-packages.ps1
@@ -40,6 +40,15 @@ Download-File http://buildsources.delivery.puppetlabs.net/windows/sysinternals/p
 Download-File http://buildsources.delivery.puppetlabs.net/windows/sysinternals/pstools.zip $PackerDownloads\pstools.zip
 & $7zip x C:\Packer\Downloads\pstools.zip -y $ostring
 
+Download-File http://buildsources.delivery.puppetlabs.net/windows/sysinternals/sdelete.zip $PackerDownloads\sdelete.zip
+& $7zip x C:\Packer\Downloads\sdelete.zip -y $ostring
+
+Download-File http://buildsources.delivery.puppetlabs.net/windows/sysinternals/bginfo.zip $PackerDownloads\bginfo.zip
+& $7zip x C:\Packer\Downloads\bginfo.zip -y $ostring
+
+Download-File http://buildsources.delivery.puppetlabs.net/windows/sysinternals/autologon.zip $PackerDownloads\autologon.zip
+& $7zip x C:\Packer\Downloads\autologon.zip -y $ostring
+
 Write-Host "Updating path with $SysInternals"
 $RegPath = 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment'
 $OldPath = (Get-ItemProperty -Path $RegPath -Name PATH).Path

--- a/templates/windows-2016rtm/files/config-vmware-vsphere-cygwin.ps1
+++ b/templates/windows-2016rtm/files/config-vmware-vsphere-cygwin.ps1
@@ -66,3 +66,6 @@ winrm set winrm/config/service/auth '@{Basic="true"}'
 # Add permissive Firewall rules (RE-7516) - This is preferred to disabling the firewall
 netsh advfirewall firewall add rule name="All Incoming" dir=in action=allow enable=yes interfacetype=any profile=any localip=any remoteip=any
 netsh advfirewall firewall add rule name="All Outgoing" dir=out action=allow enable=yes interfacetype=any profile=any localip=any remoteip=any
+
+# Re-Enable AutoAdminLogon
+autologon -AcceptEula Administrator . PackerAdmin

--- a/templates/windows-2016rtm/files/windows-2016rtm-x86_64-vmware.package.ps1
+++ b/templates/windows-2016rtm/files/windows-2016rtm-x86_64-vmware.package.ps1
@@ -52,10 +52,4 @@ winrm set winrm/config/service/auth '@{Basic="true"}'
 winrm set winrm/config/service '@{AllowUnencrypted="true"}'
 Write-BoxstarterMessage "WinRM setup complete"
 
-# Re-Enable AutoAdminLogon
-$WinlogonPath = "HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Winlogon"
-Set-ItemProperty -Path $WinlogonPath -Name AutoAdminLogon -Value "1" -ErrorAction SilentlyContinue
-Set-ItemProperty -Path $WinlogonPath -Name DefaultUserName -Value "Administrator" -ErrorAction SilentlyContinue
-Set-ItemProperty -Path $WinlogonPath -Name DefaultPassword -Value "PackerAdmin" -ErrorAction SilentlyContinue
-
 # End


### PR DESCRIPTION
This needs associated changes to the puppet-configure script.
The configure scripts changes are useful - the need to revert to PS
1.0.6 is under review.

Need to tidy up version handling using PS splatting but putting this out for review for the moment.
/cc @McdonaldSeanp @glennsarti 