### PR TITLE
(IMAGES-480) Enable LSA for Cygwin Authentication

### DIFF
--- a/scripts/windows/init/vagrant-arm-host.ps1
+++ b/scripts/windows/init/vagrant-arm-host.ps1
@@ -22,6 +22,10 @@ Write-Host "Setup Authorised Keys"
 & $CygWinShell --login -c `'cp /home/vagrant/.ssh/id_rsa.pub /home/vagrant/.ssh/authorized_keys`'
 & $CygWinShell --login -c `'cat "/cygdrive/c/Packer/Init/authorized_keys.vagrant" `>`> /home/vagrant/.ssh/authorized_keys`'
 
+# Setup LSA Authentication
+Write-Host "Register the Cygwin LSA authentication package "
+& $CygWinShell --login -c `'auto_answer="yes" /usr/bin/cyglsa-config`'
+
 # Add github.com as a known host (needed for git@gihub:<repo> clone ops)
 & $CygWinShell --login -c `'ssh-keyscan -t rsa github.com `>`> /home/vagrant/.ssh/known_hosts`'
 

--- a/scripts/windows/init/vmpooler-post-clone-configuration.ps1
+++ b/scripts/windows/init/vmpooler-post-clone-configuration.ps1
@@ -65,6 +65,10 @@ Write-Host "Setup Authorised Keys"
 & $CygWinShell --login -c `'cp /home/Administrator/.ssh/id_rsa.pub /home/Administrator/.ssh/authorized_keys`'
 & $CygWinShell --login -c `'cat "/cygdrive/c/Packer/Init/authorized_keys.vmpooler" `>`> /home/Administrator/.ssh/authorized_keys`'
 
+# Setup LSA Authentication
+Write-Host "Register the Cygwin LSA authentication package "
+& $CygWinShell --login -c `'auto_answer="yes" /usr/bin/cyglsa-config`'
+
 # Add github.com as a known host (needed for git@gihub:<repo> clone ops)
 & $CygWinShell --login -c `'ssh-keyscan -t rsa github.com `>`> /home/Administrator/.ssh/known_hosts`'
 

--- a/templates/windows-2012r2/x86_64.virtualbox.vagrant.cygwin.json
+++ b/templates/windows-2012r2/x86_64.virtualbox.vagrant.cygwin.json
@@ -132,6 +132,9 @@
       "inline": [
         "C:\\Packer\\Init\\vagrant-arm-host.ps1"
       ]
+    },
+    {
+      "type": "windows-restart"
     }
   ],
     "post-processors": [{


### PR DESCRIPTION
This corrects the issue where sshd can't create a proper token
when using ssh public key authentication. This is documented in
https://cygwin.com/cygwin-ug-net/ntsec.html#ntsec-nopasswd1.

