### PR TITLE
(IMAGES-439) Windows Update Fixes

### DIFF
--- a/scripts/windows/clean-disk-sdelete.ps1
+++ b/scripts/windows/clean-disk-sdelete.ps1
@@ -5,13 +5,6 @@ $ErrorActionPreference = 'Stop'
 # This is using a revised Disk Zero script instead of sdelete.
 # Script obtained and modified from: http://www.hurryupandwait.io/blog/how-can-we-most-optimally-shrink-a-windows-base-image
 
-Write-Host "Cleaning Temp Files"
-try {
-  Takeown /d Y /R /f "C:\Windows\Temp\*"
-  Icacls "C:\Windows\Temp\*" /GRANT:r administrators:F /T /c /q  2>&1
-  Remove-Item "C:\Windows\Temp\*" -Recurse -Force -ErrorAction SilentlyContinue
-} catch { }
-
 Write-Host "Wiping empty space on disk..."
 $FilePath="c:\zero.tmp"
 $Volume = Get-WmiObject win32_logicaldisk -filter "DeviceID='C:'"

--- a/scripts/windows/windows-env.ps1
+++ b/scripts/windows/windows-env.ps1
@@ -89,7 +89,6 @@ Function Touch-File
     }
 }
 
-
 # Helper function to disable all sleep timeouts on the windows box.
 # Adding on the suspicion that the Cumulative Updates for Win-10 are allowing
 # standby sleep to activate during the long download.
@@ -116,5 +115,18 @@ Function Disable-PC-Sleep
     powercfg -x -hibernate-timeout-dc 0
   } Catch {
       Write-Warning -Message "Unable to set power plan to high performance"
+  }
+}
+
+# Helper function to perform a final reboot.
+# This should help pick up any "trailing" windows updates as it appears that
+# There are still some missing updates.
+
+Function Do-Packer-Final-Reboot
+{
+  if (-not (Test-Path "A:\Final.Reboot"))
+  {
+    Touch-File "A:\Final.Reboot"
+    Invoke-Reboot
   }
 }

--- a/templates/windows-10/files/i386/windows-10-i386-vmware.package.ps1
+++ b/templates/windows-10/files/i386/windows-10-i386-vmware.package.ps1
@@ -9,9 +9,9 @@ $Boxstarter.AutoLogin=$true # Save my password securely and auto-login after a r
 
 if (Test-PendingReboot){ Invoke-Reboot }
 
-Write-BoxstarterMessage "Disabling Hiberation..."
-Set-ItemProperty -Path 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Power' -Name 'HibernateFileSizePercent' -Value 0
-Set-ItemProperty -Path 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Power' -Name 'HibernateEnabled' -Value 0
+# Need to guard against system going into standby for long updates
+Write-BoxstarterMessage "Disabling Sleep timers"
+Disable-PC-Sleep
 
 if (-not (Test-Path "A:\NET45.installed"))
 {
@@ -30,6 +30,9 @@ $net = get-netconnectionprofile;Set-NetConnectionProfile -Name $net.Name -Networ
 Write-BoxstarterMessage "Starting Windows Update Pass"
 Install-WindowsUpdate -AcceptEula
 if (Test-PendingReboot) { Invoke-Reboot }
+
+# Do one final reboot in case there are any more updates to be picked up.
+Do-Packer-Final-Reboot
 
 # Enable Remote Desktop (with reduce authentication resetting here again)
 Write-BoxstarterMessage "Enable Remote Desktop"

--- a/templates/windows-10/files/i386/windows-10-slipstream.package.ps1
+++ b/templates/windows-10/files/i386/windows-10-slipstream.package.ps1
@@ -9,9 +9,9 @@ $Boxstarter.AutoLogin=$true # Save my password securely and auto-login after a r
 
 if (Test-PendingReboot){ Invoke-Reboot }
 
-Write-BoxstarterMessage "Disabling Hiberation..."
-Set-ItemProperty -Path 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Power' -Name 'HibernateFileSizePercent' -Value 0
-Set-ItemProperty -Path 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Power' -Name 'HibernateEnabled' -Value 0
+# Need to guard against system going into standby for long updates
+Write-BoxstarterMessage "Disabling Sleep timers"
+Disable-PC-Sleep
 
 # Set all network adapters Private
 Write-BoxstarterMessage "Set all network adapters private"

--- a/templates/windows-10/files/x86_64/windows-10-slipstream.package.ps1
+++ b/templates/windows-10/files/x86_64/windows-10-slipstream.package.ps1
@@ -9,9 +9,9 @@ $Boxstarter.AutoLogin=$true # Save my password securely and auto-login after a r
 
 if (Test-PendingReboot){ Invoke-Reboot }
 
-Write-BoxstarterMessage "Disabling Hiberation..."
-Set-ItemProperty -Path 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Power' -Name 'HibernateFileSizePercent' -Value 0
-Set-ItemProperty -Path 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Power' -Name 'HibernateEnabled' -Value 0
+# Need to guard against system going into standby for long updates
+Write-BoxstarterMessage "Disabling Sleep timers"
+Disable-PC-Sleep
 
 # Set all network adapters Private
 Write-BoxstarterMessage "Set all network adapters private"

--- a/templates/windows-10/files/x86_64/windows-10-x86_64-vmware.package.ps1
+++ b/templates/windows-10/files/x86_64/windows-10-x86_64-vmware.package.ps1
@@ -9,6 +9,7 @@ $Boxstarter.AutoLogin=$true # Save my password securely and auto-login after a r
 
 if (Test-PendingReboot){ Invoke-Reboot }
 
+# Need to guard against system going into standby for long updates
 Write-BoxstarterMessage "Disabling Sleep timers"
 Disable-PC-Sleep
 
@@ -29,6 +30,9 @@ $net = get-netconnectionprofile;Set-NetConnectionProfile -Name $net.Name -Networ
 Write-BoxstarterMessage "Starting Windows Update Pass"
 Install-WindowsUpdate -AcceptEula
 if (Test-PendingReboot) { Invoke-Reboot }
+
+# Do one final reboot in case there are any more updates to be picked up.
+Do-Packer-Final-Reboot
 
 # Enable Remote Desktop (with reduce authentication resetting here again)
 Write-BoxstarterMessage "Enable Remote Desktop"

--- a/templates/windows-10/i386.vmware.base.json
+++ b/templates/windows-10/i386.vmware.base.json
@@ -93,6 +93,15 @@
     {
       "type": "powershell",
       "inline": [
+        "A:\\clean-disk-dism.ps1"
+      ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "powershell",
+      "inline": [
         "A:\\clean-disk-sdelete.ps1"
       ]
     }

--- a/templates/windows-10/x86_64.vmware.base.json
+++ b/templates/windows-10/x86_64.vmware.base.json
@@ -93,6 +93,15 @@
     {
       "type": "powershell",
       "inline": [
+        "A:\\clean-disk-dism.ps1"
+      ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "powershell",
+      "inline": [
         "A:\\clean-disk-sdelete.ps1"
       ]
     }

--- a/templates/windows-2008r2/files/windows-2008r2-x86_64-vmware.package.ps1
+++ b/templates/windows-2008r2/files/windows-2008r2-x86_64-vmware.package.ps1
@@ -9,9 +9,9 @@ $Boxstarter.AutoLogin=$true # Save my password securely and auto-login after a r
 
 if (Test-PendingReboot){ Invoke-Reboot }
 
-Write-BoxstarterMessage "Disabling Hiberation..."
-Set-ItemProperty -Path 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Power' -Name 'HibernateFileSizePercent' -Value 0
-Set-ItemProperty -Path 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Power' -Name 'HibernateEnabled' -Value 0
+# Need to guard against system going into standby for long updates
+Write-BoxstarterMessage "Disabling Sleep timers"
+Disable-PC-Sleep
 
 if (-not (Test-Path "A:\NET35.installed"))
 {

--- a/templates/windows-2012/files/windows-2012-x86_64-vmware.package.ps1
+++ b/templates/windows-2012/files/windows-2012-x86_64-vmware.package.ps1
@@ -9,9 +9,9 @@ $Boxstarter.AutoLogin=$true # Save my password securely and auto-login after a r
 
 if (Test-PendingReboot){ Invoke-Reboot }
 
-Write-BoxstarterMessage "Disabling Hiberation..."
-Set-ItemProperty -Path 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Power' -Name 'HibernateFileSizePercent' -Value 0
-Set-ItemProperty -Path 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Power' -Name 'HibernateEnabled' -Value 0
+# Need to guard against system going into standby for long updates
+Write-BoxstarterMessage "Disabling Sleep timers"
+Disable-PC-Sleep
 
 if (-not (Test-Path "A:\DesktopExperience.installed"))
 {
@@ -34,6 +34,9 @@ if (-not (Test-Path "A:\NET45.installed"))
 # Install Updates and reboot until this is completed.
 Install-WindowsUpdate -AcceptEula
 if (Test-PendingReboot) { Invoke-Reboot }
+
+# Do one final reboot in case there are any more updates to be picked up.
+Do-Packer-Final-Reboot
 
 # Disable UAC
 Write-BoxstarterMessage "Disable UAC"

--- a/templates/windows-2012r2-ja/files/windows-2012r2-ja-x86_64-vmware.package.ps1
+++ b/templates/windows-2012r2-ja/files/windows-2012r2-ja-x86_64-vmware.package.ps1
@@ -9,9 +9,9 @@ $Boxstarter.AutoLogin=$true # Save my password securely and auto-login after a r
 
 if (Test-PendingReboot){ Invoke-Reboot }
 
-Write-BoxstarterMessage "Disabling Hiberation..."
-Set-ItemProperty -Path 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Power' -Name 'HibernateFileSizePercent' -Value 0
-Set-ItemProperty -Path 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Power' -Name 'HibernateEnabled' -Value 0
+# Need to guard against system going into standby for long updates
+Write-BoxstarterMessage "Disabling Sleep timers"
+Disable-PC-Sleep
 
 if (-not (Test-Path "A:\DesktopExperience.installed"))
 {
@@ -34,6 +34,9 @@ if (-not (Test-Path "A:\NET45.installed"))
 # Install Updates and reboot until this is completed.
 Install-WindowsUpdate -AcceptEula
 if (Test-PendingReboot) { Invoke-Reboot }
+
+# Do one final reboot in case there are any more updates to be picked up.
+Do-Packer-Final-Reboot
 
 # Disable UAC
 Write-BoxstarterMessage "Disable UAC"

--- a/templates/windows-2012r2-ja/files/windows-ja-slipstream.package.ps1
+++ b/templates/windows-2012r2-ja/files/windows-ja-slipstream.package.ps1
@@ -13,10 +13,9 @@ $Boxstarter.AutoLogin=$true # Save my password securely and auto-login after a r
 
 if (Test-PendingReboot){ Invoke-Reboot }
 
-Write-BoxstarterMessage "Disabling Hiberation..."
-Set-ItemProperty -Path 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Power' -Name 'HibernateFileSizePercent' -Value 0
-Set-ItemProperty -Path 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Power' -Name 'HibernateEnabled' -Value 0
-
+# Need to guard against system going into standby for long updates
+Write-BoxstarterMessage "Disabling Sleep timers"
+Disable-PC-Sleep
 
 reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate"    /v "WUServer"       /t REG_SZ /d "http://10.32.163.228:8530" /f
 reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate"    /v "WUStatusServer" /t REG_SZ /d "http://10.32.163.228:8530" /f
@@ -51,6 +50,9 @@ if (-not (Test-Path "A:\Win2012r2MSU.installed"))
 # Install Updates and reboot until this is completed.
 Install-WindowsUpdate -AcceptEula
 if (Test-PendingReboot) { Invoke-Reboot }
+
+# Do one final reboot in case there are any more updates to be picked up.
+Do-Packer-Final-Reboot
 
 # Create Dism directories and copy files over.
 # This allows errors to be handled manually in event of dism failures

--- a/templates/windows-2012r2/files/virtualbox/windows-2012r2-x86_64-virtualbox.package.ps1
+++ b/templates/windows-2012r2/files/virtualbox/windows-2012r2-x86_64-virtualbox.package.ps1
@@ -9,9 +9,9 @@ $Boxstarter.AutoLogin=$true # Save my password securely and auto-login after a r
 
 if (Test-PendingReboot){ Invoke-Reboot }
 
-Write-BoxstarterMessage "Disabling Hiberation..."
-Set-ItemProperty -Path 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Power' -Name 'HibernateFileSizePercent' -Value 0
-Set-ItemProperty -Path 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Power' -Name 'HibernateEnabled' -Value 0
+# Need to guard against system going into standby for long updates
+Write-BoxstarterMessage "Disabling Sleep timers"
+Disable-PC-Sleep
 
 if (-not (Test-Path "A:\Autologon.installed"))
 {
@@ -45,6 +45,9 @@ if (-not (Test-Path "A:\NET45.installed"))
 # Install Updates and reboot until this is completed.
 Install-WindowsUpdate -AcceptEula
 if (Test-PendingReboot) { Invoke-Reboot }
+
+# Do one final reboot in case there are any more updates to be picked up.
+Do-Packer-Final-Reboot
 
 # Disable UAC
 Write-BoxstarterMessage "Disable UAC"

--- a/templates/windows-2012r2/files/vmware/windows-2012r2-x86_64-vmware.package.ps1
+++ b/templates/windows-2012r2/files/vmware/windows-2012r2-x86_64-vmware.package.ps1
@@ -9,9 +9,9 @@ $Boxstarter.AutoLogin=$true # Save my password securely and auto-login after a r
 
 if (Test-PendingReboot){ Invoke-Reboot }
 
-Write-BoxstarterMessage "Disabling Hiberation..."
-Set-ItemProperty -Path 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Power' -Name 'HibernateFileSizePercent' -Value 0
-Set-ItemProperty -Path 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Power' -Name 'HibernateEnabled' -Value 0
+# Need to guard against system going into standby for long updates
+Write-BoxstarterMessage "Disabling Sleep timers"
+Disable-PC-Sleep
 
 if (-not (Test-Path "A:\DesktopExperience.installed"))
 {
@@ -34,6 +34,9 @@ if (-not (Test-Path "A:\NET45.installed"))
 # Install Updates and reboot until this is completed.
 Install-WindowsUpdate -AcceptEula
 if (Test-PendingReboot) { Invoke-Reboot }
+
+# Do one final reboot in case there are any more updates to be picked up.
+Do-Packer-Final-Reboot
 
 # Disable UAC
 Write-BoxstarterMessage "Disable UAC"

--- a/templates/windows-2012r2/x86_64.virtualbox.base.json
+++ b/templates/windows-2012r2/x86_64.virtualbox.base.json
@@ -54,6 +54,15 @@
       "inline": [
         "A:\\clean-disk-dism.ps1"
       ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "powershell",
+      "inline": [
+        "A:\\clean-disk-sdelete.ps1"
+      ]
     }
   ]
 }

--- a/templates/windows-2012r2/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-2012r2/x86_64.vmware.vsphere.cygwin.json
@@ -78,6 +78,10 @@
         "time.synchronize.tools.startup": "FALSE",
         "time.synchronize.tools.enable": "FALSE",
         "time.synchronize.resume.host": "FALSE"
+      },
+      "vmx_data_post": {
+        "memsize": "6144",
+        "devices.hotplug": "false"
       }
     }
   ],

--- a/templates/windows-2016/files/windows-2016-x86_64-vmware.package.ps1
+++ b/templates/windows-2016/files/windows-2016-x86_64-vmware.package.ps1
@@ -9,9 +9,9 @@ $Boxstarter.AutoLogin=$true # Save my password securely and auto-login after a r
 
 if (Test-PendingReboot){ Invoke-Reboot }
 
-Write-BoxstarterMessage "Disabling Hiberation..."
-Set-ItemProperty -Path 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Power' -Name 'HibernateFileSizePercent' -Value 0
-Set-ItemProperty -Path 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Power' -Name 'HibernateEnabled' -Value 0
+# Need to guard against system going into standby for long updates
+Write-BoxstarterMessage "Disabling Sleep timers"
+Disable-PC-Sleep
 
 if (-not (Test-Path "A:\DesktopExperience.installed"))
 {
@@ -34,6 +34,9 @@ if (-not (Test-Path "A:\NET45.installed"))
 # Install Updates and reboot until this is completed.
 Install-WindowsUpdate -AcceptEula
 if (Test-PendingReboot) { Invoke-Reboot }
+
+# Do one final reboot in case there are any more updates to be picked up.
+Do-Packer-Final-Reboot
 
 # Disable UAC
 Write-BoxstarterMessage "Disable UAC"

--- a/templates/windows-7/files/windows-7-slipstream.package.ps1
+++ b/templates/windows-7/files/windows-7-slipstream.package.ps1
@@ -13,10 +13,9 @@ $Boxstarter.AutoLogin=$true # Save my password securely and auto-login after a r
 
 if (Test-PendingReboot){ Invoke-Reboot }
 
-Write-BoxstarterMessage "Disabling Hiberation..."
-Set-ItemProperty -Path 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Power' -Name 'HibernateFileSizePercent' -Value 0
-Set-ItemProperty -Path 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Power' -Name 'HibernateEnabled' -Value 0
-
+# Need to guard against system going into standby for long updates
+Write-BoxstarterMessage "Disabling Sleep timers"
+Disable-PC-Sleep
 
 reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate"    /v "WUServer"       /t REG_SZ /d "http://10.32.163.228:8530" /f
 reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate"    /v "WUStatusServer" /t REG_SZ /d "http://10.32.163.228:8530" /f
@@ -48,10 +47,12 @@ if (-not (Test-Path "A:\Win7MSU.installed"))
   if (Test-PendingReboot) { Invoke-Reboot }
 }
 
-
 # Install Updates and reboot until this is completed.
 Install-WindowsUpdate -AcceptEula
 if (Test-PendingReboot) { Invoke-Reboot }
+
+# Do one final reboot in case there are any more updates to be picked up.
+Do-Packer-Final-Reboot
 
 # Create Dism directories and copy files over.
 # This allows errors to be handled manually in event of dism failures

--- a/templates/windows-7/files/windows-7-x86_64-vmware.package.ps1
+++ b/templates/windows-7/files/windows-7-x86_64-vmware.package.ps1
@@ -9,9 +9,9 @@ $Boxstarter.AutoLogin=$true # Save my password securely and auto-login after a r
 
 if (Test-PendingReboot){ Invoke-Reboot }
 
-Write-BoxstarterMessage "Disabling Hiberation..."
-Set-ItemProperty -Path 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Power' -Name 'HibernateFileSizePercent' -Value 0
-Set-ItemProperty -Path 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Power' -Name 'HibernateEnabled' -Value 0
+# Need to guard against system going into standby for long updates
+Write-BoxstarterMessage "Disabling Sleep timers"
+Disable-PC-Sleep
 
 if (-not (Test-Path "A:\NET45.installed"))
 {
@@ -26,6 +26,9 @@ if (-not (Test-Path "A:\NET45.installed"))
 Write-BoxstarterMessage "Starting Windows Update Pass"
 Install-WindowsUpdate -AcceptEula
 if (Test-PendingReboot) { Invoke-Reboot }
+
+# Do one final reboot in case there are any more updates to be picked up.
+Do-Packer-Final-Reboot
 
 # Enable Remote Desktop (with reduce authentication resetting here again)
 Write-BoxstarterMessage "Enable Remote Desktop"

--- a/templates/windows-8.1/files/windows-8.1-x86_64-vmware.package.ps1
+++ b/templates/windows-8.1/files/windows-8.1-x86_64-vmware.package.ps1
@@ -9,9 +9,9 @@ $Boxstarter.AutoLogin=$true # Save my password securely and auto-login after a r
 
 if (Test-PendingReboot){ Invoke-Reboot }
 
-Write-BoxstarterMessage "Disabling Hiberation..."
-Set-ItemProperty -Path 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Power' -Name 'HibernateFileSizePercent' -Value 0
-Set-ItemProperty -Path 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Power' -Name 'HibernateEnabled' -Value 0
+# Need to guard against system going into standby for long updates
+Write-BoxstarterMessage "Disabling Sleep timers"
+Disable-PC-Sleep
 
 if (-not (Test-Path "A:\NET45.installed"))
 {
@@ -30,6 +30,9 @@ $net = get-netconnectionprofile;Set-NetConnectionProfile -Name $net.Name -Networ
 Write-BoxstarterMessage "Starting Windows Update Pass"
 Install-WindowsUpdate -AcceptEula
 if (Test-PendingReboot) { Invoke-Reboot }
+
+# Do one final reboot in case there are any more updates to be picked up.
+Do-Packer-Final-Reboot
 
 # Enable Remote Desktop (with reduce authentication resetting here again)
 Write-BoxstarterMessage "Enable Remote Desktop"


### PR DESCRIPTION
This corrects two issues were causing failures to the Image builder:
1. System goes to sleep during long update cycles (esp win-10/2016)
    (This was already tested for win-10 and is being rolled out to all builds).
    This also affected the Dism Cleanup operations which had to be removed.
2. Windows Update could occur during subsequent configuration stages,
   especially if the base image was built over a month previously.
   Again Win-10/2016 were impacted the most due to the size of the
   Cumulative Update downloaded each month.

Since no further updates should be done to the image once the base is
done, the Download cache for Windows Update is also cleaned.