### PR TITLE
(IMAGES-76) Change Post-Clone to sysprep operation

### DIFF
--- a/scripts/windows/cleanup-host.ps1
+++ b/scripts/windows/cleanup-host.ps1
@@ -33,6 +33,9 @@ if ($env:ChocolateyBinRoot -ne '' -and $env:ChocolateyBinRoot -ne $null) { Remov
 if ($env:ChocolateyToolsRoot -ne '' -and $env:ChocolateyToolsRoot -ne $null) { Remove-Item -Recurse -Force "$env:ChocolateyToolsRoot" }
 [System.Environment]::SetEnvironmentVariable("ChocolateyBinRoot", $null, 'User')
 [System.Environment]::SetEnvironmentVariable("ChocolateyToolsLocation", $null, 'User')
+# Stray key that also needs removed to clean Chocolatey
+reg.exe delete "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" /v "ChocolateyInstall" /f
+
 
 # Clean up files
 Write-Host "Clearing Files"

--- a/scripts/windows/init/post-clone-configuration.ps1
+++ b/scripts/windows/init/post-clone-configuration.ps1
@@ -11,6 +11,9 @@ function ExitScript([int]$ExitCode){
 	exit $ExitCode
 }
 
+# One off registry fix for background which isn't copied correctly from Default User profile
+reg.exe ADD "HKCU\Control Panel\Colors" /v "Background" /t REG_SZ /d "10 59 118" /f
+
 # First things first - resync time to make sure we aren't using ESX/VMware time (RE-8033)
 Write-Host "Resyncing Time"
 w32tm /resync

--- a/scripts/windows/init/vmpooler-clone-arm-runonce.reg
+++ b/scripts/windows/init/vmpooler-clone-arm-runonce.reg
@@ -1,4 +1,4 @@
 Windows Registry Editor Version 5.00
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce]
-"Host Rename Script"="c:\\WINDOWS\\system32\\WindowsPowerShell\\v1.0\\powershell.exe -noprofile -sta -WindowStyle Hidden -file C:\\Packer\\Init\\post-clone-run-once.ps1"
+"Sysprep Command"="C:\\Windows\\System32\\sysprep\\sysprep /generalize /oobe /reboot /quiet /unattend:C:\\Packer\\Init\\post-clone.autounattend.xml"

--- a/scripts/windows/windows-env.ps1
+++ b/scripts/windows/windows-env.ps1
@@ -61,7 +61,6 @@ param (
 # As noted elsewhere, the intention to to replace all Powershell registry calls with Puppet code
 
 Function Set-UserKey($key,$valuename,$reg_type,$data) {
-  Write-Host "Setting user registry entry: $key\$valuename"
-  reg.exe ADD "HKCU\$key" /v "$valuename" /t $reg_type /d $data /f
+  Write-Host "Setting Default User registry entry: $key\$valuename"
   reg.exe ADD "HKLM\DEFUSER\$key" /v "$valuename" /t $reg_type /d $data /f
 }

--- a/templates/windows-2012/files/post-clone.autounattend.xml
+++ b/templates/windows-2012/files/post-clone.autounattend.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns="urn:schemas-microsoft-com:unattend">
+    <settings pass="oobeSystem">
+        <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <InputLocale>en-US</InputLocale>
+            <SystemLocale>en-US</SystemLocale>
+            <UILanguage>en-US</UILanguage>
+            <UserLocale>en-US</UserLocale>
+        </component>
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <FirstLogonCommands>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File C:\Packer\Init\post-clone-configuration.ps1</CommandLine>
+                    <Description>Post Clone configuration</Description>
+                    <Order>1</Order>
+                </SynchronousCommand>
+            </FirstLogonCommands>
+            <OOBE>
+                <HideEULAPage>true</HideEULAPage>
+                <HideLocalAccountScreen>true</HideLocalAccountScreen>
+                <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>
+                <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+                <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+                <NetworkLocation>Work</NetworkLocation>
+                <ProtectYourPC>1</ProtectYourPC>
+            </OOBE>
+            <RegisteredOwner />
+            <ProductKey>XC9B7-NBPP2-83J2H-RHMBY-92BT4</ProductKey>
+            <UserAccounts>
+                <LocalAccounts>
+                    <LocalAccount wcm:action="add">
+                        <Password>
+                            <Value>PackerAdmin</Value>
+                            <PlainText>true</PlainText>
+                        </Password>
+                        <Description>Local Administrator</Description>
+                        <DisplayName>Administrator</DisplayName>
+                        <Group>Administrators</Group>
+                        <Name>Administrator</Name>
+                    </LocalAccount>
+                </LocalAccounts>
+                <AdministratorPassword>
+                    <Value>PackerAdmin</Value>
+                    <PlainText>true</PlainText>
+                </AdministratorPassword>
+            </UserAccounts>
+            <AutoLogon>
+                <Password>
+                    <Value>PackerAdmin</Value>
+                    <PlainText>true</PlainText>
+                </Password>
+                <Domain>.</Domain>
+                <Enabled>true</Enabled>
+                <LogonCount>99999</LogonCount>
+                <Username>Administrator</Username>
+            </AutoLogon>
+        </component>
+    </settings>
+</unattend>

--- a/templates/windows-2012/x86_64.vmware.base.json
+++ b/templates/windows-2012/x86_64.vmware.base.json
@@ -59,6 +59,7 @@
         "ethernet0.virtualdev" : "vmxnet3",
         "scsi0.virtualdev": "lsisas1068",
         "virtualHW.version": "10",
+        "devices.hotplug": "false",
 
         "vcpu.hotadd": "TRUE",
         "mem.hotadd": "TRUE",

--- a/templates/windows-2012/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-2012/x86_64.vmware.vsphere.cygwin.json
@@ -151,6 +151,11 @@
       "destination": "C:\\Packer\\Init"
     },
     {
+      "type": "file",
+      "source": "./files/post-clone.autounattend.xml",
+      "destination": "C:\\Packer\\Init\\post-clone.autounattend.xml"
+    },
+    {
       "type": "powershell",
       "inline": [
         "C:\\Packer\\Init\\vmpooler-arm-host.ps1"

--- a/templates/windows-2012/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-2012/x86_64.vmware.vsphere.cygwin.json
@@ -63,6 +63,7 @@
         "ethernet0.virtualdev" : "vmxnet3",
         "scsi0.virtualdev": "lsisas1068",
         "virtualHW.version": "10",
+        "devices.hotplug": "false",
 
         "vcpu.hotadd": "TRUE",
         "mem.hotadd": "TRUE",

--- a/templates/windows-2012r2/files/post-clone.autounattend.xml
+++ b/templates/windows-2012r2/files/post-clone.autounattend.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns="urn:schemas-microsoft-com:unattend">
+    <settings pass="oobeSystem">
+        <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <InputLocale>en-US</InputLocale>
+            <SystemLocale>en-US</SystemLocale>
+            <UILanguage>en-US</UILanguage>
+            <UserLocale>en-US</UserLocale>
+        </component>
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <FirstLogonCommands>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File C:\Packer\Init\post-clone-configuration.ps1</CommandLine>
+                    <Description>Post Clone configuration</Description>
+                    <Order>1</Order>
+                </SynchronousCommand>
+            </FirstLogonCommands>
+            <OOBE>
+                <HideEULAPage>true</HideEULAPage>
+                <HideLocalAccountScreen>true</HideLocalAccountScreen>
+                <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>
+                <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+                <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+                <NetworkLocation>Work</NetworkLocation>
+                <ProtectYourPC>1</ProtectYourPC>
+            </OOBE>
+            <RegisteredOwner />
+            <ProductKey>D2N9P-3P6X9-2R39C-7RTCD-MDVJX</ProductKey>
+            <UserAccounts>
+                <LocalAccounts>
+                    <LocalAccount wcm:action="add">
+                        <Password>
+                            <Value>PackerAdmin</Value>
+                            <PlainText>true</PlainText>
+                        </Password>
+                        <Description>Local Administrator</Description>
+                        <DisplayName>Administrator</DisplayName>
+                        <Group>Administrators</Group>
+                        <Name>Administrator</Name>
+                    </LocalAccount>
+                </LocalAccounts>
+                <AdministratorPassword>
+                    <Value>PackerAdmin</Value>
+                    <PlainText>true</PlainText>
+                </AdministratorPassword>
+            </UserAccounts>
+            <AutoLogon>
+                <Password>
+                    <Value>PackerAdmin</Value>
+                    <PlainText>true</PlainText>
+                </Password>
+                <Domain>.</Domain>
+                <Enabled>true</Enabled>
+                <LogonCount>99999</LogonCount>
+                <Username>Administrator</Username>
+            </AutoLogon>
+        </component>
+    </settings>
+</unattend>

--- a/templates/windows-2012r2/x86_64.vmware.base.json
+++ b/templates/windows-2012r2/x86_64.vmware.base.json
@@ -59,6 +59,7 @@
         "ethernet0.virtualdev" : "vmxnet3",
         "scsi0.virtualdev": "lsisas1068",
         "virtualHW.version": "10",
+        "devices.hotplug": "false",
 
         "vcpu.hotadd": "TRUE",
         "mem.hotadd": "TRUE",

--- a/templates/windows-2012r2/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-2012r2/x86_64.vmware.vsphere.cygwin.json
@@ -151,6 +151,11 @@
       "destination": "C:\\Packer\\Init"
     },
     {
+      "type": "file",
+      "source": "./files/post-clone.autounattend.xml",
+      "destination": "C:\\Packer\\Init\\post-clone.autounattend.xml"
+    },
+    {
       "type": "powershell",
       "inline": [
         "C:\\Packer\\Init\\vmpooler-arm-host.ps1"

--- a/templates/windows-2012r2/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-2012r2/x86_64.vmware.vsphere.cygwin.json
@@ -63,6 +63,7 @@
         "ethernet0.virtualdev" : "vmxnet3",
         "scsi0.virtualdev": "lsisas1068",
         "virtualHW.version": "10",
+        "devices.hotplug": "false",
 
         "vcpu.hotadd": "TRUE",
         "mem.hotadd": "TRUE",

--- a/templates/windows-2016rtm/files/post-clone.autounattend.xml
+++ b/templates/windows-2016rtm/files/post-clone.autounattend.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns="urn:schemas-microsoft-com:unattend">
+    <settings pass="oobeSystem">
+        <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <InputLocale>en-US</InputLocale>
+            <SystemLocale>en-US</SystemLocale>
+            <UILanguage>en-US</UILanguage>
+            <UserLocale>en-US</UserLocale>
+        </component>
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <FirstLogonCommands>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File C:\Packer\Init\post-clone-configuration.ps1</CommandLine>
+                    <Description>Post Clone configuration</Description>
+                    <Order>1</Order>
+                </SynchronousCommand>
+            </FirstLogonCommands>
+            <OOBE>
+                <HideEULAPage>true</HideEULAPage>
+                <HideLocalAccountScreen>true</HideLocalAccountScreen>
+                <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>
+                <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+                <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+                <NetworkLocation>Work</NetworkLocation>
+                <ProtectYourPC>1</ProtectYourPC>
+            </OOBE>
+            <RegisteredOwner />
+            <ProductKey>6XBNX-4JQGW-QX6QG-74P76-72V67</ProductKey>
+            <UserAccounts>
+                <LocalAccounts>
+                    <LocalAccount wcm:action="add">
+                        <Password>
+                            <Value>PackerAdmin</Value>
+                            <PlainText>true</PlainText>
+                        </Password>
+                        <Description>Local Administrator</Description>
+                        <DisplayName>Administrator</DisplayName>
+                        <Group>Administrators</Group>
+                        <Name>Administrator</Name>
+                    </LocalAccount>
+                </LocalAccounts>
+                <AdministratorPassword>
+                    <Value>PackerAdmin</Value>
+                    <PlainText>true</PlainText>
+                </AdministratorPassword>
+            </UserAccounts>
+            <AutoLogon>
+                <Password>
+                    <Value>PackerAdmin</Value>
+                    <PlainText>true</PlainText>
+                </Password>
+                <Domain>.</Domain>
+                <Enabled>true</Enabled>
+                <LogonCount>99999</LogonCount>
+                <Username>Administrator</Username>
+            </AutoLogon>
+        </component>
+    </settings>
+</unattend>

--- a/templates/windows-2016rtm/x86_64.vmware.base.json
+++ b/templates/windows-2016rtm/x86_64.vmware.base.json
@@ -59,6 +59,7 @@
         "ethernet0.virtualdev" : "vmxnet3",
         "scsi0.virtualdev": "lsisas1068",
         "virtualHW.version": "10",
+        "devices.hotplug": "false",
 
         "vcpu.hotadd": "TRUE",
         "mem.hotadd": "TRUE",

--- a/templates/windows-2016rtm/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-2016rtm/x86_64.vmware.vsphere.cygwin.json
@@ -62,6 +62,7 @@
         "ethernet0.virtualdev" : "vmxnet3",
         "scsi0.virtualdev": "lsisas1068",
         "virtualHW.version": "10",
+        "devices.hotplug": "false",
 
         "vcpu.hotadd": "TRUE",
         "mem.hotadd": "TRUE",

--- a/templates/windows-2016rtm/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-2016rtm/x86_64.vmware.vsphere.cygwin.json
@@ -150,6 +150,11 @@
       "destination": "C:\\Packer\\Init"
     },
     {
+      "type": "file",
+      "source": "./files/post-clone.autounattend.xml",
+      "destination": "C:\\Packer\\Init\\post-clone.autounattend.xml"
+    },
+    {
       "type": "powershell",
       "inline": [
         "C:\\Packer\\Init\\vmpooler-arm-host.ps1"


### PR DESCRIPTION
The Run Once key in the registry is armed to execute a sysprep command
which runs the sysprep and then the post-clone configuration script.

Add unattended file for all current OS along with an update to the
vsphere json file to upload the unattended file

Removed HKCU registry key configuration to since Default User keys will
now be used to create the Administrator Profile after the sysprep.
Needed to add one registry fix to the post-clone-config to correct the
background screen setting.