### PR TITLE
(IMAGES-369) Special template for slipstream

### DIFF
--- a/scripts/windows/generate-slipstream.ps1
+++ b/scripts/windows/generate-slipstream.ps1
@@ -1,0 +1,93 @@
+# Generates Slipstream ISO from image
+param (
+  [string]$OSName = "UNKNOWN",
+  [string]$ImageIndex = "1"
+)
+
+$ErrorActionPreference = 'Stop'
+
+. C:\Packer\Dism\windows-env.ps1
+
+New-Item -ItemType directory -Force -Path C:\Packer\Dism\$OSName
+
+$UpdateDirectory = "$ENV:Windir\SoftwareDistribution\Download"
+$DismBase = "$PackerStaging\Dism"
+$MountPoint = "$DismBase\Mount"
+$WinIsoPath = "$DismBase\$OSName-SlipStream.iso"
+$WinDistPath = "$DismBase\$OSName"
+$WinImageFile = "$WinDistPath\sources\install.wim"
+
+# Install ADK
+Write-Host "Install Win ADK"
+Download-File http://buildsources.delivery.puppetlabs.net/windows/winadk/adksetup_win2012r2.exe  $PackerDownloads\adksetup_win2012r2.exe
+Start-Process -Wait "$PackerDownloads\adksetup_win2012r2.exe" -ArgumentList "/quiet /norestart /features OptionId.DeploymentTools"
+Write-Host "Win ADK Installed"
+
+# Need extra disk for this bit.
+$IsoGen = "C:\Program Files (x86)\Windows Kits\8.1\Assessment and Deployment Kit\Deployment Tools\amd64\Oscdimg\oscdimg.exe"
+if ($psversiontable.psversion.major -gt 2) {
+  $size = (Get-PartitionSupportedSize -DriveLetter C)
+  $sizemax = $size.SizeMax
+  Write-Host "Setting Drive C partition size to $sizemax"
+  Resize-Partition -DriveLetter C -Size $sizemax
+}
+else {
+  Write-Host "Using DiskPart to extend C: drive partition"
+  $diskpartcommands=@"
+list disk
+select disk 0
+list partition
+select partition 3
+extend
+list partition
+exit
+"@
+
+  $diskpartcommands | diskpart
+}
+
+# Use Robocopy to make duplicate of Image ISO
+Write-Host "Copy Image ISO to $WinDistPath"
+robocopy /E /NP /NDL /NFL D:\ $WinDistPath *.*
+
+# Read in the exclude list of CABS to be ignored.
+#
+$ExcludedCabs = @{}
+$Content = Get-Content $DismBase/slipstream-filter
+foreach ($CabName in $Content)
+{
+  $ExcludedCabs.Add("$CabName", "Ignore")
+}
+
+# Search for all CAB Files in Date Order - exclude express cab files if present as they can't be applied in a DISM command
+
+$Cabs = Get-ChildItem -Path $UpdateDirectory -Recurse -Include *.cab -Exclude *Express*.cab | Sort LastWriteTime
+
+Write-Host "Mounting $WinImageFile"
+Set-ItemProperty $WinImageFile -name IsReadOnly -value $false
+dism /mount-wim /wimfile:$WinImageFile /index:$ImageIndex /mountdir:$MountPoint
+
+$Cabtotal = $Cabs.Count
+ForEach ($Cab in $Cabs) {
+	$CabCount++
+  Write-Host "======================================================="
+	Write-Host "Working on CAB File ($CabCount of $Cabtotal)  $Cab"
+
+    if ($ExcludedCabs.ContainsKey($Cab.Name)) {
+      Write-Host "Ignoring CAB"
+      Continue
+    }
+
+    DISM /image:$MountPoint /add-package /packagepath:$Cab  /loglevel:1 /logpath=$DismBase\dism-slip.log
+    if ($? -eq $TRUE){
+      $Cab.Name | Out-File -FilePath $DismBase\Updates-Sucessful.log -Append
+		  Write-Host "Update $Cab Succeeded"
+    } else {
+		  Write-Host "***** Update $Cab FAILED *******"
+      $Cab.Name | Out-File -FilePath $DismBase\Updates-Failed.log -Append
+    }
+}
+
+dism /unmount-wim /mountdir:$MountPoint /commit
+
+& $IsoGen -m -o -u2 -udfver102 -bootdata:"2#p0,e,b$WinDistPath\boot\etfsboot.com#pEF,e,b$WinDistPath\efi\microsoft\boot\efisys.bin" $WinDistPath $WinIsoPath

--- a/scripts/windows/slipstream.package.ps1
+++ b/scripts/windows/slipstream.package.ps1
@@ -1,0 +1,76 @@
+$ErrorActionPreference = "Stop"
+
+. A:\windows-env.ps1
+
+# Boxstarter options
+$Boxstarter.RebootOk=$true # Allow reboots?
+$Boxstarter.NoPassword=$false # Is this a machine with no login password?
+$Boxstarter.AutoLogin=$true # Save my password securely and auto-login after a reboot
+
+if (Test-PendingReboot){ Invoke-Reboot }
+
+Write-BoxstarterMessage "Disabling Hiberation..."
+Set-ItemProperty -Path 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Power' -Name 'HibernateFileSizePercent' -Value 0
+Set-ItemProperty -Path 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Power' -Name 'HibernateEnabled' -Value 0
+
+
+reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate"    /v "WUServer"       /t REG_SZ /d "http://10.32.163.228:8530" /f
+reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate"    /v "WUStatusServer" /t REG_SZ /d "http://10.32.163.228:8530" /f
+
+reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" /v "NoAutoUpdate" /t REG_DWORD /d 0 /f
+reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" /v "AUOptions" /t REG_DWORD /d 2 /f
+reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" /v "ScheduledInstallDay" /t REG_DWORD /d 0 /f
+reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" /v "ScheduledInstallTime" /t REG_DWORD /d 3 /f
+reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" /v "UseWUServer" /t REG_DWORD /d 1 /f
+
+
+if (-not (Test-Path "A:\NET45.installed"))
+{
+  # Install .Net Framework 4.5.2
+  Write-BoxstarterMessage "Installing .Net 4.5"
+  choco install dotnet4.5 -y
+  Touch-File "A:\NET45.installed"
+  if (Test-PendingReboot) { Invoke-Reboot }
+}
+
+# Install Updates and reboot until this is completed.
+Install-WindowsUpdate -AcceptEula
+if (Test-PendingReboot) { Invoke-Reboot }
+
+# Create Dism directories and copy files over.
+# This allows errors to be handled manually in event of dism failures
+
+New-Item -ItemType directory -Force -Path C:\Packer
+New-Item -ItemType directory -Force -Path C:\Packer\Dism
+New-Item -ItemType directory -Force -Path C:\Packer\Downloads
+New-Item -ItemType directory -Force -Path C:\Packer\Dism\Mount
+New-Item -ItemType directory -Force -Path C:\Packer\Dism\Logs
+
+Copy-Item A:\windows-env.ps1 C:\Packer\Dism
+Copy-Item A:\generate-slipstream.ps1 C:\Packer\Dism
+Copy-Item A:\slipstream-filter C:\Packer\Dism
+
+# Add WinRM Firewall Rule
+Write-BoxstarterMessage "Setting up winrm"
+netsh advfirewall firewall add rule name="WinRM-HTTP" dir=in localport=5985 protocol=TCP action=allow
+
+$enableArgs=@{Force=$true}
+try {
+ $command=Get-Command Enable-PSRemoting
+  if($command.Parameters.Keys -contains "skipnetworkprofilecheck"){
+      $enableArgs.skipnetworkprofilecheck=$true
+  }
+}
+catch {
+  $global:error.RemoveAt(0)
+}
+Enable-PSRemoting @enableArgs
+Enable-WSManCredSSP -Force -Role Server
+# NOTE - This is insecure but can be shored up in later customisation.  Required for Vagrant and other provisioning tools
+winrm set winrm/config/client/auth '@{Basic="true"}'
+winrm set winrm/config/service/auth '@{Basic="true"}'
+winrm set winrm/config/service '@{AllowUnencrypted="true"}'
+winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="2048"}'
+Write-BoxstarterMessage "WinRM setup complete"
+
+# End

--- a/templates/windows-2012r2/files/slipstream-filter
+++ b/templates/windows-2012r2/files/slipstream-filter
@@ -1,0 +1,1 @@
+# CAB files to be filtered out in case of DISM Issues

--- a/templates/windows-2012r2/x86_64.vmware.base.json
+++ b/templates/windows-2012r2/x86_64.vmware.base.json
@@ -3,9 +3,9 @@
     "template_name": "windows-2012r2-x86_64",
 
     "provisioner": "vmware",
-    "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2012_r2_with_update_x64_dvd_6052708.iso",
+    "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2012_r2_with_update_x64_dvd_6052708_SlipStream_01.iso",
     "iso_checksum_type": "md5",
-    "iso_checksum": "78bff6565f178ed08ab534397fe44845",
+    "iso_checksum": "5006c404bded89c4f7f24e7df8c6a266",
     "headless": "true",
     "tools_iso": "{{env `VMWARE_TOOLS_ISO`}}/windows.iso"
   },

--- a/templates/windows-2012r2/x86_64.vmware.slipstream.json
+++ b/templates/windows-2012r2/x86_64.vmware.slipstream.json
@@ -1,0 +1,99 @@
+{
+  "variables": {
+    "template_name": "windows-2012r2-x86_64",
+    "os_name" : "Win-2012r2",
+
+    "provisioner": "vmware",
+    "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2012_r2_with_update_x64_dvd_6052708.iso",
+    "iso_checksum_type": "md5",
+    "iso_checksum": "78bff6565f178ed08ab534397fe44845",
+    "headless": "false",
+    "tools_iso": "{{env `VMWARE_TOOLS_ISO`}}/windows.iso"
+  },
+
+  "description": "Customised Win-2012r2 build to prepare slipstream ISO",
+
+  "_comment": [
+      "The boot_command is hacky because the UEFI boot file used requires the 'Press any key' to be done"
+  ],
+  "builders": [
+    {
+      "name": "{{user `template_name`}}-{{user `provisioner`}}",
+      "vm_name": "packer-{{build_name}}",
+      "type": "vmware-iso",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "headless": "{{user `headless`}}",
+
+      "communicator": "winrm",
+      "winrm_username": "Administrator",
+      "winrm_password": "PackerAdmin",
+      "winrm_timeout": "16h",
+
+      "shutdown_command": "shutdown /s /t 1 /c \"Packer Shutdown\" /f /d p:4:1",
+      "shutdown_timeout": "1h",
+      "guest_os_type": "windows8srv-64",
+      "disk_size": 30720,
+      "disk_type_id": "0",
+      "floppy_files": [
+        "files/autounattend.xml",
+        "../../scripts/windows/bootstrap-base.bat",
+        "../../scripts/windows/start-boxstarter.ps1",
+        "../../scripts/windows/windows-env.ps1",
+        "../../scripts/windows/shutdown-packer.bat",
+        "../../scripts/windows/generalize-packer.bat",
+        "../../scripts/windows/generate-slipstream.ps1",
+        "files/slipstream-filter",
+        "files/generalize-packer.autounattend.xml",
+        "../../scripts/windows/slipstream.package.ps1"
+      ],
+
+      "boot_command": [ "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait>"],
+      "boot_wait": "1s",
+
+      "vmx_data": {
+        "gui.fitguestusingnativedisplayresolution": "FALSE",
+
+        "firmware": "efi",
+        "memsize": "4096",
+        "numvcpus": "2",
+        "ethernet0.virtualdev" : "vmxnet3",
+        "scsi0.virtualdev": "lsisas1068",
+        "virtualHW.version": "10",
+        "devices.hotplug": "false",
+
+        "vcpu.hotadd": "TRUE",
+        "mem.hotadd": "TRUE",
+
+        "tools.syncTime": "FALSE",
+        "time.synchronize.continue": "FALSE",
+        "time.synchronize.restore": "FALSE",
+        "time.synchronize.resume.disk": "FALSE",
+        "time.synchronize.shrink": "FALSE",
+        "time.synchronize.tools.startup": "FALSE",
+        "time.synchronize.tools.enable": "FALSE",
+        "time.synchronize.resume.host": "FALSE",
+        "scsi0:1.present": "TRUE",
+        "scsi0:1.autodetect": "TRUE",
+        "scsi0:1.deviceType": "cdrom-image",
+        "scsi0:1.fileName": "{{user `tools_iso`}}"
+      },
+      "vmx_data_post": {
+        "scsi0:1.present": "FALSE",
+        "scsi0:1.autodetect": "FALSE",
+        "scsi0:1.devicetype":  "",
+        "scsi0:1.filename": ""
+      }
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "powershell",
+      "inline": [
+        "C:\\Packer\\Dism\\generate-slipstream.ps1 -OSName {{user `os_name`}} -ImageIndex 2"
+      ],
+      "valid_exit_codes": [0,1]
+    }
+  ]
+}


### PR DESCRIPTION
Specialised template that:
1. Boots from base Windows ISO
2. Downloads and installs all windows updates from a WSUS Server.
3. Applies the updates to an offline copy of the windows image.
4. Generates a new ISO Slipstream image from the offline updated copy.

This image can then be exported to ```osmirror``` to be used for the Packer/Windows build process.

It is intended for manual use on a desktop at the moment.