### PR TITLE
(IMAGES-22) Address DISM issues in Win-10 template

### DIFF
--- a/scripts/windows/init/post-clone-configuration.ps1
+++ b/scripts/windows/init/post-clone-configuration.ps1
@@ -19,7 +19,6 @@ Write-Host "Resyncing Time"
 w32tm /resync
 w32tm /tz
 
-
 # Get VMPooler Guest name
 # This is a bit roundabout, but it allows us to detect of the guestinfo.hostname is available or not
 # Command is: vmtoolsd.exe --cmd "info-get guestinfo.hostname"'
@@ -52,24 +51,26 @@ $CygwinDownloads = $ENV:CYGWINDOWNLOADS
 $AdministratorHome = "$ENV:CYGWINDIR\home\Administrator"
 
 # Set up cygserv Username
+Write-Host "Setting SSH Host Configuration"
 $qa_root_passwd = Get-Content "$ENV:CYGWINDOWNLOADS\qapasswd"
-& $CygWinShell --login -c `'ssh-host-config -y --pwd $qa_root_passwd`'
+& $CygWinShell --login -c `'ssh-host-config --yes --privileged --user cyg_server --pwd $qa_root_passwd`'
 
 # Generate ssh keys.
+Write-Host "Generate SSH Keys"
 & $CygWinShell --login -c `'rm -rf /home/Administrator/.ssh/id_rsa*`'
 & $CygWinShell --login -c `'ssh-keygen -t rsa -N `"`" -f /home/Administrator/.ssh/id_rsa`'
 
 # Setup Authorised keys (now that home directory exists - with nasty cygpath conversion
+Write-Host "Setup Authorised Keys"
 $CygpCygwinDownloads = $Cygwindownloads.replace("\","/").replace("C:","/cygdrive/c")
 & $CygWinShell --login -c `'cp /home/Administrator/.ssh/id_rsa.pub /home/Administrator/.ssh/authorized_keys`'
 & $CygWinShell --login -c `'cat "$CygpCygwinDownloads/authorized_keys" `>`> /home/Administrator/.ssh/authorized_keys`'
 
-
-# Create sshd process and set to Manual startup
+Write-Host "Add SSHD Process with Manual Startup"
 & $CygWinShell --login -c `'cygrunsrv -S sshd`'
 Set-Service "sshd" -StartupType Manual
 
-# Re-enable NetBIOS services
+Write-Host "Re-enable NETBios Services"
 Set-Service "lmhosts" -StartupType Automatic
 Set-Service "netbt" -StartupType Automatic
 

--- a/templates/windows-10/README.md
+++ b/templates/windows-10/README.md
@@ -4,12 +4,20 @@
 
 This is the Windows 10 Packer Template
 
+### Build notes
+
+The Cumulative updates and associated component cleanup (Dism /StartComponentCleanup) appear to have quite a few issues that prevent building on the jenkins-imaging build hosts.
+So a revised Slipstream procedure has been put in place to specify and download the latest Cumulative Update and a preceding critical fix as MSU from the [Microsoft Update Catalog](http://www.catalog.update.microsoft.com/Home.ASPX)
+These are added as packages (slipstreamed) to the offline image. The Cleanup Component operation is also done before the ISO Source for the base build is produced.
+The Clean-Dism procedure is not used during the actual base build as it only yields a very small space improvement, whereas, if left in place, it tends to affect the reliability of the build.
+
 ### VM settings
 
 
 ## Documentation
 
 The Confluence Documentation for the process is at [Windows/Packer Imaging Process](https://confluence.puppetlabs.com/display/QE/Packer+Generation+of+Windows+Templates+for+VMPooler)
+
 
 ### Issues
 

--- a/templates/windows-10/files/post-clone.autounattend.xml
+++ b/templates/windows-10/files/post-clone.autounattend.xml
@@ -1,5 +1,49 @@
 <?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
+    <settings pass="windowsPE">
+        <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <UserData>
+                <!-- Product Key from http://technet.microsoft.com/en-us/library/jj612867.aspx -->
+                <ProductKey>
+                    <!-- Do not uncomment the Key element if you are using trial ISOs -->
+                    <!-- KMS Setup keys  https://technet.microsoft.com/en-us/library/jj612867.aspx -->
+                    <Key>NPPR9-FWDCX-D2C8J-H872K-2YT43</Key>
+                    <WillShowUI>OnError</WillShowUI>
+                </ProductKey>
+                <AcceptEula>true</AcceptEula>
+                <FullName>Puppet Labs</FullName>
+                <Organization>Puppet Labs</Organization>
+            </UserData>
+        </component>
+    </settings>
+    <settings pass="specialize">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <OEMInformation>
+                <HelpCustomized>false</HelpCustomized>
+            </OEMInformation>
+            <ComputerName>*</ComputerName>
+            <TimeZone>UTC</TimeZone>
+            <RegisteredOwner />
+            <ProductKey>NPPR9-FWDCX-D2C8J-H872K-2YT43</ProductKey>
+            <CopyProfile>true</CopyProfile>
+        </component>
+        <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <RunSynchronous>
+                <RunSynchronousCommand wcm:action="add">
+                    <Path>net user administrator /active:yes</Path>
+                    <Order>1</Order>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Path>reg add HKLM\Software\Microsoft\Windows\CurrentVersion\Policies\System /v EnableFirstLogonAnimation /t REG_DWORD /d 0 /f</Path>
+                    <Order>2</Order>
+                    <Description>Do not Show First Logon Animation</Description>
+                </RunSynchronousCommand>
+            </RunSynchronous>
+        </component>
+        <component name="Microsoft-Windows-Security-SPP-UX" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <SkipAutoActivation>true</SkipAutoActivation>
+        </component>
+    </settings>
     <settings pass="oobeSystem">
         <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <InputLocale>en-US</InputLocale>

--- a/templates/windows-10/files/slipstream-filter
+++ b/templates/windows-10/files/slipstream-filter
@@ -1,0 +1,1 @@
+# CAB files to be filtered out in case of DISM Issues

--- a/templates/windows-10/files/windows-10-slipstream.package.ps1
+++ b/templates/windows-10/files/windows-10-slipstream.package.ps1
@@ -1,0 +1,84 @@
+$ErrorActionPreference = "Stop"
+
+. A:\windows-env.ps1
+
+# Boxstarter options
+$Boxstarter.RebootOk=$true # Allow reboots?
+$Boxstarter.NoPassword=$false # Is this a machine with no login password?
+$Boxstarter.AutoLogin=$true # Save my password securely and auto-login after a reboot
+
+if (Test-PendingReboot){ Invoke-Reboot }
+
+Write-BoxstarterMessage "Disabling Hiberation..."
+Set-ItemProperty -Path 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Power' -Name 'HibernateFileSizePercent' -Value 0
+Set-ItemProperty -Path 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Power' -Name 'HibernateEnabled' -Value 0
+
+# Set all network adapters Private
+Write-BoxstarterMessage "Set all network adapters private"
+$net = get-netconnectionprofile;Set-NetConnectionProfile -Name $net.Name -NetworkCategory Private
+
+if (-not (Test-Path "A:\NET45.installed"))
+{
+  # Install .Net Framework 4.5.2
+  Write-BoxstarterMessage "Installing .Net 4.5"
+  choco install dotnet4.5 -y
+  Touch-File "A:\NET45.installed"
+  if (Test-PendingReboot) { Invoke-Reboot }
+}
+
+# Create Dism directories and copy files over.
+# This allows errors to be handled manually in event of dism failures
+
+New-Item -ItemType directory -Force -Path C:\Packer
+New-Item -ItemType directory -Force -Path C:\Packer\Dism
+New-Item -ItemType directory -Force -Path C:\Packer\Downloads
+New-Item -ItemType directory -Force -Path C:\Packer\Dism\Mount
+New-Item -ItemType directory -Force -Path C:\Packer\Dism\Logs
+
+$MSUPackageDir = "$ENV:WINDIR\SoftwareDistribution\Download\SlipMSUPackages"
+New-Item -ItemType directory -Force -Path $MSUPackageDir
+
+# Forget downloading any windows update pass - download the updates we need directly.
+# (KB3199986) - http://download.windowsupdate.com/c/msdownload/update/software/crup/2016/10/windows10.0-kb3199986-x64_5d4678c30de2de2bd7475073b061d0b3b2e5c3be.msu
+# (KB3200970) - Cumulative Update - http://download.windowsupdate.com/d/msdownload/update/software/secu/2016/11/windows10.0-kb3200970-x64_3fa1daafc46a83ed5d0ecbd0a811e1421b7fad5a.msu
+
+if (-not (Test-Path "A:\Win10.Downloads"))
+{
+  # Install Windows Rollup Update first.
+  Write-Host "Download KB KB3199986"
+  Download-File "http://download.windowsupdate.com/c/msdownload/update/software/crup/2016/10/windows10.0-kb3199986-x64_5d4678c30de2de2bd7475073b061d0b3b2e5c3be.msu"  "$MSUPackageDir\windows10.0-kb3199986-x64_5d4678c30de2de2bd7475073b061d0b3b2e5c3be.msu"
+  Write-Host "Download Main CU - KB3200970"
+  Download-File "http://download.windowsupdate.com/d/msdownload/update/software/secu/2016/11/windows10.0-kb3200970-x64_3fa1daafc46a83ed5d0ecbd0a811e1421b7fad5a.msu"  "$MSUPackageDir\windows10.0-kb3200970-x64_3fa1daafc46a83ed5d0ecbd0a811e1421b7fad5a.msu"
+  Write-Host "Downloads complete"
+  Touch-File "A:\Win10.Downloads"
+  if (Test-PendingReboot) { Invoke-Reboot }
+}
+
+Copy-Item A:\windows-env.ps1 C:\Packer\Dism
+Copy-Item A:\generate-slipstream.ps1 C:\Packer\Dism
+Copy-Item A:\slipstream-filter C:\Packer\Dism
+
+# Add WinRM Firewall Rule
+Write-BoxstarterMessage "Setting up winrm"
+netsh advfirewall firewall add rule name="WinRM-HTTP" dir=in localport=5985 protocol=TCP action=allow
+
+$enableArgs=@{Force=$true}
+try {
+ $command=Get-Command Enable-PSRemoting
+  if($command.Parameters.Keys -contains "skipnetworkprofilecheck"){
+      $enableArgs.skipnetworkprofilecheck=$true
+  }
+}
+catch {
+  $global:error.RemoveAt(0)
+}
+Enable-PSRemoting @enableArgs
+Enable-WSManCredSSP -Force -Role Server
+# NOTE - This is insecure but can be shored up in later customisation.  Required for Vagrant and other provisioning tools
+winrm set winrm/config/client/auth '@{Basic="true"}'
+winrm set winrm/config/service/auth '@{Basic="true"}'
+winrm set winrm/config/service '@{AllowUnencrypted="true"}'
+winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="2048"}'
+Write-BoxstarterMessage "WinRM setup complete"
+
+# End

--- a/templates/windows-10/x86_64.vmware.slipstream.json
+++ b/templates/windows-10/x86_64.vmware.slipstream.json
@@ -1,12 +1,13 @@
 {
   "variables": {
     "template_name": "windows-10-x86_64",
+    "os_name" : "Win-10",
 
     "provisioner": "vmware",
-    "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_10_enterprise_version_1607_updated_jul_2016_x64_dvd_9054264_SlipStream_02.iso",
+    "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_10_enterprise_version_1607_updated_jul_2016_x64_dvd_9054264.iso",
     "iso_checksum_type": "md5",
-    "iso_checksum": "14cf73d5070bc2fa8c75c636ea69a47e",
-    "headless": "true",
+    "iso_checksum": "06fc1188353f10b007c1e4a8f08b36b6",
+    "headless": "false",
     "tools_iso": "{{env `VMWARE_TOOLS_ISO`}}/windows.iso",
     "vmware_output_dir": "{{env `VMWARE_OUTPUT_DIR`}}"
   },
@@ -45,10 +46,10 @@
         "../../scripts/windows/windows-env.ps1",
         "../../scripts/windows/shutdown-packer.bat",
         "../../scripts/windows/generalize-packer.bat",
-        "../../scripts/windows/clean-disk-dism.ps1",
-        "../../scripts/windows/clean-disk-sdelete.ps1",
+        "../../scripts/windows/generate-slipstream.ps1",
+        "files/slipstream-filter",
         "files/generalize-packer.autounattend.xml",
-        "files/{{build_name}}.package.ps1"
+        "files/windows-10-slipstream.package.ps1"
       ],
 
       "boot_command": [ "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait>"],
@@ -93,8 +94,9 @@
     {
       "type": "powershell",
       "inline": [
-        "A:\\clean-disk-sdelete.ps1"
-      ]
+        "C:\\Packer\\Dism\\generate-slipstream.ps1 -OSName {{user `os_name`}} -ImageIndex 1 -PatchSearch *.msu"
+      ],
+      "valid_exit_codes": [0,1]
     }
   ]
 }

--- a/templates/windows-10/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-10/x86_64.vmware.vsphere.cygwin.json
@@ -163,5 +163,20 @@
         "C:\\Packer\\Init\\vmpooler-arm-host.ps1"
       ]
     }
+  ],
+  "post-processors": [
+    {
+      "type": "vsphere",
+      "host": "{{user `packer_vcenter_host`}}",
+      "username": "{{user `packer_vcenter_username`}}",
+      "password": "{{user `packer_vcenter_password`}}",
+      "datacenter": "{{user `packer_vcenter_dc`}}",
+      "cluster": "{{user `packer_vcenter_cluster`}}",
+      "datastore": "{{user `packer_vcenter_datastore`}}",
+      "vm_folder": "{{user `packer_vcenter_folder`}}",
+      "vm_name": "{{user `template_name`}}-{{user `version`}}",
+      "vm_network": "{{user `packer_vcenter_net`}}",
+      "insecure" : "{{user `packer_vcenter_insecure`}}"
+    }
   ]
 }


### PR DESCRIPTION
Use Slipstream image to prepare ISO with the latest CU available. This
reduces the overall install time, but may need to be updated prior to
each release to include the latest CU.

The DISM cleanup is done as part of the slipstream process so the
clean-dism script is not used for Windows-10 base build - at least until
bare-metal hardware is introduced as otherwise the jenkins-imaging
builds fail fairly consistently.