### PR TITLE
Fix powershell scripts for Powershell 5.1.14393

### DIFF
--- a/manifests/windows/windows_group_policy/manifests/local/machine_client_side_extensions.pp
+++ b/manifests/windows/windows_group_policy/manifests/local/machine_client_side_extensions.pp
@@ -107,7 +107,7 @@ define windows_group_policy::local::machine_client_side_extensions(
   $policy_type = 'Machine'
 
   if $ensure in ['present'] {
-    exec { "GPO-Local-UserCSE-$name":
+    exec { "GPO-Local-MachineCSE-$name":
       command => template('windows_group_policy/script_header.ps1',
                           'windows_group_policy/gp_extensions.ps1',
                           'windows_group_policy/local_gpo_ext.ps1',

--- a/manifests/windows/windows_group_policy/templates/gp_extensions.ps1
+++ b/manifests/windows/windows_group_policy/templates/gp_extensions.ps1
@@ -15,9 +15,7 @@ Function Convert-GUIDListToHashTable($list) {
 
 Function Set-GPTExtensionGUIDs($guidList) {
   # Generate the setting string
-  $settingString = '[' + (
-    ($guidList.GetEnumerator() | ForEach-Object -Process { Write-Output "{$($_.Key.ToUpper())}" } | Sort-Object) -join ''
-  ) + ']'    
+  $settingString = '[' + ( ($guidList.GetEnumerator() | ForEach-Object -Process { Write-Output "{$($_.Key.ToUpper())}" } | Sort-Object) -join '' ) + ']'    
 
   if ($PolicyType.ToUpper() -eq 'USER') {
     $settingName = 'gPCUserExtensionNames'
@@ -28,8 +26,7 @@ Function Set-GPTExtensionGUIDs($guidList) {
   # Update the GPT.INI
   Write-Verbose "Updating $($settingName)=$($settingString)"
   $wasReplaced = $false
-  $newGPTContent = (Get-GPTIniContents |
-  ForEach-Object {
+  $newGPTContent = (Get-GPTIniContents | ForEach-Object {
     if ($_ -match "$($settingName)=") {
       Write-Output "$($settingName)=$($settingString)"
       $wasReplaced = $true
@@ -50,8 +47,7 @@ Function Get-GPExtensionListFromGPT {
   $UserExtensions = @{}
 
   if (Test-Path -Path $gptIniPath) {
-    Get-Content $gptIniPath |
-    ForEach-Object {
+    Get-Content $gptIniPath | ForEach-Object {
       if ($_ -match "gPCMachineExtensionNames=\[(.+)\]") {
         $MachineExtensions = (Convert-GUIDListToHashTable -List ([string]$matches[1].Trim()))
       }

--- a/manifests/windows/windows_group_policy/templates/local_gpo.ps1
+++ b/manifests/windows/windows_group_policy/templates/local_gpo.ps1
@@ -20,8 +20,7 @@ Add-Type -Language CSharp -TypeDefinition $PolFileEditorCS -ErrorAction Stop
 # Add-Type -Language CSharpVersion3 -TypeDefinition $PolFileEditorCS -ErrorAction Stop
 $VerbosePreference = $vp
 
-function Compare-PolicyValueIsSameAs($objPolicyEntry,$value)
-{
+function Compare-PolicyValueIsSameAs($objPolicyEntry,$value) {
   $isSame = $false
   switch ($objPolicyEntry.Type)
   {
@@ -32,8 +31,7 @@ function Compare-PolicyValueIsSameAs($objPolicyEntry,$value)
   Write-Output $isSame
 }
 
-function Set-PolicySetting($objPolicy)
-{
+function Set-PolicySetting($objPolicy) {
   # Set the policy setting
   switch ($PolicyValueType.ToUpper()) {
     "REG_DWORD" {
@@ -55,8 +53,7 @@ function Set-PolicySetting($objPolicy)
   return Invoke-IncrementGPTVersion 
 }
 
-function Open-PolicyFile([string]$policyFilePath = '', [bool]$createIfNotExist = $true)
-{
+function Open-PolicyFile([string]$policyFilePath = '', [bool]$createIfNotExist = $true) {
   if ($policyFilePath -eq '') { $policyFilePath = "$($env:systemroot)\system32\GroupPolicy\$PolicyType\registry.pol" }
 
   try

--- a/manifests/windows/windows_group_policy/templates/script_header.ps1
+++ b/manifests/windows/windows_group_policy/templates/script_header.ps1
@@ -46,8 +46,7 @@ Function Invoke-IncrementGPTVersion {
   Write-Verbose "New GP version is $currentGPVersion"
 
   Write-Verbose "Updating Version=$($currentGPVersion)"
-  $newGPTContent = (Get-GPTIniContents |
-  ForEach-Object {
+  $newGPTContent = (Get-GPTIniContents | ForEach-Object {
     if ($_ -match "Version=(\d+)$") {
       Write-Output "Version=$($currentGPVersion)"
     } else { Write-Output $_ }


### PR DESCRIPTION
	(maint) Update Windows Group Policy module for Powershell 5.1.14393  …
A bug has been identified on Powershell 5.1.14393 which has changed the way
STDIN is parsed (PowerShell/PowerShell#2068).

-  Trailing `{` is ignored on the next line.

Additional errors were found where:
- Would not parse a pipe over a new line e.g. this would not work
```
$newGPTContent = (Get-GPTIniContents |
  ForEach-Object {
```

Must use instead
```
 $newGPTContent = (Get-GPTIniContents | ForEach-Object {
```

- Would not parse an expression over a new line e.g. this would not work
```
  $settingString = '[' + (
    ($guidList.GetEnumerator() | ForEach-Object -Process ....
  ) + ']'
```

Must use instead
```
 $settingString = '[' + ( ($guidList.GetEnumerator() | ForEach-Object ...
```

This PR modifies the powershell scripts to workaround these issues.