### PR TITLE
(IMAGES-331) Use Slipstream ISO for Windows 2012

### DIFF
--- a/templates/windows-2012/x86_64.vmware.base.json
+++ b/templates/windows-2012/x86_64.vmware.base.json
@@ -3,9 +3,9 @@
     "template_name": "windows-2012-x86_64",
 
     "provisioner": "vmware",
-    "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/en_windows_server_2012_x64_dvd_915478.iso",
+    "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/en_windows_server_2012_x64_dvd_915478_SlipStream_01.iso",
     "iso_checksum_type": "md5",
-    "iso_checksum": "da91135483e24689bfdaf05d40301506",
+    "iso_checksum": "4ae8bdee5782a11ef17eb86f09278e59",
     "headless": "true",
     "tools_iso": "{{env `VMWARE_TOOLS_ISO`}}/windows.iso"
   },


### PR DESCRIPTION
This is a first pass at a slipstreamed .iso for the Win-2012 build
It reduces the number of updates to about 80 rather than 260, thus
reducing the overall Windows Update time during build from about 10
hours to 2 hours.