### PR TITLE
(IMAGES-376) Revised In/Out VMWare Directories

### DIFF
--- a/templates/windows-10/i386.vmware.base.json
+++ b/templates/windows-10/i386.vmware.base.json
@@ -8,7 +8,7 @@
     "iso_checksum": "14ba31a70181e8865598c2e06e202b10",
     "headless": "true",
     "tools_iso": "{{env `VMWARE_TOOLS_ISO`}}/windows.iso",
-    "vmware_output_dir": "{{env `VMWARE_OUTPUT_DIR`}}"
+    "packer_output_dir": "{{env `PACKER_VM_OUT_DIR`}}"
   },
 
   "description": "Builds a Windows Server 10 Enterprise 32 bit template VM for use in VMware",
@@ -24,7 +24,7 @@
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "output_directory": "{{user `vmware_output_dir`}}/output-{{build_name}}",
+      "output_directory": "{{user `packer_output_dir`}}/output-{{build_name}}",
 
       "headless": "{{user `headless`}}",
 

--- a/templates/windows-10/i386.vmware.slipstream.json
+++ b/templates/windows-10/i386.vmware.slipstream.json
@@ -9,7 +9,7 @@
     "iso_checksum": "dfb7e70fcd434cf345f7c07972473374",
     "headless": "false",
     "tools_iso": "{{env `VMWARE_TOOLS_ISO`}}/windows.iso",
-    "vmware_output_dir": "{{env `VMWARE_OUTPUT_DIR`}}"
+    "packer_output_dir": "{{env `PACKER_VM_OUT_DIR`}}"
   },
 
   "description": "Builds a Windows Server 10 Enterprise template VM for use in VMware",
@@ -25,7 +25,7 @@
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "output_directory": "{{user `vmware_output_dir`}}/output-{{build_name}}",
+      "output_directory": "{{user `packer_output_dir`}}/output-{{build_name}}",
 
       "headless": "{{user `headless`}}",
 

--- a/templates/windows-10/i386.vmware.vsphere.cygwin.json
+++ b/templates/windows-10/i386.vmware.vsphere.cygwin.json
@@ -17,7 +17,8 @@
     "packer_vcenter_net": "{{env `PACKER_VCENTER_NET`}}",
     "packer_vcenter_insecure": "{{env `PACKER_VCENTER_INSECURE`}}",
     "packer_sha": "{{env `PACKER_SHA`}}",
-    "vmware_output_dir": "{{env `VMWARE_OUTPUT_DIR`}}"
+    "packer_source_dir": "{{env `PACKER_VM_SRC_DIR`}}",
+    "packer_output_dir": "{{env `PACKER_VM_OUT_DIR`}}"
   },
 
   "description": "Builds a Windows 10 (Anniversary Edition) template VM for use in VMware",
@@ -27,8 +28,8 @@
       "name": "{{user `template_name`}}-{{user `provisioner`}}-vsphere-cygwin",
       "vm_name": "packer-{{build_name}}",
       "type": "vmware-vmx",
-      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
-      "output_directory": "{{user `vmware_output_dir`}}/output-{{build_name}}",
+      "source_path": "{{user `packer_source_dir`}}/output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
+      "output_directory": "{{user `packer_output_dir`}}/output-{{build_name}}",
 
       "headless": "{{user `headless`}}",
 
@@ -176,7 +177,8 @@
       "vm_folder": "{{user `packer_vcenter_folder`}}",
       "vm_name": "{{user `template_name`}}-{{user `version`}}",
       "vm_network": "{{user `packer_vcenter_net`}}",
-      "insecure" : "{{user `packer_vcenter_insecure`}}"
+      "insecure" : "{{user `packer_vcenter_insecure`}}",
+      "overwrite" : "true"
     }
   ]
 }

--- a/templates/windows-10/x86_64.vmware.base.json
+++ b/templates/windows-10/x86_64.vmware.base.json
@@ -8,7 +8,7 @@
     "iso_checksum": "14cf73d5070bc2fa8c75c636ea69a47e",
     "headless": "true",
     "tools_iso": "{{env `VMWARE_TOOLS_ISO`}}/windows.iso",
-    "vmware_output_dir": "{{env `VMWARE_OUTPUT_DIR`}}"
+    "packer_output_dir": "{{env `PACKER_VM_OUT_DIR`}}"
   },
 
   "description": "Builds a Windows Server 10 Enterprise template VM for use in VMware",
@@ -24,7 +24,7 @@
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "output_directory": "{{user `vmware_output_dir`}}/output-{{build_name}}",
+      "output_directory": "{{user `packer_output_dir`}}/output-{{build_name}}",
 
       "headless": "{{user `headless`}}",
 

--- a/templates/windows-10/x86_64.vmware.slipstream.json
+++ b/templates/windows-10/x86_64.vmware.slipstream.json
@@ -9,7 +9,7 @@
     "iso_checksum": "06fc1188353f10b007c1e4a8f08b36b6",
     "headless": "false",
     "tools_iso": "{{env `VMWARE_TOOLS_ISO`}}/windows.iso",
-    "vmware_output_dir": "{{env `VMWARE_OUTPUT_DIR`}}"
+    "packer_output_dir": "{{env `PACKER_VM_OUT_DIR`}}"
   },
 
   "description": "Builds a Windows Server 10 Enterprise template VM for use in VMware",
@@ -25,7 +25,7 @@
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "output_directory": "{{user `vmware_output_dir`}}/output-{{build_name}}",
+      "output_directory": "{{user `packer_output_dir`}}/output-{{build_name}}",
 
       "headless": "{{user `headless`}}",
 

--- a/templates/windows-10/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-10/x86_64.vmware.vsphere.cygwin.json
@@ -17,7 +17,8 @@
     "packer_vcenter_net": "{{env `PACKER_VCENTER_NET`}}",
     "packer_vcenter_insecure": "{{env `PACKER_VCENTER_INSECURE`}}",
     "packer_sha": "{{env `PACKER_SHA`}}",
-    "vmware_output_dir": "{{env `VMWARE_OUTPUT_DIR`}}"
+    "packer_source_dir": "{{env `PACKER_VM_SRC_DIR`}}",
+    "packer_output_dir": "{{env `PACKER_VM_OUT_DIR`}}"
   },
 
   "description": "Builds a Windows 10 (Anniversary Edition) template VM for use in VMware",
@@ -27,8 +28,8 @@
       "name": "{{user `template_name`}}-{{user `provisioner`}}-vsphere-cygwin",
       "vm_name": "packer-{{build_name}}",
       "type": "vmware-vmx",
-      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
-      "output_directory": "{{user `vmware_output_dir`}}/output-{{build_name}}",
+      "source_path": "{{user `packer_source_dir`}}/output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
+      "output_directory": "{{user `packer_output_dir`}}/output-{{build_name}}",
 
       "headless": "{{user `headless`}}",
 
@@ -176,7 +177,8 @@
       "vm_folder": "{{user `packer_vcenter_folder`}}",
       "vm_name": "{{user `template_name`}}-{{user `version`}}",
       "vm_network": "{{user `packer_vcenter_net`}}",
-      "insecure" : "{{user `packer_vcenter_insecure`}}"
+      "insecure" : "{{user `packer_vcenter_insecure`}}",
+      "overwrite" : "true"
     }
   ]
 }

--- a/templates/windows-2008r2/x86_64.vmware.base.json
+++ b/templates/windows-2008r2/x86_64.vmware.base.json
@@ -8,7 +8,7 @@
     "iso_checksum": "1d1941c6d90389ba28c2068ac0d5b6ba",
     "headless": "true",
     "tools_iso": "{{env `VMWARE_TOOLS_ISO`}}/windows.iso",
-    "vmware_output_dir": "{{env `VMWARE_OUTPUT_DIR`}}"
+    "packer_output_dir": "{{env `PACKER_VM_OUT_DIR`}}"
   },
 
   "description": "Builds a Windows Server 2008R2 template VM for use in VMware",
@@ -24,7 +24,7 @@
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "output_directory": "{{user `vmware_output_dir`}}/output-{{build_name}}",
+      "output_directory": "{{user `packer_output_dir`}}/output-{{build_name}}",
 
       "headless": "{{user `headless`}}",
 

--- a/templates/windows-2008r2/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-2008r2/x86_64.vmware.vsphere.cygwin.json
@@ -17,7 +17,8 @@
     "packer_vcenter_net": "{{env `PACKER_VCENTER_NET`}}",
     "packer_vcenter_insecure": "{{env `PACKER_VCENTER_INSECURE`}}",
     "packer_sha": "{{env `PACKER_SHA`}}",
-    "vmware_output_dir": "{{env `VMWARE_OUTPUT_DIR`}}"
+    "packer_source_dir": "{{env `PACKER_VM_SRC_DIR`}}",
+    "packer_output_dir": "{{env `PACKER_VM_OUT_DIR`}}"
   },
 
   "description": "Builds a Windows Server 2012 template VM for use in VMware",
@@ -27,8 +28,8 @@
       "name": "{{user `template_name`}}-{{user `provisioner`}}-vsphere-cygwin",
       "vm_name": "packer-{{build_name}}",
       "type": "vmware-vmx",
-      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
-      "output_directory": "{{user `vmware_output_dir`}}/output-{{build_name}}",
+      "source_path": "{{user `packer_source_dir`}}/output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
+      "output_directory": "{{user `packer_output_dir`}}/output-{{build_name}}",
 
       "headless": "{{user `headless`}}",
 
@@ -177,7 +178,8 @@
       "vm_folder": "{{user `packer_vcenter_folder`}}",
       "vm_name": "{{user `template_name`}}-{{user `version`}}",
       "vm_network": "{{user `packer_vcenter_net`}}",
-      "insecure" : "{{user `packer_vcenter_insecure`}}"
+      "insecure" : "{{user `packer_vcenter_insecure`}}",
+      "overwrite" : "true"
     }
   ]
 }

--- a/templates/windows-2012/x86_64.vmware.base.json
+++ b/templates/windows-2012/x86_64.vmware.base.json
@@ -8,7 +8,7 @@
     "iso_checksum": "9557556a063802c1d29e55a6d539e2ed",
     "headless": "true",
     "tools_iso": "{{env `VMWARE_TOOLS_ISO`}}/windows.iso",
-    "vmware_output_dir": "{{env `VMWARE_OUTPUT_DIR`}}"
+    "packer_output_dir": "{{env `PACKER_VM_OUT_DIR`}}"
   },
 
   "description": "Builds a Windows Server 2012 template VM for use in VMware",
@@ -24,7 +24,7 @@
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "output_directory": "{{user `vmware_output_dir`}}/output-{{build_name}}",
+      "output_directory": "{{user `packer_output_dir`}}/output-{{build_name}}",
 
       "headless": "{{user `headless`}}",
 

--- a/templates/windows-2012/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-2012/x86_64.vmware.vsphere.cygwin.json
@@ -17,7 +17,8 @@
     "packer_vcenter_net": "{{env `PACKER_VCENTER_NET`}}",
     "packer_vcenter_insecure": "{{env `PACKER_VCENTER_INSECURE`}}",
     "packer_sha": "{{env `PACKER_SHA`}}",
-    "vmware_output_dir": "{{env `VMWARE_OUTPUT_DIR`}}"
+    "packer_source_dir": "{{env `PACKER_VM_SRC_DIR`}}",
+    "packer_output_dir": "{{env `PACKER_VM_OUT_DIR`}}"
   },
 
   "description": "Builds a Windows Server 2012 template VM for use in VMware",
@@ -27,8 +28,8 @@
       "name": "{{user `template_name`}}-{{user `provisioner`}}-vsphere-cygwin",
       "vm_name": "packer-{{build_name}}",
       "type": "vmware-vmx",
-      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
-      "output_directory": "{{user `vmware_output_dir`}}/output-{{build_name}}",
+      "source_path": "{{user `packer_source_dir`}}/output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
+      "output_directory": "{{user `packer_output_dir`}}/output-{{build_name}}",
 
       "headless": "{{user `headless`}}",
 
@@ -177,7 +178,8 @@
       "vm_folder": "{{user `packer_vcenter_folder`}}",
       "vm_name": "{{user `template_name`}}-{{user `version`}}",
       "vm_network": "{{user `packer_vcenter_net`}}",
-      "insecure" : "{{user `packer_vcenter_insecure`}}"
+      "insecure" : "{{user `packer_vcenter_insecure`}}",
+      "overwrite" : "true"
     }
   ]
 }

--- a/templates/windows-2012r2-ja/x86_64.vmware.base.json
+++ b/templates/windows-2012r2-ja/x86_64.vmware.base.json
@@ -8,7 +8,7 @@
     "iso_checksum": "d06430e4ddc79330649b4b16d984a3d5",
     "headless": "true",
     "tools_iso": "{{env `VMWARE_TOOLS_ISO`}}/windows.iso",
-    "vmware_output_dir": "{{env `VMWARE_OUTPUT_DIR`}}"
+    "packer_output_dir": "{{env `PACKER_VM_OUT_DIR`}}"
   },
 
   "description": "Builds a Windows Server 2012 R2 Japanese template VM for use in VMware",
@@ -24,7 +24,7 @@
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "output_directory": "{{user `vmware_output_dir`}}/output-{{build_name}}",
+      "output_directory": "{{user `packer_output_dir`}}/output-{{build_name}}",
 
       "headless": "{{user `headless`}}",
 

--- a/templates/windows-2012r2-ja/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-2012r2-ja/x86_64.vmware.vsphere.cygwin.json
@@ -17,7 +17,8 @@
     "packer_vcenter_net": "{{env `PACKER_VCENTER_NET`}}",
     "packer_vcenter_insecure": "{{env `PACKER_VCENTER_INSECURE`}}",
     "packer_sha": "{{env `PACKER_SHA`}}",
-    "vmware_output_dir": "{{env `VMWARE_OUTPUT_DIR`}}"
+    "packer_source_dir": "{{env `PACKER_VM_SRC_DIR`}}",
+    "packer_output_dir": "{{env `PACKER_VM_OUT_DIR`}}"
   },
 
   "description": "Builds a Windows Server 2012 R2 Japanese template VM for use in VMware",
@@ -27,8 +28,8 @@
       "name": "{{user `template_name`}}-{{user `provisioner`}}-vsphere-cygwin",
       "vm_name": "packer-{{build_name}}",
       "type": "vmware-vmx",
-      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
-      "output_directory": "{{user `vmware_output_dir`}}/output-{{build_name}}",
+      "source_path": "{{user `packer_source_dir`}}/output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
+      "output_directory": "{{user `packer_output_dir`}}/output-{{build_name}}",
 
       "headless": "{{user `headless`}}",
 
@@ -177,7 +178,8 @@
       "vm_folder": "{{user `packer_vcenter_folder`}}",
       "vm_name": "{{user `template_name`}}-{{user `version`}}",
       "vm_network": "{{user `packer_vcenter_net`}}",
-      "insecure" : "{{user `packer_vcenter_insecure`}}"
+      "insecure" : "{{user `packer_vcenter_insecure`}}",
+      "overwrite" : "true"
     }
   ]
 }

--- a/templates/windows-2012r2/x86_64.virtualbox.base.json
+++ b/templates/windows-2012r2/x86_64.virtualbox.base.json
@@ -44,7 +44,8 @@
         "../../scripts/windows/generalize-packer.bat",
         "../../scripts/windows/start-boxstarter.ps1",
         "../../scripts/windows/windows-env.ps1",
-        "../../scripts/windows/clean-disk-dism.ps1"
+        "../../scripts/windows/clean-disk-dism.ps1",
+        "../../scripts/windows/clean-disk-sdelete.ps1"
       ]
     }
   ],

--- a/templates/windows-2012r2/x86_64.virtualbox.base.json
+++ b/templates/windows-2012r2/x86_64.virtualbox.base.json
@@ -9,7 +9,7 @@
     "headless"         : "true",
     "memory_size"      : "2048",
     "cpu_count"        : "2",
-    "vmware_output_dir": "{{env `VMWARE_OUTPUT_DIR`}}"
+    "packer_output_dir": "{{env `PACKER_VM_OUT_DIR`}}"
   },
   "description": "Builds a Windows Server 2012 R2 template VM for use in VirtualBox",
   "builders": [
@@ -17,7 +17,7 @@
       "type"                   : "virtualbox-iso",
       "name"                   : "{{user `template_name`}}-{{user `provisioner`}}",
       "vm_name"                : "packer-{{build_name}}",
-      "output_directory"       : "{{user `vmware_output_dir`}}/output-{{build_name}}",
+      "output_directory"       : "{{user `packer_output_dir`}}/output-{{build_name}}",
       "iso_url"                : "{{user `iso_url`}}",
       "iso_checksum_type"      : "{{user `iso_checksum_type`}}",
       "iso_checksum"           : "{{user `iso_checksum`}}",

--- a/templates/windows-2012r2/x86_64.virtualbox.vagrant.cygwin.json
+++ b/templates/windows-2012r2/x86_64.virtualbox.vagrant.cygwin.json
@@ -5,14 +5,16 @@
     "headless"      : "true",
     "qa_root_passwd": "{{env `QA_ROOT_PASSWD_PLAIN`}}",
     "packer_sha"    : "{{env `PACKER_SHA`}}",
-    "vmware_output_dir": "{{env `VMWARE_OUTPUT_DIR`}}"
+    "packer_source_dir": "{{env `PACKER_VM_SRC_DIR`}}",
+    "packer_output_dir": "{{env `PACKER_VM_OUT_DIR`}}"
   },
   "description": "Builds a Windows Server 2012 R2 template VM for use in VirtualBox with Vagrant",
   "builders": [
     {
       "type"                : "virtualbox-ovf",
       "name"                : "{{user `template_name`}}-{{user `provisioner`}}-vagrant-cygwin",
-      "source_path"         : "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.ovf",
+      "source_path"         : "{{user `packer_source_dir`}}/output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.ovf",
+      "output_directory"    : "{{user `packer_output_dir`}}/output-{{build_name}}",
       "headless"            : "{{user `headless`}}",
       "communicator"        : "winrm",
       "winrm_username"      : "vagrant",

--- a/templates/windows-2012r2/x86_64.vmware.base.json
+++ b/templates/windows-2012r2/x86_64.vmware.base.json
@@ -8,7 +8,7 @@
     "iso_checksum": "5006c404bded89c4f7f24e7df8c6a266",
     "headless": "true",
     "tools_iso": "{{env `VMWARE_TOOLS_ISO`}}/windows.iso",
-    "vmware_output_dir": "{{env `VMWARE_OUTPUT_DIR`}}"
+    "packer_output_dir": "{{env `PACKER_VM_OUT_DIR`}}"
   },
 
   "description": "Builds a Windows Server 2012 R2 template VM for use in VMware",
@@ -24,7 +24,7 @@
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "output_directory": "{{user `vmware_output_dir`}}/output-{{build_name}}",
+      "output_directory": "{{user `packer_output_dir`}}/output-{{build_name}}",
 
       "headless": "{{user `headless`}}",
 

--- a/templates/windows-2012r2/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-2012r2/x86_64.vmware.vsphere.cygwin.json
@@ -17,7 +17,8 @@
     "packer_vcenter_net": "{{env `PACKER_VCENTER_NET`}}",
     "packer_vcenter_insecure": "{{env `PACKER_VCENTER_INSECURE`}}",
     "packer_sha": "{{env `PACKER_SHA`}}",
-    "vmware_output_dir": "{{env `VMWARE_OUTPUT_DIR`}}"
+    "packer_source_dir": "{{env `PACKER_VM_SRC_DIR`}}",
+    "packer_output_dir": "{{env `PACKER_VM_OUT_DIR`}}"
   },
 
   "description": "Builds a Windows Server 2012 R2 template VM for use in VMware",
@@ -27,8 +28,8 @@
       "name": "{{user `template_name`}}-{{user `provisioner`}}-vsphere-cygwin",
       "vm_name": "packer-{{build_name}}",
       "type": "vmware-vmx",
-      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
-      "output_directory": "{{user `vmware_output_dir`}}/output-{{build_name}}",
+      "source_path": "{{user `packer_source_dir`}}/output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
+      "output_directory": "{{user `packer_output_dir`}}/output-{{build_name}}",
 
       "headless": "{{user `headless`}}",
 
@@ -181,7 +182,8 @@
       "vm_folder": "{{user `packer_vcenter_folder`}}",
       "vm_name": "{{user `template_name`}}-{{user `version`}}",
       "vm_network": "{{user `packer_vcenter_net`}}",
-      "insecure" : "{{user `packer_vcenter_insecure`}}"
+      "insecure" : "{{user `packer_vcenter_insecure`}}",
+      "overwrite" : "true"
     }
   ]
 }

--- a/templates/windows-2016/x86_64.vmware.base.json
+++ b/templates/windows-2016/x86_64.vmware.base.json
@@ -8,7 +8,7 @@
     "iso_checksum": "0abed3337eb4773fa2a3efc6701e370b",
     "headless": "true",
     "tools_iso": "{{env `VMWARE_TOOLS_ISO`}}/windows.iso",
-    "vmware_output_dir": "{{env `VMWARE_OUTPUT_DIR`}}"
+    "packer_output_dir": "{{env `PACKER_VM_OUT_DIR`}}"
   },
 
   "description": "Builds a Windows Server 2016 Technical Preview template VM for use in VMware",
@@ -24,7 +24,7 @@
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "output_directory": "{{user `vmware_output_dir`}}/output-{{build_name}}",
+      "output_directory": "{{user `packer_output_dir`}}/output-{{build_name}}",
 
       "headless": "{{user `headless`}}",
 

--- a/templates/windows-2016/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-2016/x86_64.vmware.vsphere.cygwin.json
@@ -17,7 +17,8 @@
     "packer_vcenter_net": "{{env `PACKER_VCENTER_NET`}}",
     "packer_vcenter_insecure": "{{env `PACKER_VCENTER_INSECURE`}}",
     "packer_sha": "{{env `PACKER_SHA`}}",
-    "vmware_output_dir": "{{env `VMWARE_OUTPUT_DIR`}}"
+    "packer_source_dir": "{{env `PACKER_VM_SRC_DIR`}}",
+    "packer_output_dir": "{{env `PACKER_VM_OUT_DIR`}}"
   },
 
   "description": "Builds a Windows Server 2016 Technical Preview 5 template VM for use in VMware",
@@ -27,8 +28,8 @@
       "name": "{{user `template_name`}}-{{user `provisioner`}}-vsphere-cygwin",
       "vm_name": "packer-{{build_name}}",
       "type": "vmware-vmx",
-      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
-      "output_directory": "{{user `vmware_output_dir`}}/output-{{build_name}}",
+      "source_path": "{{user `packer_source_dir`}}/output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
+      "output_directory": "{{user `packer_output_dir`}}/output-{{build_name}}",
 
       "headless": "{{user `headless`}}",
 
@@ -176,7 +177,8 @@
       "vm_folder": "{{user `packer_vcenter_folder`}}",
       "vm_name": "{{user `template_name`}}-{{user `version`}}",
       "vm_network": "{{user `packer_vcenter_net`}}",
-      "insecure" : "{{user `packer_vcenter_insecure`}}"
+      "insecure" : "{{user `packer_vcenter_insecure`}}",
+      "overwrite" : "true"
     }
   ]
 }

--- a/templates/windows-7/x86_64.vmware.base.json
+++ b/templates/windows-7/x86_64.vmware.base.json
@@ -8,7 +8,7 @@
     "iso_checksum": "d0cfa6d4de725e14ba72f4fd91c615b0",
     "headless": "true",
     "tools_iso": "{{env `VMWARE_TOOLS_ISO`}}/windows.iso",
-    "vmware_output_dir": "{{env `VMWARE_OUTPUT_DIR`}}"
+    "packer_output_dir": "{{env `PACKER_VM_OUT_DIR`}}"
   },
 
   "description": "Builds a Windows Server 7 Enterprise template VM for use in VMware",
@@ -24,7 +24,7 @@
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "output_directory": "{{user `vmware_output_dir`}}/output-{{build_name}}",
+      "output_directory": "{{user `packer_output_dir`}}/output-{{build_name}}",
 
       "headless": "{{user `headless`}}",
 

--- a/templates/windows-7/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-7/x86_64.vmware.vsphere.cygwin.json
@@ -17,7 +17,8 @@
     "packer_vcenter_net": "{{env `PACKER_VCENTER_NET`}}",
     "packer_vcenter_insecure": "{{env `PACKER_VCENTER_INSECURE`}}",
     "packer_sha": "{{env `PACKER_SHA`}}",
-    "vmware_output_dir": "{{env `VMWARE_OUTPUT_DIR`}}"
+    "packer_source_dir": "{{env `PACKER_VM_SRC_DIR`}}",
+    "packer_output_dir": "{{env `PACKER_VM_OUT_DIR`}}"
   },
 
   "description": "Builds a Windows 7 template VM for use in VMware",
@@ -27,8 +28,8 @@
       "name": "{{user `template_name`}}-{{user `provisioner`}}-vsphere-cygwin",
       "vm_name": "packer-{{build_name}}",
       "type": "vmware-vmx",
-      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
-      "output_directory": "{{user `vmware_output_dir`}}/output-{{build_name}}",
+      "source_path": "{{user `packer_source_dir`}}/output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
+      "output_directory": "{{user `packer_output_dir`}}/output-{{build_name}}",
 
       "headless": "{{user `headless`}}",
 
@@ -176,7 +177,8 @@
       "vm_folder": "{{user `packer_vcenter_folder`}}",
       "vm_name": "{{user `template_name`}}-{{user `version`}}",
       "vm_network": "{{user `packer_vcenter_net`}}",
-      "insecure" : "{{user `packer_vcenter_insecure`}}"
+      "insecure" : "{{user `packer_vcenter_insecure`}}",
+      "overwrite" : "true"
     }
   ]
 }

--- a/templates/windows-8.1/x86_64.vmware.base.json
+++ b/templates/windows-8.1/x86_64.vmware.base.json
@@ -8,7 +8,7 @@
     "iso_checksum": "ce996fb7136d55314747c5cef2602b27",
     "headless": "true",
     "tools_iso": "{{env `VMWARE_TOOLS_ISO`}}/windows.iso",
-    "vmware_output_dir": "{{env `VMWARE_OUTPUT_DIR`}}"
+    "packer_output_dir": "{{env `PACKER_VM_OUT_DIR`}}"
   },
 
   "description": "Builds a Windows Server 8.1 Enterprise template VM for use in VMware",
@@ -24,7 +24,7 @@
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "output_directory": "{{user `vmware_output_dir`}}/output-{{build_name}}",
+      "output_directory": "{{user `packer_output_dir`}}/output-{{build_name}}",
 
       "headless": "{{user `headless`}}",
 

--- a/templates/windows-8.1/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-8.1/x86_64.vmware.vsphere.cygwin.json
@@ -18,7 +18,8 @@
     "packer_vcenter_insecure": "{{env `PACKER_VCENTER_INSECURE`}}",
     "packer_sha": "{{env `PACKER_SHA`}}",
 
-    "vmware_output_dir": "{{env `VMWARE_OUTPUT_DIR`}}"
+    "packer_source_dir": "{{env `PACKER_VM_SRC_DIR`}}",
+    "packer_output_dir": "{{env `PACKER_VM_OUT_DIR`}}"
   },
 
   "description": "Builds a Windows 8.1 template VM for use in VMware",
@@ -28,8 +29,8 @@
       "name": "{{user `template_name`}}-{{user `provisioner`}}-vsphere-cygwin",
       "vm_name": "packer-{{build_name}}",
       "type": "vmware-vmx",
-      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
-      "output_directory": "{{user `vmware_output_dir`}}/output-{{build_name}}",
+      "source_path": "{{user `packer_source_dir`}}/output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
+      "output_directory": "{{user `packer_output_dir`}}/output-{{build_name}}",
 
       "headless": "{{user `headless`}}",
 
@@ -177,7 +178,8 @@
       "vm_folder": "{{user `packer_vcenter_folder`}}",
       "vm_name": "{{user `template_name`}}-{{user `version`}}",
       "vm_network": "{{user `packer_vcenter_net`}}",
-      "insecure" : "{{user `packer_vcenter_insecure`}}"
+      "insecure" : "{{user `packer_vcenter_insecure`}}",
+      "overwrite" : "true"
     }
   ]
 }


### PR DESCRIPTION
This is to support the updated jenkins/jjb job structure and using Git specifications in the build.

It also updates the Input/Output directories for all the Windows/Packer builds to remove Hypervisor (VMWARE) specific dents and to support the vagrant builds on ```jenkins-imaging```