### PR TITLE
(maint) Yakkety Virtualbox VMs should be headless

### DIFF
--- a/templates/ubuntu-16.10/i386.virtualbox.base.json
+++ b/templates/ubuntu-16.10/i386.virtualbox.base.json
@@ -47,6 +47,7 @@
       "boot_wait": "10s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
+      "headless": "{{user `headless`}}",
       "http_directory": "files",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/templates/ubuntu-16.10/x86_64.virtualbox.base.json
+++ b/templates/ubuntu-16.10/x86_64.virtualbox.base.json
@@ -45,6 +45,7 @@
       "boot_wait": "10s",
       "disk_size": 20480,
       "guest_os_type": "{{user `template_os`}}",
+      "headless": "{{user `headless`}}",
       "http_directory": "files",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",


### PR DESCRIPTION
We need to ensure that the variables section of the definition contains
a reference to the user section key headless.