### PR TITLE
(maint) disable periodic updates on ubuntu

### DIFF
--- a/manifests/modules/packer/manifests/updates.pp
+++ b/manifests/modules/packer/manifests/updates.pp
@@ -24,4 +24,9 @@ class packer::updates {
 
   package { $pkgs_to_update: ensure => latest; }
 
+  if $::operatingsystem == 'Ubuntu' {
+    file { '/etc/apt/apt.conf.d/10disable-periodic':
+      content => 'APT::Periodic::Enable \"0\";'
+    }
+  }
 }

--- a/templates/ubuntu-16.10/CHANGELOG
+++ b/templates/ubuntu-16.10/CHANGELOG
@@ -1,3 +1,7 @@
+### 0.0.2
+
+* Disable periodic apt updates
+
 ### 0.0.1
 
 * Initial release

--- a/templates/ubuntu-16.10/i386.vsphere.nocm.json
+++ b/templates/ubuntu-16.10/i386.vsphere.nocm.json
@@ -3,7 +3,7 @@
   "variables":
     {
       "template_name": "ubuntu-16.10-i386",
-      "version": "0.0.1",
+      "version": "0.0.2",
 
       "provisioner": "vmware",
       "required_modules": "puppetlabs-stdlib example42-network puppetlabs-apt",

--- a/templates/ubuntu-16.10/x86_64.vsphere.nocm.json
+++ b/templates/ubuntu-16.10/x86_64.vsphere.nocm.json
@@ -3,7 +3,7 @@
   "variables":
     {
       "template_name": "ubuntu-16.10-x86_64",
-      "version": "0.0.1",
+      "version": "0.0.2",
 
       "provisioner": "vmware",
       "required_modules": "puppetlabs-stdlib example42-network puppetlabs-apt",


### PR DESCRIPTION
periodic apt updates can lead to dpkg being locked at inconvenient times