### PR TITLE
(MAINT) Move Set-User-Key function to windows-env

### DIFF
--- a/scripts/windows/install-win-packages.ps1
+++ b/scripts/windows/install-win-packages.ps1
@@ -62,34 +62,22 @@ Write-Host "Sysinternal Tools Installed"
 # Put in registry keys to suppress the EULA popup on first use.
 # (since puppet modules don't support HKCU)
 
-# First a helper function
-function AcceptSysInternalsEULA {
-param (
-  [string]$regkeyroot
- )
-   Write-Host "Setting Sysinternals Registry Keys for $regkeyroot"
-
-   reg.exe ADD "$regkeyroot\Software\Sysinternals\Process Explorer" /v EulaAccepted /t REG_DWORD /d 1 /f
-   reg.exe ADD "$regkeyroot\Software\Sysinternals\Process Monitor"  /v EulaAccepted /t REG_DWORD /d 1 /f
-   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsExec"           /v EulaAccepted /t REG_DWORD /d 1 /f
-   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsFile"           /v EulaAccepted /t REG_DWORD /d 1 /f
-   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsGetSid"         /v EulaAccepted /t REG_DWORD /d 1 /f
-   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsInfo"           /v EulaAccepted /t REG_DWORD /d 1 /f
-   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsKill"           /v EulaAccepted /t REG_DWORD /d 1 /f
-   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsList"           /v EulaAccepted /t REG_DWORD /d 1 /f
-   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsLoggedOn"       /v EulaAccepted /t REG_DWORD /d 1 /f
-   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsLogList"        /v EulaAccepted /t REG_DWORD /d 1 /f
-   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsPasswd"         /v EulaAccepted /t REG_DWORD /d 1 /f
-   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsService"        /v EulaAccepted /t REG_DWORD /d 1 /f
-   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsShutdown"       /v EulaAccepted /t REG_DWORD /d 1 /f
-   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsSuspend"        /v EulaAccepted /t REG_DWORD /d 1 /f
-   reg.exe ADD "$regkeyroot\Software\Sysinternals\PsTools"          /v EulaAccepted /t REG_DWORD /d 1 /f
-}
-
-# Accept for current user.
-AcceptSysInternalsEULA HKCU
-
-# Same for the Default User
 reg.exe load HKLM\DEFUSER c:\users\default\ntuser.dat
-AcceptSysInternalsEULA HKLM\DEFUSER
+
+Set-UserKey 'Software\Sysinternals\Process Explorer' 'EulaAccepted'       'REG_DWORD' 1
+Set-UserKey 'Software\Sysinternals\Process Monitor'  'EulaAccepted'       'REG_DWORD' 1
+Set-UserKey 'Software\Sysinternals\PsExec'           'EulaAccepted'       'REG_DWORD' 1
+Set-UserKey 'Software\Sysinternals\PsFile'           'EulaAccepted'       'REG_DWORD' 1
+Set-UserKey 'Software\Sysinternals\PsGetSid'         'EulaAccepted'       'REG_DWORD' 1
+Set-UserKey 'Software\Sysinternals\PsInfo'           'EulaAccepted'       'REG_DWORD' 1
+Set-UserKey 'Software\Sysinternals\PsKill'           'EulaAccepted'       'REG_DWORD' 1
+Set-UserKey 'Software\Sysinternals\PsList'           'EulaAccepted'       'REG_DWORD' 1
+Set-UserKey 'Software\Sysinternals\PsLoggedOn'       'EulaAccepted'       'REG_DWORD' 1
+Set-UserKey 'Software\Sysinternals\PsLogList'        'EulaAccepted'       'REG_DWORD' 1
+Set-UserKey 'Software\Sysinternals\PsPasswd'         'EulaAccepted'       'REG_DWORD' 1
+Set-UserKey 'Software\Sysinternals\PsService'        'EulaAccepted'       'REG_DWORD' 1
+Set-UserKey 'Software\Sysinternals\PsShutdown'       'EulaAccepted'       'REG_DWORD' 1
+Set-UserKey 'Software\Sysinternals\PsSuspend'        'EulaAccepted'       'REG_DWORD' 1
+Set-UserKey 'Software\Sysinternals\PsTools'          'EulaAccepted'       'REG_DWORD' 1
+
 reg.exe unload HKLM\DEFUSER

--- a/scripts/windows/windows-env.ps1
+++ b/scripts/windows/windows-env.ps1
@@ -55,3 +55,12 @@ param (
     }
   }
 }
+
+# Helper function to set both User and Default User registry key.
+# This assumes the default user hive has been mounted as HKLM\DEFUSER
+# As noted elsewhere, the intention to to replace all Powershell registry calls with Puppet code
+
+Function Set-UserKey($key,$valuename,$reg_type,$data) {
+  reg.exe ADD "HKCU\$key" /v "$valuename" /t $reg_type /d $data /f
+  reg.exe ADD "HKLM\DEFUSER\$key" /v "$valuename" /t $reg_type /d $data /f
+}

--- a/templates/windows-2012r2/files/config-vmware-vsphere-cygwin.ps1
+++ b/templates/windows-2012r2/files/config-vmware-vsphere-cygwin.ps1
@@ -26,12 +26,6 @@ Enable-RemoteDesktop -DoNotRequireUserLevelAuthentication
 # TODO Migrate these to the puppet settings once the HKCU restriction is removed.
 #######################################################################################################################
 
-# Quick helper function
-Function Set-UserKey($key,$valuename,$reg_type,$data) {
-  reg.exe ADD "HKCU\$key" /v "$valuename" /t $reg_type /d $data /f
-  reg.exe ADD "HKLM\DEFUSER\$key" /v "$valuename" /t $reg_type /d $data /f
-}
-
 # Load Default User for registry to accomodate changes.
 # All HKCU changes are replicated for the default user.
 reg.exe load HKLM\DEFUSER c:\users\default\ntuser.dat

--- a/templates/windows-2016rtm/files/config-vmware-vsphere-cygwin.ps1
+++ b/templates/windows-2016rtm/files/config-vmware-vsphere-cygwin.ps1
@@ -26,12 +26,6 @@ Enable-RemoteDesktop -DoNotRequireUserLevelAuthentication
 # TODO Migrate these to the puppet settings once the HKCU restriction is removed.
 #######################################################################################################################
 
-# Quick helper function
-Function Set-UserKey($key,$valuename,$reg_type,$data) {
-  reg.exe ADD "HKCU\$key" /v "$valuename" /t $reg_type /d $data /f
-  reg.exe ADD "HKLM\DEFUSER\$key" /v "$valuename" /t $reg_type /d $data /f
-}
-
 # Load Default User for registry to accomodate changes.
 # All HKCU changes are replicated for the default user.
 reg.exe load HKLM\DEFUSER c:\users\default\ntuser.dat


### PR DESCRIPTION
This allows us to share the function across both current windows/json
templates and the windows installer powershell script.
Update the windows install (EULA Accept) to use new function.

This is a follow on from @glennsarti PR #128