### PR TITLE
(IMAGES-389) Re-Enable autologin for first boot

### DIFF
--- a/templates/windows-10/files/config-vmware-vsphere-cygwin.ps1
+++ b/templates/windows-10/files/config-vmware-vsphere-cygwin.ps1
@@ -118,3 +118,8 @@ netsh advfirewall firewall add rule name="All Outgoing" dir=out action=allow ena
 
 # Re-Enable AutoAdminLogon
 autologon -AcceptEula Administrator . PackerAdmin
+
+# Re-Enable AutoAdminLogon
+autologon -AcceptEula Administrator . PackerAdmin
+
+# End

--- a/templates/windows-2008r2/files/config-vmware-vsphere-cygwin.ps1
+++ b/templates/windows-2008r2/files/config-vmware-vsphere-cygwin.ps1
@@ -112,4 +112,7 @@ secedit /configure /db secedit.sdb /cfg A:\Low-SecurityPasswordPolicy.inf /quiet
 netsh advfirewall firewall add rule name="All Incoming" dir=in action=allow enable=yes interfacetype=any profile=any localip=any remoteip=any
 netsh advfirewall firewall add rule name="All Outgoing" dir=out action=allow enable=yes interfacetype=any profile=any localip=any remoteip=any
 
+# Re-Enable AutoAdminLogon
+autologon -AcceptEula Administrator . PackerAdmin
+
 # End

--- a/templates/windows-2012/files/config-vmware-vsphere-cygwin.ps1
+++ b/templates/windows-2012/files/config-vmware-vsphere-cygwin.ps1
@@ -114,4 +114,7 @@ winrm set winrm/config/service/auth '@{Basic="true"}'
 netsh advfirewall firewall add rule name="All Incoming" dir=in action=allow enable=yes interfacetype=any profile=any localip=any remoteip=any
 netsh advfirewall firewall add rule name="All Outgoing" dir=out action=allow enable=yes interfacetype=any profile=any localip=any remoteip=any
 
+# Re-Enable AutoAdminLogon
+autologon -AcceptEula Administrator . PackerAdmin
+
 # End

--- a/templates/windows-2012r2/files/config-vmware-vsphere-cygwin.ps1
+++ b/templates/windows-2012r2/files/config-vmware-vsphere-cygwin.ps1
@@ -114,4 +114,7 @@ winrm set winrm/config/service/auth '@{Basic="true"}'
 netsh advfirewall firewall add rule name="All Incoming" dir=in action=allow enable=yes interfacetype=any profile=any localip=any remoteip=any
 netsh advfirewall firewall add rule name="All Outgoing" dir=out action=allow enable=yes interfacetype=any profile=any localip=any remoteip=any
 
+# Re-Enable AutoAdminLogon
+autologon -AcceptEula Administrator . PackerAdmin
+
 # End

--- a/templates/windows-7/files/config-vmware-vsphere-cygwin.ps1
+++ b/templates/windows-7/files/config-vmware-vsphere-cygwin.ps1
@@ -118,3 +118,8 @@ netsh advfirewall firewall add rule name="All Outgoing" dir=out action=allow ena
 
 # Re-Enable AutoAdminLogon
 autologon -AcceptEula Administrator . PackerAdmin
+
+# Re-Enable AutoAdminLogon
+autologon -AcceptEula Administrator . PackerAdmin
+
+# End

--- a/templates/windows-8.1/files/config-vmware-vsphere-cygwin.ps1
+++ b/templates/windows-8.1/files/config-vmware-vsphere-cygwin.ps1
@@ -118,3 +118,8 @@ netsh advfirewall firewall add rule name="All Outgoing" dir=out action=allow ena
 
 # Re-Enable AutoAdminLogon
 autologon -AcceptEula Administrator . PackerAdmin
+
+# Re-Enable AutoAdminLogon
+autologon -AcceptEula Administrator . PackerAdmin
+
+# End


### PR DESCRIPTION
The Autologon registry changes were removed, but the replacement
sysinternals autologon utility wasn't added for all OS's prior to
Win-2016. This means that the Windows Images don't initialise on the
pooler.