### PR TITLE
(RE-8013) Update to use new signing key

### DIFF
--- a/manifests/modules/packer/manifests/puppet.pp
+++ b/manifests/modules/packer/manifests/puppet.pp
@@ -7,7 +7,7 @@ class packer::puppet {
       apt::source { 'puppetlabs-pc1':
         location   => 'http://apt.puppetlabs.com',
         repos      => 'PC1',
-        key        => '4BD6EC30',
+        key        => '7F438280EF8D349F',
         key_server => 'pgp.mit.edu',
       }
 


### PR DESCRIPTION
Soon we will be changing out the key used to sign the new public repos.
This code will break once that happens without this update, but this
update should be merged as close as possible to when the repos are
switched over to the new key