### PR TITLE
(CPR-395) Update kernel package with osfamily RedHat

### DIFF
--- a/manifests/modules/packer/manifests/updates.pp
+++ b/manifests/modules/packer/manifests/updates.pp
@@ -14,6 +14,7 @@ class packer::updates {
   $redhat_pkgs = [
     'glibc',
     'openssh',
+    'kernel',
   ]
 
   if $::osfamily == 'Debian' {


### PR DESCRIPTION
the kernel package is required to be updated at install time so it matches the kernel-devel version, required for VBoxGuestAddtions installation