### PR TITLE
(maint) update travis to use trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: bash
 
 # Use container-based infrastructure for quicker build start-up
 sudo: false
+dist: trusty
 
 addons:
   apt:


### PR DESCRIPTION
Update travis to use the trusty container rather than the default of
precise.  This will address an issue with the old curl in precise and
newly issued hashicorp certs.

Related to https://github.com/travis-ci/travis-ci/issues/7131