### PR TITLE
(IMAGES-385) Resolve Win-2012 build hang

### DIFF
--- a/scripts/windows/clean-disk-dism.ps1
+++ b/scripts/windows/clean-disk-dism.ps1
@@ -69,8 +69,7 @@ Write-Host "Clearing Files"
     "$ENV:USERPROFILE\AppData\Local\Microsoft\Windows\WER\ReportArchive",
     "$ENV:USERPROFILE\AppData\Local\Microsoft\Windows\WER\ReportQueue",
     "$ENV:ALLUSERSPROFILE\Microsoft\Windows\WER\ReportArchive",
-    "$ENV:ALLUSERSPROFILE\Microsoft\Windows\WER\ReportQueue",
-    "$ENV:WINDIR\winsxs\manifestcache"
+    "$ENV:ALLUSERSPROFILE\Microsoft\Windows\WER\ReportQueue"
 ) | % {
         if(Test-Path $_) {
             Write-Host "Removing $_"

--- a/scripts/windows/generate-slipstream.ps1
+++ b/scripts/windows/generate-slipstream.ps1
@@ -101,7 +101,7 @@ if ($WindowsVersion -eq '6.1.7601' ) {
 }
 ElseIf ($WindowsVersion -eq '6.2.9200' -or $WindowsVersion -eq '6.0.6002') {
   # Note /ResetBase option is not available on Windows-2012, so need to screen for this.
-  dism /image:$MountPoint /Cleanup-Image /StartComponentCleanup
+  Write-Host "Skipping Cleanup"
 } else {
   dism /image:$MountPoint /Cleanup-Image /StartComponentCleanup /ResetBase
 }

--- a/scripts/windows/windows-env.ps1
+++ b/scripts/windows/windows-env.ps1
@@ -130,3 +130,22 @@ Function Do-Packer-Final-Reboot
     Invoke-Reboot
   }
 }
+
+# Helper function to install Windows/MS Patch.
+# Downloads file to $TEMP and uses wusa to install it.
+
+Function Install_Win_Patch
+{
+  param(
+    [Parameter(Mandatory = $true)]
+    [String]$PatchUrl
+  )
+
+  $PatchFilename = $PatchUrl.Substring($PatchUrl.LastIndexOf("/") + 1)
+
+  Write-Host "Downloading $PatchFilename"
+  Download-File "$PatchUrl"  "$ENV:TEMP\$PatchFilename"
+  Write-Host "Applying $PatchFilename Patch"
+  Start-Process -Wait "wusa.exe" -ArgumentList "$ENV:TEMP\$PatchFilename /quiet /norestart"
+  Write-Host "Patch Installed"
+}

--- a/templates/windows-2012/files/slipstream-filter
+++ b/templates/windows-2012/files/slipstream-filter
@@ -1,0 +1,10 @@
+# CAB files to be filtered out in case of DISM Issues
+windows8-rt-kb2981685-x64.cab
+windows8-rt-kb2973501-x64.cab
+windows8-rt-kb3003729-x64.cab
+windows8-rt-kb3012702-x64.cab
+windows8-rt-kb3096053-x64.cab
+windows8-rt-kb3080446-x64.cab
+windows8-rt-kb3042058-x64.cab
+Windows8-RT-KB3173426-x64.cab
+windows8-rt-kb3170455-x64.cab

--- a/templates/windows-2012/files/windows-2012-slipstream.package.ps1
+++ b/templates/windows-2012/files/windows-2012-slipstream.package.ps1
@@ -1,0 +1,102 @@
+$ErrorActionPreference = "Stop"
+
+# Customised Slipstream script for Windows-7 - this proves a bit more difficult than the "usual"
+# Slipstream update process.
+# Use a rollup update.
+
+. A:\windows-env.ps1
+
+# Boxstarter options
+$Boxstarter.RebootOk=$true # Allow reboots?
+$Boxstarter.NoPassword=$false # Is this a machine with no login password?
+$Boxstarter.AutoLogin=$true # Save my password securely and auto-login after a reboot
+
+if (Test-PendingReboot){ Invoke-Reboot }
+
+# Need to guard against system going into standby for long updates
+Write-BoxstarterMessage "Disabling Sleep timers"
+Disable-PC-Sleep
+
+reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate"    /v "WUServer"       /t REG_SZ /d "http://10.32.163.228:8530" /f
+reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate"    /v "WUStatusServer" /t REG_SZ /d "http://10.32.163.228:8530" /f
+
+reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" /v "NoAutoUpdate" /t REG_DWORD /d 0 /f
+reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" /v "AUOptions" /t REG_DWORD /d 2 /f
+reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" /v "ScheduledInstallDay" /t REG_DWORD /d 0 /f
+reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" /v "ScheduledInstallTime" /t REG_DWORD /d 3 /f
+reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" /v "UseWUServer" /t REG_DWORD /d 1 /f
+
+if (-not (Test-Path "A:\NET45.installed"))
+{
+  # Install .Net Framework 4.5.2
+  Write-BoxstarterMessage "Installing .Net 4.5"
+  choco install dotnet4.5 -y
+  Touch-File "A:\NET45.installed"
+  if (Test-PendingReboot) { Invoke-Reboot }
+}
+
+# Install all patches related to Windows Update and Servicing Stack - These were gleaned from Google searches and
+# The following lists:
+#        https://blogs.technet.microsoft.com/chad/2015/01/21/current-windows-server-2012-r2-windows-8-8-1-update-rollups/
+#        https://social.technet.microsoft.com/wiki/contents/articles/23820.windows-8-and-windows-server-2012-list-of-rollup-updates.aspx#General_availability
+if (-not (Test-Path "A:\Win2012.Patches"))
+{
+  $patches = @(
+    'http://download.windowsupdate.com/msdownload/update/software/crup/2012/10/windows8-rt-kb2761094-x64_7f31aa2f3ba35dae806363e88c3757776b4a7266.msu',
+    'http://download.windowsupdate.com/msdownload/update/software/crup/2012/10/windows8-rt-kb2764870-x64_196e3394e91fb46f536181406fe4e533d3c64b07.msu',
+    'http://download.windowsupdate.com/msdownload/update/software/crup/2012/09/windows8-rt-kb2756872-x64_99dcb07efbf01d02bc5e8a2d49ec1dddfd786dfb.msu',
+    'http://download.windowsupdate.com/c/msdownload/update/software/crup/2014/07/windows8-rt-kb2937636-x64_29e0b587c8f09bcf635c1b79d09c00eef33113ec.msu',
+    'http://download.windowsupdate.com/c/msdownload/update/software/updt/2015/04/windows8-rt-kb3003729-x64_e95e2c0534a7f3e8f51dd9bdb7d59e32f6d65612.msu',
+    'http://download.windowsupdate.com/d/msdownload/update/software/updt/2015/09/windows8-rt-kb3096053-x64_930f557083e97c7e22e7da133e802afca4963d4f.msu',
+    'http://download.windowsupdate.com/d/msdownload/update/software/crup/2016/06/windows8-rt-kb3173426-x64_ecf1b38d9e3cdf1eace07b9ddbf6f57c1c9d9309.msu'
+  )
+  $patches | % { Install_Win_Patch -PatchUrl $_ }
+  
+  Touch-File "A:\Win2012.Patches"
+  if (Test-PendingReboot) { Invoke-Reboot }
+}
+
+# Install Updates and reboot until this is completed.
+Install-WindowsUpdate -AcceptEula
+if (Test-PendingReboot) { Invoke-Reboot }
+
+# Do one final reboot in case there are any more updates to be picked up.
+Do-Packer-Final-Reboot
+
+# Create Dism directories and copy files over.
+# This allows errors to be handled manually in event of dism failures
+
+New-Item -ItemType directory -Force -Path C:\Packer
+New-Item -ItemType directory -Force -Path C:\Packer\Dism
+New-Item -ItemType directory -Force -Path C:\Packer\Downloads
+New-Item -ItemType directory -Force -Path C:\Packer\Dism\Mount
+New-Item -ItemType directory -Force -Path C:\Packer\Dism\Logs
+
+Copy-Item A:\windows-env.ps1 C:\Packer\Dism
+Copy-Item A:\generate-slipstream.ps1 C:\Packer\Dism
+Copy-Item A:\slipstream-filter C:\Packer\Dism
+
+# Add WinRM Firewall Rule
+Write-BoxstarterMessage "Setting up winrm"
+netsh advfirewall firewall add rule name="WinRM-HTTP" dir=in localport=5985 protocol=TCP action=allow
+
+$enableArgs=@{Force=$true}
+try {
+ $command=Get-Command Enable-PSRemoting
+  if($command.Parameters.Keys -contains "skipnetworkprofilecheck"){
+      $enableArgs.skipnetworkprofilecheck=$true
+  }
+}
+catch {
+  $global:error.RemoveAt(0)
+}
+Enable-PSRemoting @enableArgs
+Enable-WSManCredSSP -Force -Role Server
+# NOTE - This is insecure but can be shored up in later customisation.  Required for Vagrant and other provisioning tools
+winrm set winrm/config/client/auth '@{Basic="true"}'
+winrm set winrm/config/service/auth '@{Basic="true"}'
+winrm set winrm/config/service '@{AllowUnencrypted="true"}'
+winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="2048"}'
+Write-BoxstarterMessage "WinRM setup complete"
+
+# End

--- a/templates/windows-2012/files/windows-2012-x86_64-vmware.package.ps1
+++ b/templates/windows-2012/files/windows-2012-x86_64-vmware.package.ps1
@@ -7,6 +7,20 @@ $Boxstarter.RebootOk=$true # Allow reboots?
 $Boxstarter.NoPassword=$false # Is this a machine with no login password?
 $Boxstarter.AutoLogin=$true # Save my password securely and auto-login after a reboot
 
+# These are necessary for Win-2012 only until we get the proper WSUS server up.
+# Otherwise the Windows Update section hangs.
+# The static IP address will be replaced here by a regular DNS name in a common config file when the WSUS server is introduced.
+#
+reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate"    /v "WUServer"       /t REG_SZ /d "http://10.32.163.228:8530" /f
+reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate"    /v "WUStatusServer" /t REG_SZ /d "http://10.32.163.228:8530" /f
+
+reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" /v "NoAutoUpdate" /t REG_DWORD /d 0 /f
+reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" /v "AUOptions" /t REG_DWORD /d 2 /f
+reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" /v "ScheduledInstallDay" /t REG_DWORD /d 0 /f
+reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" /v "ScheduledInstallTime" /t REG_DWORD /d 3 /f
+reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" /v "UseWUServer" /t REG_DWORD /d 1 /f
+
+
 if (Test-PendingReboot){ Invoke-Reboot }
 
 # Need to guard against system going into standby for long updates

--- a/templates/windows-2012/files/windows-2012-x86_64-vmware.package.ps1
+++ b/templates/windows-2012/files/windows-2012-x86_64-vmware.package.ps1
@@ -31,6 +31,20 @@ if (-not (Test-Path "A:\NET45.installed"))
   if (Test-PendingReboot) { Invoke-Reboot }
 }
 
+# Servicing Stack Patches that don't get slipstreamed properly to be installed.
+if (-not (Test-Path "A:\Win2012.Patches"))
+{
+  $patches = @(
+    'http://download.windowsupdate.com/c/msdownload/update/software/updt/2015/04/windows8-rt-kb3003729-x64_e95e2c0534a7f3e8f51dd9bdb7d59e32f6d65612.msu',
+    'http://download.windowsupdate.com/d/msdownload/update/software/updt/2015/09/windows8-rt-kb3096053-x64_930f557083e97c7e22e7da133e802afca4963d4f.msu',
+    'http://download.windowsupdate.com/d/msdownload/update/software/crup/2016/06/windows8-rt-kb3173426-x64_ecf1b38d9e3cdf1eace07b9ddbf6f57c1c9d9309.msu'
+  )
+  $patches | % { Install_Win_Patch -PatchUrl $_ }
+
+  Touch-File "A:\Win2012.Patches"
+  if (Test-PendingReboot) { Invoke-Reboot }
+}
+
 # Install Updates and reboot until this is completed.
 Install-WindowsUpdate -AcceptEula
 if (Test-PendingReboot) { Invoke-Reboot }

--- a/templates/windows-2012/x86_64.vmware.slipstream.json
+++ b/templates/windows-2012/x86_64.vmware.slipstream.json
@@ -1,17 +1,17 @@
 {
   "variables": {
     "template_name": "windows-2012-x86_64",
+    "os_name" : "Win-2012",
 
     "provisioner": "vmware",
-    "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2012_x64_dvd_915478_SlipStream_02.iso",
+    "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2012_x64_dvd_915478.iso",
     "iso_checksum_type": "md5",
-    "iso_checksum": "9557556a063802c1d29e55a6d539e2ed",
-    "headless": "true",
-    "tools_iso": "{{env `VMWARE_TOOLS_ISO`}}/windows.iso",
-    "vmware_output_dir": "{{env `VMWARE_OUTPUT_DIR`}}"
+    "iso_checksum": "da91135483e24689bfdaf05d40301506",
+    "headless": "false",
+    "tools_iso": "{{env `VMWARE_TOOLS_ISO`}}/windows.iso"
   },
 
-  "description": "Builds a Windows Server 2012 template VM for use in VMware",
+  "description": "Customised Win-2012 build to prepare slipstream ISO",
 
   "_comment": [
       "The boot_command is hacky because the UEFI boot file used requires the 'Press any key' to be done"
@@ -24,8 +24,6 @@
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "output_directory": "{{user `vmware_output_dir`}}/output-{{build_name}}",
-
       "headless": "{{user `headless`}}",
 
       "communicator": "winrm",
@@ -36,22 +34,22 @@
       "shutdown_command": "shutdown /s /t 1 /c \"Packer Shutdown\" /f /d p:4:1",
       "shutdown_timeout": "1h",
       "guest_os_type": "windows8srv-64",
-      "disk_size": 61440,
+      "disk_size": 40720,
       "disk_type_id": "0",
       "floppy_files": [
         "files/autounattend.xml",
+        "files/generalize-packer.autounattend.xml",
+        "files/slipstream-filter",
         "../../scripts/windows/bootstrap-base.bat",
         "../../scripts/windows/start-boxstarter.ps1",
         "../../scripts/windows/windows-env.ps1",
         "../../scripts/windows/shutdown-packer.bat",
         "../../scripts/windows/generalize-packer.bat",
-        "../../scripts/windows/clean-disk-dism.ps1",
-        "../../scripts/windows/clean-disk-sdelete.ps1",
-        "files/generalize-packer.autounattend.xml",
-        "files/{{build_name}}.package.ps1"
+        "../../scripts/windows/generate-slipstream.ps1",
+        "files/windows-2012-slipstream.package.ps1"
       ],
 
-      "boot_command": [ "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter>"],
+      "boot_command": [ "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait>"],
       "boot_wait": "1s",
 
       "vmx_data": {
@@ -93,17 +91,9 @@
     {
       "type": "powershell",
       "inline": [
-        "A:\\clean-disk-dism.ps1"
-      ]
-    },
-    {
-      "type": "windows-restart"
-    },
-    {
-      "type": "powershell",
-      "inline": [
-        "A:\\clean-disk-sdelete.ps1"
-      ]
+        "C:\\Packer\\Dism\\generate-slipstream.ps1 -OSName {{user `os_name`}} -ImageIndex 2"
+      ],
+      "valid_exit_codes": [0,1]
     }
   ]
 }


### PR DESCRIPTION
The Windows-2012 build hangs indefinately during the Windows Update.
The first step to address this was to create a formal slipstream build
process for Win-2012 (as the first slipstream was built manually) and to
ensure that all the correct Windows Servicing Stack updates were
installed correctly to allow it to operate with WSUS.

It was also necessary to filter out a number of updates during the DISM
offline servicing phase as these appeared to corrupt the image. Three of
the updates are critical however, to the actual build, so these are
inserted into the main build package script just prior to the windows
update phase.