### PR TITLE
(IMAGES-7832) Add Win-2008R2 Base and Cygwin Templates to packer

### DIFF
--- a/manifests/windows/windows_group_policy/templates/local_gpo.ps1
+++ b/manifests/windows/windows_group_policy/templates/local_gpo.ps1
@@ -14,10 +14,15 @@ $PolicyValueType = '<%= @type %>'
 
 $vp = $VerbosePreference
 $VerbosePreference = 'SilentlyContinue'
-# To import on PowerShell v3, you can use this command:
-Add-Type -Language CSharp -TypeDefinition $PolFileEditorCS -ErrorAction Stop
-# To make it work on PowerShell v2, use this command instead:
-# Add-Type -Language CSharpVersion3 -TypeDefinition $PolFileEditorCS -ErrorAction Stop
+
+if ($psversiontable.psversion.major -eq 2) {
+  # To make it work on PowerShell v2, use this command instead:
+  Add-Type -Language CSharpVersion3 -TypeDefinition $PolFileEditorCS -ErrorAction Stop
+}
+else {
+  # To import on PowerShell v3, you can use this command:
+  Add-Type -Language CSharp -TypeDefinition $PolFileEditorCS -ErrorAction Stop
+}
 $VerbosePreference = $vp
 
 function Compare-PolicyValueIsSameAs($objPolicyEntry,$value) {
@@ -50,7 +55,7 @@ function Set-PolicySetting($objPolicy) {
   Write-Verbose "Saving the registry pol file"
   $objPolicy.SaveFile() | Out-Null
 
-  return Invoke-IncrementGPTVersion 
+  return Invoke-IncrementGPTVersion
 }
 
 function Open-PolicyFile([string]$policyFilePath = '', [bool]$createIfNotExist = $true) {

--- a/manifests/windows/windows_group_policy/templates/local_gpo.ps1
+++ b/manifests/windows/windows_group_policy/templates/local_gpo.ps1
@@ -17,7 +17,31 @@ $VerbosePreference = 'SilentlyContinue'
 
 if ($psversiontable.psversion.major -eq 2) {
   # To make it work on PowerShell v2, use this command instead:
-  Add-Type -Language CSharpVersion3 -TypeDefinition $PolFileEditorCS -ErrorAction Stop
+  #    Add-Type -Language CSharpVersion3 -TypeDefinition $PolFileEditorCS -ErrorAction Stop
+  # So in the PowerShell Module (v1.0.6) uses STDIN redirection which mucks up the Add-Type call.  Go Figure!
+  # Instead we need to precompile the DLL by calling CSC.EXE directly AND not using the same console process as powershell, and then import that instead.
+  # Also, you can not use Add-Type -Path as it will try to use .Net 2.0 instead of 3.x/4.x as Powershell 2.0 uses .Net 2.0 by default.
+
+  $tempDLLPath = Join-Path -Path $ENV:Temp -ChildPath "PolFileEditor.dll"
+  $tempSourcePath = Join-Path -Path $ENV:Temp -ChildPath "PolFileEditor.cs"
+
+  if (Test-Path -Path $tempDLLPath) { Remove-Item $tempDLLPath -Confirm:$false -Force | Out-Null }
+  if (Test-Path -Path $tempSourcePath) { Remove-Item $tempSourcePath -Confirm:$false -Force | Out-Null }
+  
+  Write-Verbose "Creating temporary DLL from source..."
+  $cscDir = "$($ENV:WINDIR)\Microsoft.NET\Framework\v3.5\csc.exe"
+  if (-not (Test-Path -Path $cscDir)) { Throw "Could not find .Net Framework 3.5 installation" }
+  $PolFileEditorCS | Set-Content $tempSourcePath
+  Start-Process -FilePath $cscDir -Wait -NoNewWindow:$false -ArgumentList @('/target:library',"`"/out:$($tempDLLPath)`"","`"$($tempSourcePath)`"") 
+
+  # Cleanup
+  Remove-Item $tempSourcePath -Confirm:$false -Force | Out-Null
+
+  # Sanity Check
+  if (-not (Test-Path -Path $tempDLLPath)) { Throw "Failed to generate the temporary DLL" }
+
+  # Import the type
+  Add-Type -Path $tempDLLPath -ErrorAction Stop
 }
 else {
   # To import on PowerShell v3, you can use this command:

--- a/templates/windows-2008r2/README.md
+++ b/templates/windows-2008r2/README.md
@@ -1,0 +1,16 @@
+# puppetlabs-packer
+
+### About
+
+This is the Windows 2012 Packer Template
+
+### VM settings
+
+
+## Documentation
+
+The Confluence Documentation for the process is at [Windows/Packer Imaging Process](https://confluence.puppetlabs.com/display/QE/Packer+Generation+of+Windows+Templates+for+VMPooler)
+
+### Issues
+
+Please open any issues within the CPR ( Community Package Repository ) project on the [Puppet Labs issue tracker](https://tickets.puppetlabs.com/browse/CPR).

--- a/templates/windows-2008r2/files/autounattend.xml
+++ b/templates/windows-2008r2/files/autounattend.xml
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns="urn:schemas-microsoft-com:unattend">
+    <servicing/>
+    <settings pass="windowsPE">
+        <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <SetupUILanguage>
+                <UILanguage>en-US</UILanguage>
+            </SetupUILanguage>
+            <InputLocale>en-US</InputLocale>
+            <SystemLocale>en-US</SystemLocale>
+            <UILanguage>en-US</UILanguage>
+            <UILanguageFallback>en-US</UILanguageFallback>
+            <UserLocale>en-US</UserLocale>
+        </component>
+        <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <DiskConfiguration>
+                <Disk wcm:action="add">
+                    <DiskID>0</DiskID>
+                    <WillWipeDisk>true</WillWipeDisk>
+                    <CreatePartitions>
+                        <!-- EFI system partition (ESP) -->
+                        <CreatePartition wcm:action="add">
+                            <Order>1</Order>
+                            <Type>EFI</Type>
+                            <Size>100</Size>
+                        </CreatePartition>
+                        <!-- Microsoft reserved partition (MSR) -->
+                        <CreatePartition wcm:action="add">
+                            <Order>2</Order>
+                            <Type>MSR</Type>
+                            <Size>128</Size>
+                        </CreatePartition>
+                        <!-- Windows partition -->
+                        <!-- Only Allocate 20G initially - rest will be allocated near end of prep -->
+                        <CreatePartition wcm:action="add">
+                            <Order>3</Order>
+                            <Type>Primary</Type>
+                            <Extend>false</Extend>
+                            <Size>32212</Size>
+                        </CreatePartition>
+                    </CreatePartitions>
+                    <ModifyPartitions>
+                        <!-- EFI system partition (ESP) -->
+                        <ModifyPartition wcm:action="add">
+                            <Order>1</Order>
+                            <PartitionID>1</PartitionID>
+                            <Label>System</Label>
+                            <Format>FAT32</Format>
+                        </ModifyPartition>
+                        <!-- Windows partition -->
+                        <ModifyPartition wcm:action="add">
+                            <Order>2</Order>
+                            <PartitionID>3</PartitionID>
+                            <Label>Windows w2008R2</Label>
+                            <Letter>C</Letter>
+                            <Format>NTFS</Format>
+                        </ModifyPartition>
+                    </ModifyPartitions>
+                </Disk>
+                <WillShowUI>OnError</WillShowUI>
+            </DiskConfiguration>
+            <ImageInstall>
+                <OSImage>
+                    <InstallFrom>
+                        <MetaData wcm:action="add">
+                            <Key>/IMAGE/NAME</Key>
+                            <Value>Windows Server 2008 R2 SERVERSTANDARD</Value>
+                        </MetaData>
+                    </InstallFrom>
+                    <InstallTo>
+                        <DiskID>0</DiskID>
+                        <PartitionID>3</PartitionID>
+                    </InstallTo>
+                </OSImage>
+            </ImageInstall>
+            <UserData>
+                <!-- Product Key from http://technet.microsoft.com/en-us/library/jj612867.aspx -->
+                <ProductKey>
+                    <!-- Do not uncomment the Key element if you are using trial ISOs -->
+                    <!-- KMS Setup keys  https://technet.microsoft.com/en-us/library/jj612867.aspx -->
+                    <Key>YC6KT-GKW9T-YTKYR-T4X34-R7VHC</Key>
+                    <WillShowUI>OnError</WillShowUI>
+                </ProductKey>
+                <AcceptEula>true</AcceptEula>
+                <FullName>Puppet Labs</FullName>
+                <Organization>Puppet Labs</Organization>
+            </UserData>
+        </component>
+    </settings>
+    <settings pass="specialize">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <OEMInformation>
+                <HelpCustomized>false</HelpCustomized>
+            </OEMInformation>
+            <ComputerName>*</ComputerName>
+            <TimeZone>UTC</TimeZone>
+            <RegisteredOwner />
+            <AutoLogon>
+                <Password>
+                    <Value>PackerAdmin</Value>
+                    <PlainText>true</PlainText>
+                </Password>
+                <Enabled>true</Enabled>
+                <Username>Administrator</Username>
+                <Domain>.</Domain>
+                <LogonCount>999</LogonCount>
+            </AutoLogon>
+        </component>
+        <component name="Microsoft-Windows-ServerManager-SvrMgrNc" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <DoNotOpenServerManagerAtLogon>true</DoNotOpenServerManagerAtLogon>
+        </component>
+        <component name="Microsoft-Windows-IE-ESC" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <IEHardenAdmin>false</IEHardenAdmin>
+            <IEHardenUser>false</IEHardenUser>
+        </component>
+        <component name="Microsoft-Windows-Security-SPP-UX" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <SkipAutoActivation>true</SkipAutoActivation>
+        </component>
+    </settings>
+    <settings pass="oobeSystem">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <UserAccounts>
+                <LocalAccounts>
+                    <LocalAccount wcm:action="add">
+                        <Password>
+                            <Value>PackerAdmin</Value>
+                            <PlainText>true</PlainText>
+                        </Password>
+                        <Group>Administrators</Group>
+                        <DisplayName>Administrator</DisplayName>
+                        <Name>Administrator</Name>
+                        <Description>Local Administrator</Description>
+                    </LocalAccount>
+                </LocalAccounts>
+            </UserAccounts>
+            <FirstLogonCommands>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c A:\bootstrap-base.bat</CommandLine>
+                    <Description>Bootstrap for everything</Description>
+                    <Order>1</Order>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c start /wait E:\setup64.exe /s /v "/qn reboot=r"</CommandLine>
+                    <Description>Install VMWare Tools (and drivers)</Description>
+                    <Order>2</Order>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c wmic useraccount where "name='Administrator'" set PasswordExpires=FALSE</CommandLine>
+                    <Description>Disable Administrator Password reset</Description>
+                    <Order>3</Order>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c A:\generalize-packer.bat</CommandLine>
+                    <Description>Sysprep generalize</Description>
+                    <Order>4</Order>
+                </SynchronousCommand>
+            </FirstLogonCommands>
+            <OOBE>
+                <HideEULAPage>true</HideEULAPage>
+                <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+                <NetworkLocation>Home</NetworkLocation>
+                <ProtectYourPC>1</ProtectYourPC>
+            </OOBE>
+            <RegisteredOwner />
+        </component>
+    </settings>
+    <settings pass="offlineServicing">
+        <component name="Microsoft-Windows-LUA-Settings" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <EnableLUA>false</EnableLUA>
+        </component>
+        <!-- Added for driver injection. Typically for NICs and Mass Storage -->
+        <component name="Microsoft-Windows-PnpCustomizationsNonWinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <DriverPaths>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="0">
+                    <Path>A:\</Path>
+                </PathAndCredentials>
+            </DriverPaths>
+        </component>
+    </settings>
+    <settings pass="auditSystem">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <UserAccounts>
+                <AdministratorPassword>
+                    <Value>PackerAdmin</Value>
+                    <PlainText>true</PlainText>
+                </AdministratorPassword>
+            </UserAccounts>
+            <AutoLogon>
+                <Password>
+                    <Value>PackerAdmin</Value>
+                    <PlainText>true</PlainText>
+                </Password>
+                <Domain>.</Domain>
+                <Enabled>true</Enabled>
+                <LogonCount>999</LogonCount>
+                <Username>Administrator</Username>
+            </AutoLogon>
+        </component>
+    </settings>
+</unattend>

--- a/templates/windows-2008r2/files/config-vmware-vsphere-cygwin.ps1
+++ b/templates/windows-2008r2/files/config-vmware-vsphere-cygwin.ps1
@@ -1,0 +1,123 @@
+# Registry and other settings that are easier done outside puppet for the moment.
+# These tend to be OS specific so will be left in the OS area.
+#
+$ErrorActionPreference = "Stop"
+
+. A:\windows-env.ps1
+
+# Some other quick win settings provided by Boxstarter
+# Although this is no longer run under boxstarter, we are still able to use it's cmdlets.
+Write-Host "Other Stuff......."
+
+# Enable Bootlog
+Write-Host "Enable Bootlog"
+cmd /c "bcdedit /set {current} bootlog yes"
+
+#Disable UAC for Windows-2012
+#Disable-UAC
+
+# Enable Remote Desktop (with reduce authentication resetting here again)
+Enable-RemoteDesktop -DoNotRequireUserLevelAuthentication
+
+#######################################################################################################################
+# Ideally these registry settings would be done through puppet.
+# Unfortunately there is a puppet registry module restriction on manipulating HKCU, so need to use
+# Powershell commands here instead.
+# TODO Migrate these to the puppet settings once the HKCU restriction is removed.
+#######################################################################################################################
+
+# Load Default User for registry to accomodate changes.
+# All HKCU changes are replicated for the default user.
+reg.exe load HKLM\DEFUSER c:\users\default\ntuser.dat
+
+# Set IE Home Page for this and Default User.
+Write-Host "Setting IE Home Page"
+Set-UserKey 'Software\Microsoft\Internet Explorer\Main' 'Start Page' 'REG_SZ' 'about:blank'
+
+# UI and desktop settings (note classic is enforced by Group policy")
+# Set Visual Effects for Best Performance
+Write-Host "Setting Visual Effects to Best Performance"
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects' 'VisualFXSetting' 'REG_DWORD' 2
+
+# Set solid color background - blueish
+Write-Host "Setting Solid background colour"
+Set-UserKey 'Control Panel\Colors' 'Background' 'REG_SZ' '"10 59 118"'
+Set-UserKey 'Control Panel\Colors' 'Wallpaper' 'REG_SZ' '""'
+
+# Start Menu Options
+Write-Host "Setting Start Menu Options"
+# Control panel start-menu cascading doesn't appear to be available in W 2012
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\ControlPanel' 'AllItemsIconView' 'REG_DWORD' 1
+
+# Icon Notification Tray - enable all notifications for the moment.
+# Setting as per spec is tricky (see RE-7692)
+Write-Host "Enabling all notification icons"
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer' 'EnableAutoTray' 'REG_DWORD' 0
+
+# Set Explorer UI settings
+Write-Host "Setting Explorer and Taskbar UI Settings..."
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'AlwaysShowMenus'       'REG_DWORD' 1
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'AutoCheckSelect'       'REG_DWORD' 0
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'DisablePreviewDesktop' 'REG_DWORD' 1
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'DontPrettyPath'        'REG_DWORD' 0
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'Filter'                'REG_DWORD' 0
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'Hidden'                'REG_DWORD' 1
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'HideDrivesWithNoMedia' 'REG_DWORD' 0
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'HideFileExt'           'REG_DWORD' 0
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'HideIcons'             'REG_DWORD' 0
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'HideMergeConflicts'    'REG_DWORD' 0
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'IconsOnly'             'REG_DWORD' 1
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'ListviewAlphaSelect'   'REG_DWORD' 0
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'ListviewShadow'        'REG_DWORD' 0
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'ListviewWatermark'     'REG_DWORD' 0
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'MapNetDrvBtn'          'REG_DWORD' 0
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'SeparateProcess'       'REG_DWORD' 0
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'ServerAdminUI'         'REG_DWORD' 1
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'ShowCompColor'         'REG_DWORD' 1
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'ShowInfoTip'           'REG_DWORD' 1
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'ShowStatusBar'         'REG_DWORD' 1
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'ShowSuperHidden'       'REG_DWORD' 1
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'ShowTypeOverlay'       'REG_DWORD' 1
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'Start_SearchFiles'     'REG_DWORD' 1
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'StartMenuAdminTools'   'REG_DWORD' 1
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'StartMenuInit'         'REG_DWORD' 6
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'StoreAppsOnTaskbar'    'REG_DWORD' 1
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'TaskbarAnimations'     'REG_DWORD' 0
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'TaskbarGlomLevel'      'REG_DWORD' 1
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'TaskbarSizeMove'       'REG_DWORD' 1
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'TaskbarSmallIcons'     'REG_DWORD' 0
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'WebView'               'REG_DWORD' 1
+
+# Set FullPath to be displayed in the window title bar
+Write-Host "Setting Full Path to be displayed on title bars..."
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\CabinetState' 'FullPath'          'REG_DWORD' 1
+
+# Set some UI acceleration features to tune down all of the fancy animations etc..
+Write-Host "Disabling fancy UI animations..."
+Set-UserKey 'Control Panel\Desktop'               'DragFullWindows'           'REG_SZ'      '0'
+Set-UserKey 'Control Panel\Desktop'               'FontSmoothing'             'REG_SZ'      '0'
+Set-UserKey 'Control Panel\Desktop'               'UserPreferencesMask'       'REG_BINARY' '9000038010000000'
+Set-UserKey 'Control Panel\Desktop\WindowMetrics' 'MinAnimate'                'REG_SZ'      '0'
+Set-UserKey 'Software\Microsoft\Windows\DWM'      'AlwaysHibernateThumbnails' 'REG_DWORD'   0
+Set-UserKey 'Software\Microsoft\Windows\DWM'      'EnableAeroPeek'            'REG_DWORD'   0
+
+# Unload default user.
+reg.exe unload HKLM\DEFUSER
+
+# Set the Security Policies
+Write-Host "Setting Low Security Password Policies"
+secedit /configure /db secedit.sdb /cfg A:\Low-SecurityPasswordPolicy.inf /quiet
+
+# Configure WinRM - (Final configuration)
+Write-Host "Configuring WinRM"
+winrm quickconfig -force
+winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="1024"}'
+winrm set winrm/config '@{MaxTimeoutms="1800000"}'
+winrm set winrm/config/service '@{AllowUnencrypted="true"}'
+winrm set winrm/config/service/auth '@{Basic="true"}'
+
+# Add permissive Firewall rules (RE-7516) - This is preferred to disabling the firewall
+netsh advfirewall firewall add rule name="All Incoming" dir=in action=allow enable=yes interfacetype=any profile=any localip=any remoteip=any
+netsh advfirewall firewall add rule name="All Outgoing" dir=out action=allow enable=yes interfacetype=any profile=any localip=any remoteip=any
+
+# End

--- a/templates/windows-2008r2/files/generalize-packer.autounattend.xml
+++ b/templates/windows-2008r2/files/generalize-packer.autounattend.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns="urn:schemas-microsoft-com:unattend">
+    <settings pass="windowsPE">
+        <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <UserData>
+                <!-- Product Key from http://technet.microsoft.com/en-us/library/jj612867.aspx -->
+                <ProductKey>
+                    <!-- Do not uncomment the Key element if you are using trial ISOs -->
+                    <!-- KMS Setup keys  https://technet.microsoft.com/en-us/library/jj612867.aspx -->
+                    <Key>YC6KT-GKW9T-YTKYR-T4X34-R7VHC</Key>
+                    <WillShowUI>OnError</WillShowUI>
+                </ProductKey>
+                <AcceptEula>true</AcceptEula>
+                <FullName>Puppet Labs</FullName>
+                <Organization>Puppet Labs</Organization>
+            </UserData>
+        </component>
+    </settings>
+    <settings pass="specialize">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <OEMInformation>
+                <HelpCustomized>false</HelpCustomized>
+            </OEMInformation>
+            <ComputerName>*</ComputerName>
+            <TimeZone>UTC</TimeZone>
+            <RegisteredOwner />
+            <ShowWindowsLive>false</ShowWindowsLive>
+            <CopyProfile>true</CopyProfile>
+            <ProductKey>YC6KT-GKW9T-YTKYR-T4X34-R7VHC</ProductKey>
+        </component>
+        <component name="Microsoft-Windows-ServerManager-SvrMgrNc" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <DoNotOpenServerManagerAtLogon>true</DoNotOpenServerManagerAtLogon>
+        </component>
+        <component name="Microsoft-Windows-IE-ESC" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <IEHardenAdmin>false</IEHardenAdmin>
+            <IEHardenUser>false</IEHardenUser>
+        </component>
+        <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <RunSynchronous>
+                <RunSynchronousCommand wcm:action="add">
+                    <Path>net user administrator /active:yes</Path>
+                    <Order>1</Order>
+                </RunSynchronousCommand>
+            </RunSynchronous>
+        </component>
+        <component name="Microsoft-Windows-Security-SPP-UX" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <SkipAutoActivation>true</SkipAutoActivation>
+        </component>
+    </settings>
+    <settings pass="oobeSystem">
+        <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <InputLocale>en-US</InputLocale>
+            <SystemLocale>en-US</SystemLocale>
+            <UILanguage>en-US</UILanguage>
+            <UserLocale>en-US</UserLocale>
+        </component>
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <FirstLogonCommands>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c A:\bootstrap-base.bat</CommandLine>
+                    <Description>Bootstrap for everything</Description>
+                    <Order>1</Order>
+                    <RequiresUserInput>false</RequiresUserInput>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\start-boxstarter.ps1</CommandLine>
+                    <Description>Start BoxStarter</Description>
+                    <Order>4</Order>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>wmic useraccount where &quot;name=&apos;Administrator&apos;&quot; set PasswordExpires=FALSE</CommandLine>
+                    <Order>2</Order>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd /C start /wait NET ACCOUNTS /MAXPWAGE:UNLIMITED</CommandLine>
+                    <Order>3</Order>
+                </SynchronousCommand>
+            </FirstLogonCommands>
+            <OOBE>
+                <HideEULAPage>true</HideEULAPage>
+                <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+                <NetworkLocation>Work</NetworkLocation>
+                <ProtectYourPC>1</ProtectYourPC>
+            </OOBE>
+            <RegisteredOwner />
+            <UserAccounts>
+                <LocalAccounts>
+                    <LocalAccount wcm:action="add">
+                        <Password>
+                            <Value>PackerAdmin</Value>
+                            <PlainText>true</PlainText>
+                        </Password>
+                        <Description>Local Administrator</Description>
+                        <DisplayName>Administrator</DisplayName>
+                        <Group>Administrators</Group>
+                        <Name>Administrator</Name>
+                    </LocalAccount>
+                </LocalAccounts>
+                <AdministratorPassword>
+                    <Value>PackerAdmin</Value>
+                    <PlainText>true</PlainText>
+                </AdministratorPassword>
+            </UserAccounts>
+            <AutoLogon>
+                <Password>
+                    <Value>PackerAdmin</Value>
+                    <PlainText>true</PlainText>
+                </Password>
+                <Domain>.</Domain>
+                <Enabled>true</Enabled>
+                <LogonCount>99999</LogonCount>
+                <Username>Administrator</Username>
+            </AutoLogon>
+        </component>
+    </settings>
+    <settings pass="offlineServicing">
+        <component name="Microsoft-Windows-LUA-Settings" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <EnableLUA>false</EnableLUA>
+        </component>
+        <!-- Added for driver injection. Typically for NICs and Mass Storage -->
+        <component name="Microsoft-Windows-PnpCustomizationsNonWinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <DriverPaths>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="0">
+                    <Path>A:\</Path>
+                </PathAndCredentials>
+            </DriverPaths>
+        </component>
+    </settings>
+    <settings pass="auditUser">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <RegisteredOwner />
+        </component>
+    </settings>
+    <settings pass="generalize">
+        <component name="Microsoft-Windows-Security-SPP" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <SkipRearm>8</SkipRearm>
+        </component>
+    </settings>
+    <cpi:offlineImage cpi:source="wim:c:/15bcc9dfbc0eebf6f640cf0419b697269c84eece8486f4531beb4ad606410664/sources/install.wim#Windows Server 2012 R2 SERVERSTANDARD" xmlns:cpi="urn:schemas-microsoft-com:cpi" />
+</unattend>

--- a/templates/windows-2008r2/files/post-clone.autounattend.xml
+++ b/templates/windows-2008r2/files/post-clone.autounattend.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns="urn:schemas-microsoft-com:unattend">
+    <settings pass="oobeSystem">
+        <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <InputLocale>en-US</InputLocale>
+            <SystemLocale>en-US</SystemLocale>
+            <UILanguage>en-US</UILanguage>
+            <UserLocale>en-US</UserLocale>
+        </component>
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <FirstLogonCommands>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File C:\Packer\Init\post-clone-configuration.ps1</CommandLine>
+                    <Description>Post Clone configuration</Description>
+                    <Order>1</Order>
+                </SynchronousCommand>
+            </FirstLogonCommands>
+            <OOBE>
+                <HideEULAPage>true</HideEULAPage>
+                <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+                <NetworkLocation>Work</NetworkLocation>
+                <ProtectYourPC>1</ProtectYourPC>
+            </OOBE>
+            <RegisteredOwner />
+            <ProductKey>YC6KT-GKW9T-YTKYR-T4X34-R7VHC</ProductKey>
+            <UserAccounts>
+                <LocalAccounts>
+                    <LocalAccount wcm:action="add">
+                        <Password>
+                            <Value>PackerAdmin</Value>
+                            <PlainText>true</PlainText>
+                        </Password>
+                        <Description>Local Administrator</Description>
+                        <DisplayName>Administrator</DisplayName>
+                        <Group>Administrators</Group>
+                        <Name>Administrator</Name>
+                    </LocalAccount>
+                </LocalAccounts>
+                <AdministratorPassword>
+                    <Value>PackerAdmin</Value>
+                    <PlainText>true</PlainText>
+                </AdministratorPassword>
+            </UserAccounts>
+            <AutoLogon>
+                <Password>
+                    <Value>PackerAdmin</Value>
+                    <PlainText>true</PlainText>
+                </Password>
+                <Domain>.</Domain>
+                <Enabled>true</Enabled>
+                <LogonCount>99999</LogonCount>
+                <Username>Administrator</Username>
+            </AutoLogon>
+        </component>
+    </settings>
+</unattend>

--- a/templates/windows-2008r2/files/win-2008r2-x86_64-std.pp
+++ b/templates/windows-2008r2/files/win-2008r2-x86_64-std.pp
@@ -1,0 +1,3 @@
+include windows_template::local_group_policies
+include windows_template::chrome
+include windows_template::configure_services

--- a/templates/windows-2008r2/files/windows-2008r2-x86_64-vmware.package.ps1
+++ b/templates/windows-2008r2/files/windows-2008r2-x86_64-vmware.package.ps1
@@ -18,6 +18,9 @@ Write-BoxstarterMessage "Enable Remote-Desktop"
 Enable-RemoteDesktop
 netsh advfirewall firewall add rule name="Remote Desktop" dir=in localport=3389 protocol=TCP action=allow
 
+# Enable .Net 3.5 (needed for Puppet csc compiles)
+DISM /Online /Enable-Feature /FeatureName:NetFx3
+
 # Install .Net Framework 4.5.2
 Write-BoxstarterMessage "Installing .Net 4.5"
 choco install dotnet4.5 -y
@@ -64,6 +67,7 @@ Write-BoxstarterMessage "WinRM Settings"
 winrm set winrm/config/client/auth '@{Basic="true"}'
 winrm set winrm/config/service/auth '@{Basic="true"}'
 winrm set winrm/config/service '@{AllowUnencrypted="true"}'
+winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="2048"}'
 Write-BoxstarterMessage "WinRM setup complete"
 
 # Re-Enable AutoAdminLogon

--- a/templates/windows-2008r2/files/windows-2008r2-x86_64-vmware.package.ps1
+++ b/templates/windows-2008r2/files/windows-2008r2-x86_64-vmware.package.ps1
@@ -1,0 +1,75 @@
+$ErrorActionPreference = "Stop"
+
+. A:\windows-env.ps1
+
+# Boxstarter options
+$Boxstarter.RebootOk=$true # Allow reboots?
+$Boxstarter.NoPassword=$false # Is this a machine with no login password?
+$Boxstarter.AutoLogin=$true # Save my password securely and auto-login after a reboot
+
+if (Test-PendingReboot){ Invoke-Reboot }
+
+Write-BoxstarterMessage "Disabling Hiberation..."
+Set-ItemProperty -Path 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Power' -Name 'HibernateFileSizePercent' -Value 0
+Set-ItemProperty -Path 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Power' -Name 'HibernateEnabled' -Value 0
+
+# Enable RDP
+Write-BoxstarterMessage "Enable Remote-Desktop"
+Enable-RemoteDesktop
+netsh advfirewall firewall add rule name="Remote Desktop" dir=in localport=3389 protocol=TCP action=allow
+
+# Install .Net Framework 4.5.2
+Write-BoxstarterMessage "Installing .Net 4.5"
+choco install dotnet4.5 -y
+if (Test-PendingReboot) { Invoke-Reboot }
+
+# Install Updates and reboot until this is completed.
+Install-WindowsUpdate -AcceptEula
+if (Test-PendingReboot) { Invoke-Reboot }
+
+# Remove the pagefile
+Write-BoxstarterMessage "Removing page file.  Recreates on next boot"
+$pageFileMemoryKey = "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management"
+Set-ItemProperty -Path $pageFileMemoryKey -Name PagingFiles -Value ""
+
+# Add WinRM Firewall Rule
+Write-BoxstarterMessage "Adding Firewall rules for win-rm"
+netsh advfirewall firewall add rule name="WinRM-HTTP" dir=in localport=5985 protocol=TCP action=allow
+
+Write-BoxstarterMessage "Setup PSRemoting"
+$enableArgs=@{Force=$true}
+try {
+ $command=Get-Command Enable-PSRemoting
+  if($command.Parameters.Keys -contains "skipnetworkprofilecheck"){
+      $enableArgs.skipnetworkprofilecheck=$true
+  }
+}
+catch {
+  $global:error.RemoveAt(0)
+}
+Write-BoxstarterMessage "Enable PS-Remoting -Force"
+try {
+  Enable-PSRemoting @enableArgs
+}
+catch {
+  Write-BoxstarterMessage "Ignoring PSRemoting Error"
+}
+
+Write-BoxstarterMessage "Enable WSMandCredSSP"
+Enable-WSManCredSSP -Force -Role Server
+
+
+# NOTE - This is insecure but can be shored up in later customisation.  Required for Vagrant and other provisioning tools
+Write-BoxstarterMessage "WinRM Settings"
+winrm set winrm/config/client/auth '@{Basic="true"}'
+winrm set winrm/config/service/auth '@{Basic="true"}'
+winrm set winrm/config/service '@{AllowUnencrypted="true"}'
+Write-BoxstarterMessage "WinRM setup complete"
+
+# Re-Enable AutoAdminLogon
+$WinlogonPath = "HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Winlogon"
+Set-ItemProperty -Path $WinlogonPath -Name AutoAdminLogon -Value "1" -ErrorAction SilentlyContinue
+Set-ItemProperty -Path $WinlogonPath -Name DefaultUserName -Value "Administrator" -ErrorAction SilentlyContinue
+Set-ItemProperty -Path $WinlogonPath -Name DefaultPassword -Value "PackerAdmin" -ErrorAction SilentlyContinue
+
+# End

--- a/templates/windows-2008r2/x86_64.vmware.base.json
+++ b/templates/windows-2008r2/x86_64.vmware.base.json
@@ -1,0 +1,96 @@
+{
+  "variables": {
+    "template_name": "windows-2008r2-x86_64",
+
+    "provisioner": "vmware",
+    "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2008_r2_with_sp1_x64_dvd_617601.iso",
+    "iso_checksum_type": "md5",
+    "iso_checksum": "8dcde01d0da526100869e2457aafb7ca",
+    "headless": "true",
+    "tools_iso": "{{env `VMWARE_TOOLS_ISO`}}/windows.iso"
+  },
+
+  "description": "Builds a Windows Server 2008R2 template VM for use in VMware",
+
+  "_comment": [
+      "The boot_command is hacky because the UEFI boot file used requires the 'Press any key' to be done"
+  ],
+  "builders": [
+    {
+      "name": "{{user `template_name`}}-{{user `provisioner`}}",
+      "vm_name": "packer-{{build_name}}",
+      "type": "vmware-iso",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "headless": "{{user `headless`}}",
+
+      "communicator": "winrm",
+      "winrm_username": "Administrator",
+      "winrm_password": "PackerAdmin",
+      "winrm_timeout": "16h",
+
+      "shutdown_command": "shutdown /s /t 1 /c \"Packer Shutdown\" /f /d p:4:1",
+      "shutdown_timeout": "1h",
+      "guest_os_type": "windows8srv-64",
+      "disk_size": 61440,
+      "disk_type_id": "0",
+      "floppy_files": [
+        "files/autounattend.xml",
+        "../../scripts/windows/bootstrap-base.bat",
+        "../../scripts/windows/start-boxstarter.ps1",
+        "../../scripts/windows/windows-env.ps1",
+        "../../scripts/windows/shutdown-packer.bat",
+        "../../scripts/windows/generalize-packer.bat",
+        "../../scripts/windows/clean-disk-dism.ps1",
+        "files/generalize-packer.autounattend.xml",
+        "files/{{build_name}}.package.ps1"
+      ],
+
+      "boot_command": [ "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter>"],
+      "boot_wait": "1s",
+
+      "vmx_data": {
+        "gui.fitguestusingnativedisplayresolution": "FALSE",
+
+        "firmware": "efi",
+        "memsize": "4096",
+        "numvcpus": "2",
+        "ethernet0.virtualdev" : "vmxnet3",
+        "scsi0.virtualdev": "lsisas1068",
+        "virtualHW.version": "10",
+        "devices.hotplug": "false",
+
+        "vcpu.hotadd": "TRUE",
+        "mem.hotadd": "TRUE",
+
+        "tools.syncTime": "FALSE",
+        "time.synchronize.continue": "FALSE",
+        "time.synchronize.restore": "FALSE",
+        "time.synchronize.resume.disk": "FALSE",
+        "time.synchronize.shrink": "FALSE",
+        "time.synchronize.tools.startup": "FALSE",
+        "time.synchronize.tools.enable": "FALSE",
+        "time.synchronize.resume.host": "FALSE",
+        "scsi0:1.present": "TRUE",
+        "scsi0:1.autodetect": "TRUE",
+        "scsi0:1.deviceType": "cdrom-image",
+        "scsi0:1.fileName": "{{user `tools_iso`}}"
+      },
+      "vmx_data_post": {
+        "scsi0:1.present": "FALSE",
+        "scsi0:1.autodetect": "FALSE",
+        "scsi0:1.devicetype":  "",
+        "scsi0:1.filename": ""
+      }
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "powershell",
+      "inline": [
+        "exit 0"
+      ]
+    }
+  ]
+}

--- a/templates/windows-2008r2/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-2008r2/x86_64.vmware.vsphere.cygwin.json
@@ -1,0 +1,181 @@
+{
+  "variables": {
+    "template_name": "windows-2008r2-x86_64",
+    "version": "0.0.1",
+
+    "provisioner": "vmware",
+    "headless": "true",
+
+    "qa_root_passwd": "{{env `QA_ROOT_PASSWD_PLAIN`}}",
+    "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",
+    "packer_vcenter_username": "{{env `PACKER_VCENTER_USERNAME`}}",
+    "packer_vcenter_password": "{{env `PACKER_VCENTER_PASSWORD`}}",
+    "packer_vcenter_dc": "{{env `PACKER_VCENTER_DC`}}",
+    "packer_vcenter_cluster": "{{env `PACKER_VCENTER_CLUSTER`}}",
+    "packer_vcenter_datastore": "{{env `PACKER_VCENTER_DATASTORE`}}",
+    "packer_vcenter_folder": "{{env `PACKER_VCENTER_FOLDER`}}",
+    "packer_vcenter_net": "{{env `PACKER_VCENTER_NET`}}",
+    "packer_vcenter_insecure": "{{env `PACKER_VCENTER_INSECURE`}}",
+    "packer_sha": "{{env `PACKER_SHA`}}"
+  },
+
+  "description": "Builds a Windows Server 2012 template VM for use in VMware",
+
+  "builders": [
+    {
+      "name": "{{user `template_name`}}-{{user `provisioner`}}-vsphere-cygwin",
+      "vm_name": "packer-{{build_name}}",
+      "type": "vmware-vmx",
+      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
+
+      "headless": "{{user `headless`}}",
+
+      "communicator": "winrm",
+      "winrm_username": "Administrator",
+      "winrm_password": "PackerAdmin",
+      "winrm_timeout": "8h",
+
+      "shutdown_command": "A:\\shutdown-packer.bat",
+      "shutdown_timeout": "1h",
+
+
+      "floppy_files": [
+        "../../scripts/windows/bootstrap-base.bat",
+        "../../scripts/windows/cleanup-host.ps1",
+        "../../scripts/windows/install-win-packages.ps1",
+        "../../scripts/windows/install-cygwin.ps1",
+        "../../scripts/windows/cygwin-packages",
+        "../../scripts/windows/authorized_keys",
+        "../../scripts/windows/puppet-configure.ps1",
+        "../../scripts/windows/shutdown-packer.bat",
+        "../../scripts/windows/windows-env.ps1",
+        "../../scripts/windows/Low-SecurityPasswordPolicy.inf",
+        "files/config-vmware-vsphere-cygwin.ps1"
+      ],
+
+      "vmx_data": {
+        "gui.fitguestusingnativedisplayresolution": "FALSE",
+        "annotation": "{{user `template_name`}}-{{user `version`}} built {{isotime}}",
+
+        "firmware": "efi",
+        "memsize": "4096",
+        "numvcpus": "2",
+        "ethernet0.virtualdev" : "vmxnet3",
+        "scsi0.virtualdev": "lsisas1068",
+        "virtualHW.version": "10",
+        "devices.hotplug": "false",
+
+        "vcpu.hotadd": "TRUE",
+        "mem.hotadd": "TRUE",
+
+        "tools.syncTime": "FALSE",
+        "time.synchronize.continue": "FALSE",
+        "time.synchronize.restore": "FALSE",
+        "time.synchronize.resume.disk": "FALSE",
+        "time.synchronize.shrink": "FALSE",
+        "time.synchronize.tools.startup": "FALSE",
+        "time.synchronize.tools.enable": "FALSE",
+        "time.synchronize.resume.host": "FALSE"
+      }
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "powershell",
+      "inline": [
+        "md -Path C:\\Packer\\puppet\\modules",
+        "md -Path C:\\Packer\\Downloads",
+        "md -Path C:\\Packer\\Downloads\\Cygwin",
+        "md -Path C:\\Packer\\Init",
+        "md -Path C:\\Packer\\Logs",
+        "md -Path C:\\Packer\\Sysinternals"
+      ]
+    },
+    {
+      "type": "powershell",
+      "inline": [
+        "A:\\install-win-packages.ps1"
+      ]
+    },
+    {
+      "type": "powershell",
+      "inline": [
+        "A:\\install-cygwin.ps1"
+      ],
+      "environment_vars": [
+        "QA_ROOT_PASSWD={{user `qa_root_passwd`}}"
+      ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "file",
+      "source": "../../manifests/windows",
+      "destination": "C:\\Packer\\puppet\\modules"
+    },
+    {
+      "type": "file",
+      "source": "files/win-2008r2-x86_64-std.pp",
+      "destination": "C:\\Packer\\puppet\\win-2008r2-x86_64-std.pp"
+    },
+    {
+      "type": "powershell",
+      "inline": [
+        "A:\\puppet-configure.ps1 -PackerTemplateName {{user `template_name`}}-{{user `version`}} -PackerSHA '{{user `packer_sha`}}'"
+      ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "powershell",
+      "inline": [
+        "A:\\config-vmware-vsphere-cygwin.ps1"
+      ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "powershell",
+      "inline": [
+        "exit 0"
+      ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "file",
+      "source": "../../scripts/windows/init",
+      "destination": "C:\\Packer\\Init"
+    },
+    {
+      "type": "file",
+      "source": "./files/post-clone.autounattend.xml",
+      "destination": "C:\\Packer\\Init\\post-clone.autounattend.xml"
+    },
+    {
+      "type": "powershell",
+      "inline": [
+        "C:\\Packer\\Init\\vmpooler-arm-host.ps1"
+      ]
+    }
+  ],
+  "post-processors": [
+    {
+      "type": "vsphere",
+      "host": "{{user `packer_vcenter_host`}}",
+      "username": "{{user `packer_vcenter_username`}}",
+      "password": "{{user `packer_vcenter_password`}}",
+      "datacenter": "{{user `packer_vcenter_dc`}}",
+      "cluster": "{{user `packer_vcenter_cluster`}}",
+      "datastore": "{{user `packer_vcenter_datastore`}}",
+      "vm_folder": "{{user `packer_vcenter_folder`}}",
+      "vm_name": "{{user `template_name`}}-{{user `version`}}",
+      "vm_network": "{{user `packer_vcenter_net`}}",
+      "insecure" : "{{user `packer_vcenter_insecure`}}"
+    }
+  ]
+}


### PR DESCRIPTION
The files and procedures needed to create the Win-2008r2 template for
packer.

Note - some incompatible scripts (e.g. disk sizing) have been exluded in
this commit and will be handled later.

Modifications were also required to the Policy editor script to handle
PS Version 2