### PR TITLE
(IMAGES-39) Add Windows-2008 Template

### DIFF
--- a/scripts/windows/clean-disk-dism.ps1
+++ b/scripts/windows/clean-disk-dism.ps1
@@ -4,8 +4,6 @@ $ErrorActionPreference = 'Stop'
 
 $SpaceAtStart = [Math]::Round( ((Get-WmiObject win32_logicaldisk | where { $_.DeviceID -eq $env:SystemDrive }).FreeSpace)/1GB, 2)
 
-$WindowsVersion = (Get-WmiObject win32_operatingsystem).version
-
 #Set all CleanMgr VolumeCache keys to StateFlags = 0 to prevent cleanup. After, set the proper keys to 2 to allow cleanup.
 $SubKeys = Get-Childitem HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches
 Foreach ($Key in $SubKeys)
@@ -16,7 +14,12 @@ Foreach ($Key in $SubKeys)
 # Cleanup Windows Update area after all that
 # Clean the WinSxS area - actual action depends on OS Level - full DISM commands only available from 2012R2 and later.
 Write-Host "Cleaning up WinxSx updates"
-if ($WindowsVersion -eq '6.1.7601') {
+$WindowsVersion = (Get-WmiObject win32_operatingsystem).version
+If ($WindowsVersion -eq '6.0.6002') {
+  Write-Host "Windows 2008 - Reduced cleanup"
+  compcln /quiet
+}
+ElseIf ($WindowsVersion -eq '6.1.7601' ) {
   # Windows 2008R2/Win-7 - just set registry keys for cleanmgr utility
   reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches\Update Cleanup"       /v $CleanMgrStateFlags /t REG_DWORD /d $CleanMgrStateFlagClean /f
   reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches\Service Pack Cleanup" /v $CleanMgrStateFlags /t REG_DWORD /d $CleanMgrStateFlagClean /f
@@ -30,29 +33,38 @@ ElseIf ($WindowsVersion -eq '6.2.9200') {
   dism /online /cleanup-image /SPSuperseded
 }
 
-# Set registry keys for all the other cleanup areas we want to address with cleanmgr - fairly comprehensive cleanup
-reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches\Active Setup Temp Folders"                    /v $CleanMgrStateFlags /t REG_DWORD /d $CleanMgrStateFlagClean /f
-reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches\Downloaded Program Files"                     /v $CleanMgrStateFlags /t REG_DWORD /d $CleanMgrStateFlagClean /f
-reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches\Internet Cache Files"                         /v $CleanMgrStateFlags /t REG_DWORD /d $CleanMgrStateFlagClean /f
-reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches\Memory Dump Files"                            /v $CleanMgrStateFlags /t REG_DWORD /d $CleanMgrStateFlagClean /f
-reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches\Old ChkDsk Files"                             /v $CleanMgrStateFlags /t REG_DWORD /d $CleanMgrStateFlagClean /f
-reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches\Previous Installations"                       /v $CleanMgrStateFlags /t REG_DWORD /d $CleanMgrStateFlagClean /f
-reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches\Recycle Bin"                                  /v $CleanMgrStateFlags /t REG_DWORD /d $CleanMgrStateFlagClean /f
-reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches\Setup Log Files"                              /v $CleanMgrStateFlags /t REG_DWORD /d $CleanMgrStateFlagClean /f
-reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches\System error memory dump files"               /v $CleanMgrStateFlags /t REG_DWORD /d $CleanMgrStateFlagClean /f
-reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches\System error minidump files"                  /v $CleanMgrStateFlags /t REG_DWORD /d $CleanMgrStateFlagClean /f
-reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches\Temporary Files"                              /v $CleanMgrStateFlags /t REG_DWORD /d $CleanMgrStateFlagClean /f
-reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches\Temporary Setup Files"                        /v $CleanMgrStateFlags /t REG_DWORD /d $CleanMgrStateFlagClean /f
-reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches\Upgrade Discarded Files"                      /v $CleanMgrStateFlags /t REG_DWORD /d $CleanMgrStateFlagClean /f
-reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches\Windows Error Reporting Archive Files"        /v $CleanMgrStateFlags /t REG_DWORD /d $CleanMgrStateFlagClean /f
-reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches\Windows Error Reporting Queue Files"          /v $CleanMgrStateFlags /t REG_DWORD /d $CleanMgrStateFlagClean /f
-reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches\Windows Error Reporting System Archive Files" /v $CleanMgrStateFlags /t REG_DWORD /d $CleanMgrStateFlagClean /f
-reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches\Windows Error Reporting System Queue Files"   /v $CleanMgrStateFlags /t REG_DWORD /d $CleanMgrStateFlagClean /f
-reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches\Windows Upgrade Log Files"                    /v $CleanMgrStateFlags /t REG_DWORD /d $CleanMgrStateFlagClean /f
+If ($WindowsVersion -eq '6.0.6002') {
+  Write-Host "Skipping CleanMgr for Windows 2008"
+}
+else {
+  # Set registry keys for all the other cleanup areas we want to address with cleanmgr - fairly comprehensive cleanup
+  $cleankeyprefix = "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches"
+  $cleanmgrgroups = @(
+    'Active Setup Temp Folders',
+    'Downloaded Program Files',
+    'Internet Cache Files',
+    'Memory Dump Files',
+    'Old ChkDsk Files',
+    'Previous Installations',
+    'Recycle Bin',
+    'Setup Log Files',
+    'System error memory dump files',
+    'System error minidump files',
+    'Temporary Files',
+    'Temporary Setup Files',
+    'Upgrade Discarded Files',
+    'Windows Error Reporting Archive Files',
+    'Windows Error Reporting Queue Files',
+    'Windows Error Reporting System Archive Files',
+    'Windows Error Reporting System Queue Files',
+    'Windows Upgrade Log Files'
+  )
+  $cleanmgrgroups | % { reg.exe ADD "$cleankeyprefix\$_" /v $CleanMgrStateFlags /t REG_DWORD /d $CleanMgrStateFlagClean /f }
 
-# Run Cleanmgr utility
-Write-Host "Running CleanMgr with Sagerun:$CleanMgrSageSet"
-Start-Process -Wait "cleanmgr" -ArgumentList "/sagerun:$CleanMgrSageSet"
+  # Run Cleanmgr utility
+  Write-Host "Running CleanMgr with Sagerun:$CleanMgrSageSet"
+  Start-Process -Wait "cleanmgr" -ArgumentList "/sagerun:$CleanMgrSageSet"
+}
 
 # Now that all Update operations are complete, disable Windows Update and STOP it.
 Write-Host "Stopping and Disabling Windows Update"

--- a/scripts/windows/clean-disk-dism.ps1
+++ b/scripts/windows/clean-disk-dism.ps1
@@ -14,17 +14,16 @@ Foreach ($Key in $SubKeys)
 # Cleanup Windows Update area after all that
 # Clean the WinSxS area - actual action depends on OS Level - full DISM commands only available from 2012R2 and later.
 Write-Host "Cleaning up WinxSx updates"
-$WindowsVersion = (Get-WmiObject win32_operatingsystem).version
-If ($WindowsVersion -eq '6.0.6002') {
+If ($WindowsVersion -like $WindowsServer2008) {
   Write-Host "Windows 2008 - Reduced cleanup"
   compcln /quiet
 }
-ElseIf ($WindowsVersion -eq '6.1.7601' ) {
+ElseIf ($WindowsVersion -like $WindowsServer2008R2 ) {
   # Windows 2008R2/Win-7 - just set registry keys for cleanmgr utility
   reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches\Update Cleanup"       /v $CleanMgrStateFlags /t REG_DWORD /d $CleanMgrStateFlagClean /f
   reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches\Service Pack Cleanup" /v $CleanMgrStateFlags /t REG_DWORD /d $CleanMgrStateFlagClean /f
 }
-ElseIf ($WindowsVersion -eq '6.2.9200') {
+ElseIf ($WindowsVersion -like $WindowsServer2012) {
   # Note /ResetBase option is not available on Windows-2012, so need to screen for this.
   dism /online /Cleanup-Image /StartComponentCleanup
   dism /online /cleanup-image /SPSuperseded
@@ -33,7 +32,7 @@ ElseIf ($WindowsVersion -eq '6.2.9200') {
   dism /online /cleanup-image /SPSuperseded
 }
 
-If ($WindowsVersion -eq '6.0.6002') {
+If ($WindowsVersion -like $WindowsServer2008) {
   Write-Host "Skipping CleanMgr for Windows 2008"
 }
 else {

--- a/scripts/windows/cleanup-host.ps1
+++ b/scripts/windows/cleanup-host.ps1
@@ -38,8 +38,14 @@ if ($env:ChocolateyToolsRoot -ne '' -and $env:ChocolateyToolsRoot -ne $null) { R
 reg.exe delete "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" /v "ChocolateyInstall" /f
 
 # Run Cleanmgr again.
-Write-Host "Running CleanMgr with Sagerun:$CleanMgrSageSet"
-Start-Process -Wait "cleanmgr" -ArgumentList "/sagerun:$CleanMgrSageSet"
+$WindowsVersion = (Get-WmiObject win32_operatingsystem).version
+If ($WindowsVersion -eq '6.0.6002') {
+  Write-Host "Skipping CleanMgr for Windows 2008"
+}
+else {
+  Write-Host "Running CleanMgr with Sagerun:$CleanMgrSageSet"
+  Start-Process -Wait "cleanmgr" -ArgumentList "/sagerun:$CleanMgrSageSet"
+}
 
 # Clean up files (including those not addressed by cleanmgr)
 # This list is a bit different from that in the dism cleanup script.
@@ -93,7 +99,6 @@ Write-Host "Reclaimed $SpaceReclaimed GB"
 # So Powershell Version 2 and earlier must resort to diskpart.
 # Need to add extra check for Win-2008r2 even with WMF 5 added as this still breaks.
 
-$WindowsVersion = (Get-WmiObject win32_operatingsystem).version
 if ($psversiontable.psversion.major -gt 2 -and $WindowsVersion -ne '6.1.7601') {
   $size = (Get-PartitionSupportedSize -DriveLetter C)
   $sizemax = $size.SizeMax

--- a/scripts/windows/generate-slipstream.ps1
+++ b/scripts/windows/generate-slipstream.ps1
@@ -94,12 +94,11 @@ ForEach ($Cab in $Cabs) {
     }
 }
 
-$WindowsVersion = (Get-WmiObject win32_operatingsystem).version
-if ($WindowsVersion -eq '6.1.7601' ) {
+if ($WindowsVersion -like $WindowsServer2008R2 ) {
   # Windows 2008R2/Win-7 - just set registry keys for cleanmgr utility
   Write-Host "Skipping Cleanup"
 }
-ElseIf ($WindowsVersion -eq '6.2.9200' -or $WindowsVersion -eq '6.0.6002') {
+ElseIf ($WindowsVersion -like $WindowsServer2012 -or $WindowsVersion -like $WindowsServer2008) {
   # Note /ResetBase option is not available on Windows-2012, so need to screen for this.
   Write-Host "Skipping Cleanup"
 } else {

--- a/scripts/windows/init/vmpooler-arm-host.ps1
+++ b/scripts/windows/init/vmpooler-arm-host.ps1
@@ -4,8 +4,13 @@
 
 $ErrorActionPreference = 'Stop'
 
+# Windows version checking logic is copied here as its not present by Default
+# on the installed system (might be an idea to change this in the future)
+Set-Variable -Option Constant -Name WindowsServer2008   -Value "6.0.*"
+Set-Variable -Option Constant -Name WindowsServer2008r2 -Value "6.1.*"
 $WindowsVersion = (Get-WmiObject win32_operatingsystem).version
-If ($WindowsVersion -eq '6.0.6002') {
+
+If ($WindowsVersion -like $WindowsServer2008) {
   # This delight was obtained from: http://www.leeholmes.com/blog/2008/07/30/workaround-the-os-handles-position-is-not-what-filestream-expected/
   # It is only relevant for Win-2008SP2 when running Powershell in elevated mode.
   # Which seems to be necessary to get Puppet and other things to run correctly.

--- a/scripts/windows/init/vmpooler-arm-host.ps1
+++ b/scripts/windows/init/vmpooler-arm-host.ps1
@@ -4,6 +4,24 @@
 
 $ErrorActionPreference = 'Stop'
 
+$WindowsVersion = (Get-WmiObject win32_operatingsystem).version
+If ($WindowsVersion -eq '6.0.6002') {
+  # This delight was obtained from: http://www.leeholmes.com/blog/2008/07/30/workaround-the-os-handles-position-is-not-what-filestream-expected/
+  # It is only relevant for Win-2008SP2 when running Powershell in elevated mode.
+  # Which seems to be necessary to get Puppet and other things to run correctly.
+  # Suspect this is due to the early (mis)implementation of UAC in Vista/Win-2008
+  $bindingFlags = [Reflection.BindingFlags] "Instance,NonPublic,GetField"
+  $objectRef = $host.GetType().GetField("externalHostRef", $bindingFlags).GetValue($host)
+  $bindingFlags = [Reflection.BindingFlags] "Instance,NonPublic,GetProperty"
+  $consoleHost = $objectRef.GetType().GetProperty("Value", $bindingFlags).GetValue($objectRef, @())
+  [void] $consoleHost.GetType().GetProperty("IsStandardOutputRedirected", $bindingFlags).GetValue($consoleHost, @())
+  $bindingFlags = [Reflection.BindingFlags] "Instance,NonPublic,GetField"
+  $field = $consoleHost.GetType().GetField("standardOutputWriter", $bindingFlags)
+  $field.SetValue($consoleHost, [Console]::Out)
+  $field2 = $consoleHost.GetType().GetField("standardErrorWriter", $bindingFlags)
+  $field2.SetValue($consoleHost, [Console]::Out)
+}
+
 # Arm machine using RunOnce Keys
 Write-Host "Arming machine for first-run"
 reg import C:\Packer\Init\vmpooler-clone-arm-runonce.reg

--- a/scripts/windows/windows-env.ps1
+++ b/scripts/windows/windows-env.ps1
@@ -1,11 +1,17 @@
 # Placeholder Environment script for common variable definition.
 $ErrorActionPreference = 'Stop'
 
-# TODO Define variables in later tickets.
-
-# Windows Version is used for OS detection in several places, so put here.
+# Defining set of constants for Windows version checking used throughout the code.
+# Using Major/Minor versions only as listed in:
+#   https://msdn.microsoft.com/en-gb/library/windows/desktop/ms724832%28v=vs.85%29.aspx?f=255&MSPPError=-2147217396
+# These are intended to be checking using the "-like" comparison with these constants on the RHS of the test express
+# The $WindowsVersion variable is also determined at this stage as its used in multiple scripts.
+Set-Variable -Option Constant -Name WindowsServer2008   -Value "6.0.*"
+Set-Variable -Option Constant -Name WindowsServer2008r2 -Value "6.1.*"
+Set-Variable -Option Constant -Name WindowsServer2012   -Value "6.2.*"
 $WindowsVersion = (Get-WmiObject win32_operatingsystem).version
-If ($WindowsVersion -eq '6.0.6002') {
+
+If ($WindowsVersion -like $WindowsServer2008) {
   # This delight was obtained from: http://www.leeholmes.com/blog/2008/07/30/workaround-the-os-handles-position-is-not-what-filestream-expected/
   # It is only relevant for Win-2008SP2 when running Powershell in elevated mode.
   # Which seems to be necessary to get Puppet and other things to run correctly.
@@ -45,9 +51,9 @@ if ($ENV:PROCESSOR_ARCHITECTURE -eq 'x86') {
 
 # Cleanmgr Registry "SageSet" Value - setting this to "random" value and associated constants
 $CleanMgrSageSet = "5462"
-Set-Variable -Name CleanMgrStateFlags -Value "StateFlags$CleanMgrSageSet" -Option Constant
-Set-Variable -Name CleanMgrStateFlagClean -Value 2 -Option Constant
-Set-Variable -Name CleanMgrStateFlagNoAction -Value 0 -Option Constant
+Set-Variable -Option Constant -Name CleanMgrStateFlags        -Value "StateFlags$CleanMgrSageSet"
+Set-Variable -Option Constant -Name CleanMgrStateFlagClean    -Value 2
+Set-Variable -Option Constant -Name CleanMgrStateFlagNoAction -Value 0
 
 # Function to download the packages we need - used in several scripts.
 

--- a/templates/windows-2008/README.md
+++ b/templates/windows-2008/README.md
@@ -1,0 +1,16 @@
+# puppetlabs-packer
+
+### About
+
+This is the Windows 2008 Packer Template
+
+### VM settings
+
+
+## Documentation
+
+The Confluence Documentation for the process is at [Windows/Packer Imaging Process](https://confluence.puppetlabs.com/display/QE/Packer+Generation+of+Windows+Templates+for+VMPooler)
+
+### Issues
+
+Please open any issues within the CPR ( Community Package Repository ) project on the [Puppet Labs issue tracker](https://tickets.puppetlabs.com/browse/CPR).

--- a/templates/windows-2008/files/autounattend.xml
+++ b/templates/windows-2008/files/autounattend.xml
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns="urn:schemas-microsoft-com:unattend">
+    <servicing/>
+    <settings pass="windowsPE">
+        <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <SetupUILanguage>
+                <UILanguage>en-US</UILanguage>
+            </SetupUILanguage>
+            <InputLocale>en-US</InputLocale>
+            <SystemLocale>en-US</SystemLocale>
+            <UILanguage>en-US</UILanguage>
+            <UILanguageFallback>en-US</UILanguageFallback>
+            <UserLocale>en-US</UserLocale>
+        </component>
+        <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <DiskConfiguration>
+                <Disk wcm:action="add">
+                    <DiskID>0</DiskID>
+                    <WillWipeDisk>true</WillWipeDisk>
+                    <CreatePartitions>
+                        <!-- Windows partition -->
+                        <!-- Only Allocate 30G initially - rest will be allocated near end of prep -->
+                        <CreatePartition wcm:action="add">
+                            <Order>1</Order>
+                            <Type>Primary</Type>
+                            <Extend>false</Extend>
+                            <Size>32212</Size>
+                        </CreatePartition>
+                    </CreatePartitions>
+                    <ModifyPartitions>
+                        <!-- Windows partition -->
+                        <ModifyPartition wcm:action="add">
+                            <Order>1</Order>
+                            <PartitionID>1</PartitionID>
+                            <Label>Windows w2008R2</Label>
+                            <Format>NTFS</Format>
+                        </ModifyPartition>
+                    </ModifyPartitions>
+                </Disk>
+                <WillShowUI>OnError</WillShowUI>
+            </DiskConfiguration>
+            <ImageInstall>
+                <OSImage>
+                    <InstallFrom>
+                        <MetaData wcm:action="add">
+                            <Key>/IMAGE/NAME</Key>
+                            <Value>Windows Longhorn SERVERSTANDARD</Value>
+                        </MetaData>
+                    </InstallFrom>
+                    <InstallTo>
+                        <DiskID>0</DiskID>
+                        <PartitionID>1</PartitionID>
+                    </InstallTo>
+                </OSImage>
+            </ImageInstall>
+            <UserData>
+                <!-- Product Key from http://technet.microsoft.com/en-us/library/jj612867.aspx -->
+                <ProductKey>
+                    <!-- Do not uncomment the Key element if you are using trial ISOs -->
+                    <!-- KMS Setup keys  https://technet.microsoft.com/en-us/library/jj612867.aspx -->
+                    <Key>TM24T-X9RMF-VWXK6-X8JC9-BFGM2</Key>
+                    <WillShowUI>OnError</WillShowUI>
+                </ProductKey>
+                <AcceptEula>true</AcceptEula>
+                <FullName>Puppet Labs</FullName>
+                <Organization>Puppet Labs</Organization>
+            </UserData>
+        </component>
+    </settings>
+    <settings pass="specialize">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <OEMInformation>
+                <HelpCustomized>false</HelpCustomized>
+            </OEMInformation>
+            <ComputerName>*</ComputerName>
+            <TimeZone>UTC</TimeZone>
+            <RegisteredOwner />
+            <AutoLogon>
+                <Password>
+                    <Value>PackerAdmin</Value>
+                    <PlainText>true</PlainText>
+                </Password>
+                <Enabled>true</Enabled>
+                <Username>Administrator</Username>
+                <Domain>.</Domain>
+                <LogonCount>999</LogonCount>
+            </AutoLogon>
+        </component>
+        <component name="Microsoft-Windows-ServerManager-SvrMgrNc" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <DoNotOpenServerManagerAtLogon>true</DoNotOpenServerManagerAtLogon>
+        </component>
+        <component name="Microsoft-Windows-IE-ESC" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <IEHardenAdmin>false</IEHardenAdmin>
+            <IEHardenUser>false</IEHardenUser>
+        </component>
+    </settings>
+    <settings pass="oobeSystem">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <UserAccounts>
+                <LocalAccounts>
+                    <LocalAccount wcm:action="add">
+                        <Password>
+                            <Value>PackerAdmin</Value>
+                            <PlainText>true</PlainText>
+                        </Password>
+                        <Group>Administrators</Group>
+                        <DisplayName>Administrator</DisplayName>
+                        <Name>Administrator</Name>
+                        <Description>Local Administrator</Description>
+                    </LocalAccount>
+                </LocalAccounts>
+            </UserAccounts>
+            <FirstLogonCommands>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c A:\bootstrap-base.bat</CommandLine>
+                    <Description>Bootstrap for everything</Description>
+                    <Order>1</Order>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c start /wait E:\setup64.exe /s /v "/qn reboot=r"</CommandLine>
+                    <Description>Install VMWare Tools (and drivers)</Description>
+                    <Order>2</Order>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c wmic useraccount where "name='Administrator'" set PasswordExpires=FALSE</CommandLine>
+                    <Description>Disable Administrator Password reset</Description>
+                    <Order>3</Order>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c A:\generalize-packer.bat</CommandLine>
+                    <Description>Sysprep generalize</Description>
+                    <Order>4</Order>
+                </SynchronousCommand>
+            </FirstLogonCommands>
+            <OOBE>
+                <HideEULAPage>true</HideEULAPage>
+                <NetworkLocation>Home</NetworkLocation>
+                <ProtectYourPC>1</ProtectYourPC>
+            </OOBE>
+            <RegisteredOwner />
+        </component>
+    </settings>
+    <settings pass="offlineServicing">
+        <!-- Added for driver injection. Typically for NICs and Mass Storage -->
+        <component name="Microsoft-Windows-PnpCustomizationsNonWinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <DriverPaths>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="0">
+                    <Path>A:\</Path>
+                </PathAndCredentials>
+            </DriverPaths>
+        </component>
+    </settings>
+    <settings pass="auditSystem">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <UserAccounts>
+                <AdministratorPassword>
+                    <Value>PackerAdmin</Value>
+                    <PlainText>true</PlainText>
+                </AdministratorPassword>
+            </UserAccounts>
+            <AutoLogon>
+                <Password>
+                    <Value>PackerAdmin</Value>
+                    <PlainText>true</PlainText>
+                </Password>
+                <Domain>.</Domain>
+                <Enabled>true</Enabled>
+                <LogonCount>999</LogonCount>
+                <Username>Administrator</Username>
+            </AutoLogon>
+        </component>
+    </settings>
+</unattend>

--- a/templates/windows-2008/files/config-vmware-vsphere-cygwin.ps1
+++ b/templates/windows-2008/files/config-vmware-vsphere-cygwin.ps1
@@ -1,0 +1,118 @@
+# Registry and other settings that are easier done outside puppet for the moment.
+# These tend to be OS specific so will be left in the OS area.
+#
+$ErrorActionPreference = "Stop"
+
+. A:\windows-env.ps1
+
+# Some other quick win settings provided by Boxstarter
+# Although this is no longer run under boxstarter, we are still able to use it's cmdlets.
+Write-Host "Other Stuff......."
+
+# Enable Bootlog
+Write-Host "Enable Bootlog"
+cmd /c "bcdedit /set {current} bootlog yes"
+
+#Disable UAC for Windows-2012
+#Disable-UAC
+
+# Enable Remote Desktop (with reduce authentication resetting here again)
+#Enable-RemoteDesktop -DoNotRequireUserLevelAuthentication
+
+#######################################################################################################################
+# Ideally these registry settings would be done through puppet.
+# Unfortunately there is a puppet registry module restriction on manipulating HKCU, so need to use
+# Powershell commands here instead.
+# TODO Migrate these to the puppet settings once the HKCU restriction is removed.
+#######################################################################################################################
+
+# Load Default User for registry to accomodate changes.
+# All HKCU changes are replicated for the default user.
+reg.exe load HKLM\DEFUSER c:\users\default\ntuser.dat
+
+# Set IE Home Page for this and Default User.
+Write-Host "Setting IE Home Page"
+Set-UserKey 'Software\Microsoft\Internet Explorer\Main' 'Start Page' 'REG_SZ' 'about:blank'
+
+# UI and desktop settings (note classic is enforced by Group policy")
+# Set Visual Effects for Best Performance
+Write-Host "Setting Visual Effects to Best Performance"
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects' 'VisualFXSetting' 'REG_DWORD' 2
+
+# Set solid color background - blueish
+Write-Host "Setting Solid background colour"
+Set-UserKey 'Control Panel\Colors' 'Background' 'REG_SZ' '"10 59 118"'
+Set-UserKey 'Control Panel\Colors' 'Wallpaper' 'REG_SZ' '""'
+
+# Start Menu Options
+Write-Host "Setting Start Menu Options"
+# Control panel start-menu cascading doesn't appear to be available in W 2012
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\ControlPanel' 'AllItemsIconView' 'REG_DWORD' 1
+
+# Icon Notification Tray - enable all notifications for the moment.
+# Setting as per spec is tricky (see RE-7692)
+Write-Host "Enabling all notification icons"
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer' 'EnableAutoTray' 'REG_DWORD' 0
+
+# Set Explorer UI settings
+Write-Host "Setting Explorer and Taskbar UI Settings..."
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'AlwaysShowMenus'       'REG_DWORD' 1
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'AutoCheckSelect'       'REG_DWORD' 0
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'DisablePreviewDesktop' 'REG_DWORD' 1
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'DontPrettyPath'        'REG_DWORD' 0
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'Filter'                'REG_DWORD' 0
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'Hidden'                'REG_DWORD' 1
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'HideDrivesWithNoMedia' 'REG_DWORD' 0
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'HideFileExt'           'REG_DWORD' 0
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'HideIcons'             'REG_DWORD' 0
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'HideMergeConflicts'    'REG_DWORD' 0
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'IconsOnly'             'REG_DWORD' 1
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'ListviewAlphaSelect'   'REG_DWORD' 0
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'ListviewShadow'        'REG_DWORD' 0
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'ListviewWatermark'     'REG_DWORD' 0
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'MapNetDrvBtn'          'REG_DWORD' 0
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'SeparateProcess'       'REG_DWORD' 0
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'ServerAdminUI'         'REG_DWORD' 1
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'ShowCompColor'         'REG_DWORD' 1
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'ShowInfoTip'           'REG_DWORD' 1
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'ShowStatusBar'         'REG_DWORD' 1
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'ShowSuperHidden'       'REG_DWORD' 1
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'ShowTypeOverlay'       'REG_DWORD' 1
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'Start_SearchFiles'     'REG_DWORD' 1
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'StartMenuAdminTools'   'REG_DWORD' 1
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'StartMenuInit'         'REG_DWORD' 6
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'StoreAppsOnTaskbar'    'REG_DWORD' 1
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'TaskbarAnimations'     'REG_DWORD' 0
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'TaskbarGlomLevel'      'REG_DWORD' 1
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'TaskbarSizeMove'       'REG_DWORD' 1
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'TaskbarSmallIcons'     'REG_DWORD' 0
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' 'WebView'               'REG_DWORD' 1
+
+# Set FullPath to be displayed in the window title bar
+Write-Host "Setting Full Path to be displayed on title bars..."
+Set-UserKey 'Software\Microsoft\Windows\CurrentVersion\Explorer\CabinetState' 'FullPath'          'REG_DWORD' 1
+
+# Set some UI acceleration features to tune down all of the fancy animations etc..
+Write-Host "Disabling fancy UI animations..."
+Set-UserKey 'Control Panel\Desktop'               'DragFullWindows'           'REG_SZ'      '0'
+Set-UserKey 'Control Panel\Desktop'               'FontSmoothing'             'REG_SZ'      '0'
+Set-UserKey 'Control Panel\Desktop'               'UserPreferencesMask'       'REG_BINARY' '9000038010000000'
+Set-UserKey 'Control Panel\Desktop\WindowMetrics' 'MinAnimate'                'REG_SZ'      '0'
+Set-UserKey 'Software\Microsoft\Windows\DWM'      'AlwaysHibernateThumbnails' 'REG_DWORD'   0
+Set-UserKey 'Software\Microsoft\Windows\DWM'      'EnableAeroPeek'            'REG_DWORD'   0
+
+# Unload default user.
+reg.exe unload HKLM\DEFUSER
+
+# Set the Security Policies
+Write-Host "Setting Low Security Password Policies"
+secedit /configure /db secedit.sdb /cfg A:\Low-SecurityPasswordPolicy.inf /quiet
+
+# Add permissive Firewall rules (RE-7516) - This is preferred to disabling the firewall
+netsh advfirewall firewall add rule name="All Incoming" dir=in action=allow enable=yes interfacetype=any profile=any localip=any remoteip=any
+netsh advfirewall firewall add rule name="All Outgoing" dir=out action=allow enable=yes interfacetype=any profile=any localip=any remoteip=any
+
+# Re-Enable AutoAdminLogon
+autologon -AcceptEula Administrator . PackerAdmin
+
+# End

--- a/templates/windows-2008/files/generalize-packer.autounattend.xml
+++ b/templates/windows-2008/files/generalize-packer.autounattend.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns="urn:schemas-microsoft-com:unattend">
+    <settings pass="windowsPE">
+        <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <UserData>
+                <!-- Product Key from http://technet.microsoft.com/en-us/library/jj612867.aspx -->
+                <ProductKey>
+                    <!-- Do not uncomment the Key element if you are using trial ISOs -->
+                    <!-- KMS Setup keys  https://technet.microsoft.com/en-us/library/jj612867.aspx -->
+                    <Key>TM24T-X9RMF-VWXK6-X8JC9-BFGM2</Key>
+                    <WillShowUI>OnError</WillShowUI>
+                </ProductKey>
+                <AcceptEula>true</AcceptEula>
+                <FullName>Puppet Labs</FullName>
+                <Organization>Puppet Labs</Organization>
+            </UserData>
+        </component>
+    </settings>
+    <settings pass="specialize">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <OEMInformation>
+                <HelpCustomized>false</HelpCustomized>
+            </OEMInformation>
+            <ComputerName>*</ComputerName>
+            <TimeZone>UTC</TimeZone>
+            <RegisteredOwner />
+            <ShowWindowsLive>false</ShowWindowsLive>
+            <CopyProfile>true</CopyProfile>
+            <ProductKey>TM24T-X9RMF-VWXK6-X8JC9-BFGM2</ProductKey>
+        </component>
+        <component name="Microsoft-Windows-ServerManager-SvrMgrNc" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <DoNotOpenServerManagerAtLogon>true</DoNotOpenServerManagerAtLogon>
+        </component>
+        <component name="Microsoft-Windows-IE-ESC" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <IEHardenAdmin>false</IEHardenAdmin>
+            <IEHardenUser>false</IEHardenUser>
+        </component>
+        <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <RunSynchronous>
+                <RunSynchronousCommand wcm:action="add">
+                    <Path>net user administrator /active:yes</Path>
+                    <Order>1</Order>
+                </RunSynchronousCommand>
+            </RunSynchronous>
+        </component>
+    </settings>
+    <settings pass="oobeSystem">
+        <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <InputLocale>en-US</InputLocale>
+            <SystemLocale>en-US</SystemLocale>
+            <UILanguage>en-US</UILanguage>
+            <UserLocale>en-US</UserLocale>
+        </component>
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <FirstLogonCommands>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c A:\bootstrap-base.bat</CommandLine>
+                    <Description>Bootstrap for everything</Description>
+                    <Order>1</Order>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\start-boxstarter.ps1</CommandLine>
+                    <Description>Start BoxStarter</Description>
+                    <Order>4</Order>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>wmic useraccount where &quot;name=&apos;Administrator&apos;&quot; set PasswordExpires=FALSE</CommandLine>
+                    <Order>2</Order>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd /C start /wait NET ACCOUNTS /MAXPWAGE:UNLIMITED</CommandLine>
+                    <Order>3</Order>
+                </SynchronousCommand>
+            </FirstLogonCommands>
+            <OOBE>
+                <HideEULAPage>true</HideEULAPage>
+                <NetworkLocation>Work</NetworkLocation>
+                <ProtectYourPC>1</ProtectYourPC>
+            </OOBE>
+            <RegisteredOwner />
+            <UserAccounts>
+                <LocalAccounts>
+                    <LocalAccount wcm:action="add">
+                        <Password>
+                            <Value>PackerAdmin</Value>
+                            <PlainText>true</PlainText>
+                        </Password>
+                        <Description>Local Administrator</Description>
+                        <DisplayName>Administrator</DisplayName>
+                        <Group>Administrators</Group>
+                        <Name>Administrator</Name>
+                    </LocalAccount>
+                </LocalAccounts>
+                <AdministratorPassword>
+                    <Value>PackerAdmin</Value>
+                    <PlainText>true</PlainText>
+                </AdministratorPassword>
+            </UserAccounts>
+            <AutoLogon>
+                <Password>
+                    <Value>PackerAdmin</Value>
+                    <PlainText>true</PlainText>
+                </Password>
+                <Domain>.</Domain>
+                <Enabled>true</Enabled>
+                <LogonCount>99999</LogonCount>
+                <Username>Administrator</Username>
+            </AutoLogon>
+        </component>
+    </settings>
+    <settings pass="offlineServicing">
+        <!-- Added for driver injection. Typically for NICs and Mass Storage -->
+        <component name="Microsoft-Windows-PnpCustomizationsNonWinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <DriverPaths>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="0">
+                    <Path>A:\</Path>
+                </PathAndCredentials>
+            </DriverPaths>
+        </component>
+    </settings>
+    <settings pass="auditUser">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <RegisteredOwner />
+        </component>
+    </settings>
+</unattend>

--- a/templates/windows-2008/files/post-clone.autounattend.xml
+++ b/templates/windows-2008/files/post-clone.autounattend.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns="urn:schemas-microsoft-com:unattend">
+    <settings pass="windowsPE">
+        <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <UserData>
+                <!-- Product Key from http://technet.microsoft.com/en-us/library/jj612867.aspx -->
+                <ProductKey>
+                    <!-- Do not uncomment the Key element if you are using trial ISOs -->
+                    <!-- KMS Setup keys  https://technet.microsoft.com/en-us/library/jj612867.aspx -->
+                    <Key>TM24T-X9RMF-VWXK6-X8JC9-BFGM2</Key>
+                    <WillShowUI>OnError</WillShowUI>
+                </ProductKey>
+                <AcceptEula>true</AcceptEula>
+                <FullName>Puppet Labs</FullName>
+                <Organization>Puppet Labs</Organization>
+            </UserData>
+        </component>
+    </settings>
+    <settings pass="specialize">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <OEMInformation>
+                <HelpCustomized>false</HelpCustomized>
+            </OEMInformation>
+            <ComputerName>*</ComputerName>
+            <TimeZone>UTC</TimeZone>
+            <RegisteredOwner />
+            <ShowWindowsLive>false</ShowWindowsLive>
+            <CopyProfile>true</CopyProfile>
+            <ProductKey>TM24T-X9RMF-VWXK6-X8JC9-BFGM2</ProductKey>
+        </component>
+        <component name="Microsoft-Windows-ServerManager-SvrMgrNc" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <DoNotOpenServerManagerAtLogon>true</DoNotOpenServerManagerAtLogon>
+        </component>
+        <component name="Microsoft-Windows-IE-ESC" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <IEHardenAdmin>false</IEHardenAdmin>
+            <IEHardenUser>false</IEHardenUser>
+        </component>
+        <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <RunSynchronous>
+                <RunSynchronousCommand wcm:action="add">
+                    <Path>net user administrator /active:yes</Path>
+                    <Order>1</Order>
+                </RunSynchronousCommand>
+            </RunSynchronous>
+        </component>
+    </settings>
+    <settings pass="oobeSystem">
+        <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <InputLocale>en-US</InputLocale>
+            <SystemLocale>en-US</SystemLocale>
+            <UILanguage>en-US</UILanguage>
+            <UserLocale>en-US</UserLocale>
+        </component>
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <FirstLogonCommands>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File C:\Packer\Init\vmpooler-post-clone-configuration.ps1</CommandLine>
+                    <Description>Post Clone configuration</Description>
+                    <Order>1</Order>
+                </SynchronousCommand>
+            </FirstLogonCommands>
+            <OOBE>
+                <HideEULAPage>true</HideEULAPage>
+                <NetworkLocation>Work</NetworkLocation>
+                <ProtectYourPC>1</ProtectYourPC>
+            </OOBE>
+            <RegisteredOwner />
+            <UserAccounts>
+                <LocalAccounts>
+                    <LocalAccount wcm:action="add">
+                        <Password>
+                            <Value>PackerAdmin</Value>
+                            <PlainText>true</PlainText>
+                        </Password>
+                        <Description>Local Administrator</Description>
+                        <DisplayName>Administrator</DisplayName>
+                        <Group>Administrators</Group>
+                        <Name>Administrator</Name>
+                    </LocalAccount>
+                </LocalAccounts>
+                <AdministratorPassword>
+                    <Value>PackerAdmin</Value>
+                    <PlainText>true</PlainText>
+                </AdministratorPassword>
+            </UserAccounts>
+            <AutoLogon>
+                <Password>
+                    <Value>PackerAdmin</Value>
+                    <PlainText>true</PlainText>
+                </Password>
+                <Domain>.</Domain>
+                <Enabled>true</Enabled>
+                <LogonCount>99999</LogonCount>
+                <Username>Administrator</Username>
+            </AutoLogon>
+        </component>
+    </settings>
+</unattend>

--- a/templates/windows-2008/files/shutdown-packer-2008.ps1
+++ b/templates/windows-2008/files/shutdown-packer-2008.ps1
@@ -1,0 +1,13 @@
+# Windows-2008 special to do the shutdown.
+
+$ErrorActionPreference = 'Stop'
+
+. A:\windows-env.ps1
+
+Write-Host "Packer Shutdown Script"
+
+Write-Host "Disable WinRM"
+Set-Service "WinRM" -StartupType Disabled
+
+Write-Host "Initiating Shutdown"
+shutdown /s /t 20 /f /d p:4:1 /c "Packer Shutdown"

--- a/templates/windows-2008/files/win-2008-x86_64-std.pp
+++ b/templates/windows-2008/files/win-2008-x86_64-std.pp
@@ -1,0 +1,2 @@
+include windows_template::local_group_policies
+include windows_template::configure_services

--- a/templates/windows-2008/files/windows-2008-slipstream.package.ps1
+++ b/templates/windows-2008/files/windows-2008-slipstream.package.ps1
@@ -1,0 +1,81 @@
+$ErrorActionPreference = "Stop"
+
+# Customised Slipstream script for Windows-7 - this proves a bit more difficult than the "usual"
+# Slipstream update process.
+# Use a rollup update.
+
+. A:\windows-env.ps1
+
+# Boxstarter options
+$Boxstarter.RebootOk=$true # Allow reboots?
+$Boxstarter.NoPassword=$false # Is this a machine with no login password?
+$Boxstarter.AutoLogin=$true # Save my password securely and auto-login after a reboot
+
+if (Test-PendingReboot){ Invoke-Reboot }
+
+# Need to guard against system going into standby for long updates
+Write-BoxstarterMessage "Disabling Sleep timers"
+Disable-PC-Sleep
+
+reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate"    /v "WUServer"       /t REG_SZ /d "http://10.32.163.228:8530" /f
+reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate"    /v "WUStatusServer" /t REG_SZ /d "http://10.32.163.228:8530" /f
+
+reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" /v "NoAutoUpdate" /t REG_DWORD /d 0 /f
+reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" /v "AUOptions" /t REG_DWORD /d 2 /f
+reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" /v "ScheduledInstallDay" /t REG_DWORD /d 0 /f
+reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" /v "ScheduledInstallTime" /t REG_DWORD /d 3 /f
+reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" /v "UseWUServer" /t REG_DWORD /d 1 /f
+
+if (-not (Test-Path "A:\NET45.installed"))
+{
+  # Install .Net Framework 4.5.2
+  Write-BoxstarterMessage "Installing .Net 4.5"
+  choco install dotnet4.5 -y
+  Touch-File "A:\NET45.installed"
+  if (Test-PendingReboot) { Invoke-Reboot }
+}
+
+# Install Updates and reboot until this is completed.
+Install-WindowsUpdate -AcceptEula
+if (Test-PendingReboot) { Invoke-Reboot }
+
+# Do one final reboot in case there are any more updates to be picked up.
+Do-Packer-Final-Reboot
+
+# Create Dism directories and copy files over.
+# This allows errors to be handled manually in event of dism failures
+
+New-Item -ItemType directory -Force -Path C:\Packer
+New-Item -ItemType directory -Force -Path C:\Packer\Dism
+New-Item -ItemType directory -Force -Path C:\Packer\Downloads
+New-Item -ItemType directory -Force -Path C:\Packer\Dism\Mount
+New-Item -ItemType directory -Force -Path C:\Packer\Dism\Logs
+
+Copy-Item A:\windows-env.ps1 C:\Packer\Dism
+Copy-Item A:\generate-slipstream.ps1 C:\Packer\Dism
+Copy-Item A:\slipstream-filter C:\Packer\Dism
+
+# Add WinRM Firewall Rule
+Write-BoxstarterMessage "Setting up winrm"
+netsh advfirewall firewall add rule name="WinRM-HTTP" dir=in localport=5985 protocol=TCP action=allow
+
+$enableArgs=@{Force=$true}
+try {
+ $command=Get-Command Enable-PSRemoting
+  if($command.Parameters.Keys -contains "skipnetworkprofilecheck"){
+      $enableArgs.skipnetworkprofilecheck=$true
+  }
+}
+catch {
+  $global:error.RemoveAt(0)
+}
+Enable-PSRemoting @enableArgs
+Enable-WSManCredSSP -Force -Role Server
+# NOTE - This is insecure but can be shored up in later customisation.  Required for Vagrant and other provisioning tools
+winrm set winrm/config/client/auth '@{Basic="true"}'
+winrm set winrm/config/service/auth '@{Basic="true"}'
+winrm set winrm/config/service '@{AllowUnencrypted="true"}'
+winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="2048"}'
+Write-BoxstarterMessage "WinRM setup complete"
+
+# End

--- a/templates/windows-2008/files/windows-2008-x86_64-vmware-base.package.ps1
+++ b/templates/windows-2008/files/windows-2008-x86_64-vmware-base.package.ps1
@@ -1,0 +1,128 @@
+$ErrorActionPreference = "Stop"
+
+. A:\windows-env.ps1
+
+# Boxstarter options
+$Boxstarter.RebootOk=$true # Allow reboots?
+$Boxstarter.NoPassword=$false # Is this a machine with no login password?
+$Boxstarter.AutoLogin=$true # Save my password securely and auto-login after a reboot
+
+if (Test-PendingReboot){ Invoke-Reboot }
+
+# Need to guard against system going into standby for long updates
+Write-BoxstarterMessage "Disabling Sleep timers"
+Disable-PC-Sleep
+
+# Need to use WUServer as updates won't work from main MS Servers - similar to Win-2013 issues
+reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate"    /v "WUServer"       /t REG_SZ /d "http://10.32.163.228:8530" /f
+reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate"    /v "WUStatusServer" /t REG_SZ /d "http://10.32.163.228:8530" /f
+
+reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" /v "NoAutoUpdate" /t REG_DWORD /d 0 /f
+reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" /v "AUOptions" /t REG_DWORD /d 2 /f
+reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" /v "ScheduledInstallDay" /t REG_DWORD /d 0 /f
+reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" /v "ScheduledInstallTime" /t REG_DWORD /d 3 /f
+reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" /v "UseWUServer" /t REG_DWORD /d 1 /f
+
+# Make sure network connection is private
+Write-BoxstarterMessage "Setting network adapters to private"
+$networkListManager = [Activator]::CreateInstance([Type]::GetTypeFromCLSID([Guid]"{DCB00C01-570F-4A9B-8D69-199FDBA5723B}"))
+$connections = $networkListManager.GetNetworkConnections()
+
+if (-not (Test-Path "A:\NET35.Installed"))
+{
+  # Install .Net 3.5.1
+  Write-Host ".Net 3.5.1"
+  Download-File "http://buildsources.delivery.puppetlabs.net/windows/win-2008-ps2/dotnetfx35setup.exe"  "$ENV:TEMP\dotnetfx35setup.exe"
+  Start-Process -Wait "$ENV:TEMP\dotnetfx35setup.exe" -ArgumentList "/q"
+  Write-Host ".Net 3.5.1 Installed"
+  Touch-File "A:\NET35.Installed"
+  if (Test-PendingReboot) { Invoke-Reboot }
+}
+
+if (-not (Test-Path "A:\WinUpdate.Installed"))
+{
+  # Install .Net 3.5.1
+  Write-Host "Updating Windows Update agent"
+  Download-File "http://buildsources.delivery.puppetlabs.net/windows/win-2008-ps2/windowsupdateagent30-x64.exe"  "$ENV:TEMP\windowsupdateagent30-x64.exe"
+  Start-Process -Wait "$ENV:TEMP\windowsupdateagent30-x64.exe" -ArgumentList "/q"
+  Write-Host "Updating Windows Update agent"
+  Touch-File "A:\WinUpdate.Installed"
+  if (Test-PendingReboot) { Invoke-Reboot }
+}
+
+if (-not (Test-Path "A:\Win2008.Patches"))
+{
+  $patches = @(
+    'http://download.windowsupdate.com/d/msdownload/update/software/secu/2016/04/windows6.0-kb3153199-x64_ff7991c9c3465327640c5fdf296934ac12467fd0.msu',
+    "http://download.windowsupdate.com/d/msdownload/update/software/secu/2016/04/windows6.0-kb3145739-x64_918212eb27224cf312f865e159f172a4b8a75b76.msu"
+  )
+  $patches | % { Install_Win_Patch -PatchUrl $_ }
+
+  Touch-File "A:\Win2008.Patches"
+  if (Test-PendingReboot) { Invoke-Reboot }
+}
+
+if (-not (Test-Path "A:\NET45.installed"))
+{
+  # Install .Net Framework 4.5.2
+  Write-BoxstarterMessage "Installing .Net 4.5"
+  choco install dotnet4.5 -y
+  Touch-File "A:\NET45.installed"
+  if (Test-PendingReboot) { Invoke-Reboot }
+}
+
+# Install Updates and reboot until this is completed.
+try {
+    Install-WindowsUpdate -AcceptEula
+}
+catch {
+    Write-Host "Ignoring first Update error."
+}
+if (Test-PendingReboot) { Invoke-Reboot }
+Install-WindowsUpdate -AcceptEula
+if (Test-PendingReboot) { Invoke-Reboot }
+
+# Enable RDP
+Write-BoxstarterMessage "Enable Remote Desktop"
+Enable-RemoteDesktop
+netsh advfirewall firewall add rule name="Remote Desktop" dir=in localport=3389 protocol=TCP action=allow
+
+# Add WinRM Firewall Rule
+Write-BoxstarterMessage "Adding Firewall rules for win-rm"
+netsh advfirewall firewall add rule name="WinRM-HTTP" dir=in localport=5985 protocol=TCP action=allow
+
+Write-BoxstarterMessage "Setup PSRemoting"
+$enableArgs=@{Force=$true}
+try {
+ $command=Get-Command Enable-PSRemoting
+  if($command.Parameters.Keys -contains "skipnetworkprofilecheck"){
+      $enableArgs.skipnetworkprofilecheck=$true
+  }
+}
+catch {
+  $global:error.RemoveAt(0)
+}
+Write-BoxstarterMessage "Enable PS-Remoting -Force"
+try {
+  Enable-PSRemoting @enableArgs
+}
+catch {
+  Write-BoxstarterMessage "Ignoring PSRemoting Error"
+}
+
+Write-BoxstarterMessage "Enable WSMandCredSSP"
+Enable-WSManCredSSP -Force -Role Server
+
+
+# NOTE - This is insecure but can be shored up in later customisation.  Required for Vagrant and other provisioning tools
+Write-BoxstarterMessage "WinRM Settings"
+winrm set winrm/config/client/auth '@{Basic="true"}'
+winrm set winrm/config/service/auth '@{Basic="true"}'
+winrm set winrm/config/service '@{AllowUnencrypted="true"}'
+winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="2048"}'
+# Set service to start automatically (not delayed)
+Set-Service "WinRM" -StartupType Automatic
+
+Write-BoxstarterMessage "WinRM setup complete"
+
+# End

--- a/templates/windows-2008/x86_64.vmware.base.json
+++ b/templates/windows-2008/x86_64.vmware.base.json
@@ -1,0 +1,109 @@
+{
+  "variables": {
+    "template_name": "windows-2008-x86_64",
+    "template_config": "base",
+
+    "provisioner": "vmware",
+    "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2008_with_sp2_x64_dvd_342336_SlipStream_03.iso",
+    "iso_checksum_type": "md5",
+    "iso_checksum": "ab418a455fea422d2582c660ee8cd8f1",
+    "headless": "true",
+    "tools_iso": "{{env `VMWARE_TOOLS_ISO`}}/windows.iso",
+    "packer_output_dir": "{{env `PACKER_VM_OUT_DIR`}}"
+  },
+
+  "description": "Builds a Windows Server 2008 template VM for use in VMware",
+
+  "_comment": [
+      "The boot_command is hacky because the UEFI boot file used requires the 'Press any key' to be done"
+  ],
+  "builders": [
+    {
+      "name": "{{user `template_name`}}-{{user `provisioner`}}-{{user `template_config`}}",
+      "vm_name": "packer-{{build_name}}",
+      "type": "vmware-iso",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "output_directory": "{{user `packer_output_dir`}}/output-{{build_name}}",
+
+      "headless": "{{user `headless`}}",
+
+      "communicator": "winrm",
+      "winrm_username": "Administrator",
+      "winrm_password": "PackerAdmin",
+      "winrm_timeout": "16h",
+
+      "shutdown_command": "shutdown /s /t 1 /c \"Packer Shutdown\" /f /d p:4:1",
+      "shutdown_timeout": "1h",
+      "guest_os_type": "longhorn-64",
+      "disk_size": 61440,
+      "disk_type_id": "0",
+      "floppy_files": [
+        "files/autounattend.xml",
+        "../../scripts/windows/bootstrap-base.bat",
+        "../../scripts/windows/start-boxstarter.ps1",
+        "../../scripts/windows/windows-env.ps1",
+        "../../scripts/windows/shutdown-packer.bat",
+        "../../scripts/windows/generalize-packer.bat",
+        "../../scripts/windows/clean-disk-dism.ps1",
+        "../../scripts/windows/clean-disk-sdelete.ps1",
+        "files/generalize-packer.autounattend.xml",
+        "files/{{build_name}}.package.ps1"
+      ],
+
+      "boot_command": [ "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter>"],
+      "boot_wait": "1s",
+
+      "vmx_data": {
+        "gui.fitguestusingnativedisplayresolution": "FALSE",
+
+        "memsize": "4096",
+        "numvcpus": "2",
+        "ethernet0.virtualdev" : "vmxnet3",
+        "scsi0.virtualdev": "lsisas1068",
+        "virtualHW.version": "10",
+        "devices.hotplug": "false",
+
+        "vcpu.hotadd": "TRUE",
+        "mem.hotadd": "TRUE",
+
+        "tools.syncTime": "FALSE",
+        "time.synchronize.continue": "FALSE",
+        "time.synchronize.restore": "FALSE",
+        "time.synchronize.resume.disk": "FALSE",
+        "time.synchronize.shrink": "FALSE",
+        "time.synchronize.tools.startup": "FALSE",
+        "time.synchronize.tools.enable": "FALSE",
+        "time.synchronize.resume.host": "FALSE",
+        "scsi0:1.present": "TRUE",
+        "scsi0:1.autodetect": "TRUE",
+        "scsi0:1.deviceType": "cdrom-image",
+        "scsi0:1.fileName": "{{user `tools_iso`}}"
+      },
+      "vmx_data_post": {
+        "scsi0:1.present": "FALSE",
+        "scsi0:1.autodetect": "FALSE",
+        "scsi0:1.devicetype":  "",
+        "scsi0:1.filename": ""
+      }
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "powershell",
+      "inline": [
+        "A:\\clean-disk-dism.ps1"
+      ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "powershell",
+      "inline": [
+        "A:\\clean-disk-sdelete.ps1"
+      ]
+    }
+  ]
+}

--- a/templates/windows-2008/x86_64.vmware.slipstream.json
+++ b/templates/windows-2008/x86_64.vmware.slipstream.json
@@ -1,0 +1,89 @@
+{
+  "variables": {
+    "template_name": "windows-7-x86_64",
+    "os_name" : "Win-7",
+
+    "provisioner": "vmware",
+    "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2008_with_sp2_x64_dvd_342336.iso",
+    "iso_checksum_type": "md5",
+    "iso_checksum": "e94943ef484035b3288d8db69599a6b5",
+    "headless": "false",
+    "tools_iso": "{{env `VMWARE_TOOLS_ISO`}}/windows.iso"
+  },
+
+  "description": "Customised Win-7 build to prepare slipstream ISO",
+
+  "_comment": [
+      "The boot_command is hacky because the UEFI boot file used requires the 'Press any key' to be done"
+  ],
+  "builders": [
+    {
+      "name": "{{user `template_name`}}-{{user `provisioner`}}",
+      "vm_name": "packer-{{build_name}}",
+      "type": "vmware-iso",
+      "iso_url": "{{user `iso_url`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "headless": "{{user `headless`}}",
+
+      "communicator": "winrm",
+      "winrm_username": "Administrator",
+      "winrm_password": "PackerAdmin",
+      "winrm_timeout": "48h",
+
+      "shutdown_command": "shutdown /s /t 1 /c \"Packer Shutdown\" /f /d p:4:1",
+      "shutdown_timeout": "1h",
+      "guest_os_type": "longhorn-64",
+      "disk_size": 61440,
+      "disk_type_id": "0",
+      "floppy_files": [
+        "files/autounattend.xml",
+        "../../scripts/windows/bootstrap-base.bat",
+        "../../scripts/windows/start-boxstarter.ps1",
+        "../../scripts/windows/windows-env.ps1",
+        "../../scripts/windows/shutdown-packer.bat",
+        "../../scripts/windows/generalize-packer.bat",
+        "../../scripts/windows/generate-slipstream.ps1",
+        "files/slipstream-filter",
+        "files/generalize-packer.autounattend.xml",
+        "files/windows-2008-slipstream.package.ps1"
+      ],
+
+      "boot_command": [ "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait>"],
+      "boot_wait": "1s",
+
+      "vmx_data": {
+        "gui.fitguestusingnativedisplayresolution": "FALSE",
+
+        "memsize": "4096",
+        "numvcpus": "2",
+        "ethernet0.virtualdev" : "vmxnet3",
+        "scsi0.virtualdev": "lsisas1068",
+        "virtualHW.version": "10",
+        "devices.hotplug": "false",
+
+        "vcpu.hotadd": "TRUE",
+        "mem.hotadd": "TRUE",
+
+        "tools.syncTime": "FALSE",
+        "time.synchronize.continue": "FALSE",
+        "time.synchronize.restore": "FALSE",
+        "time.synchronize.resume.disk": "FALSE",
+        "time.synchronize.shrink": "FALSE",
+        "time.synchronize.tools.startup": "FALSE",
+        "time.synchronize.tools.enable": "FALSE",
+        "time.synchronize.resume.host": "FALSE",
+        "scsi0:1.present": "TRUE",
+        "scsi0:1.autodetect": "TRUE",
+        "scsi0:1.deviceType": "cdrom-image",
+        "scsi0:1.fileName": "{{user `tools_iso`}}"
+      },
+      "vmx_data_post": {
+        "scsi0:1.present": "FALSE",
+        "scsi0:1.autodetect": "FALSE",
+        "scsi0:1.devicetype":  "",
+        "scsi0:1.filename": ""
+      }
+    }
+  ]
+}

--- a/templates/windows-2008/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-2008/x86_64.vmware.vsphere.cygwin.json
@@ -1,0 +1,211 @@
+{
+  "variables": {
+    "template_name": "windows-2008-x86_64",
+    "version": "0.0.1",
+    "template_config": "vsphere.cygwin",
+
+    "provisioner": "vmware",
+    "headless": "true",
+    "winrm_username": "Administrator",
+    "winrm_password": "PackerAdmin",
+
+    "qa_root_passwd": "{{env `QA_ROOT_PASSWD_PLAIN`}}",
+    "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",
+    "packer_vcenter_username": "{{env `PACKER_VCENTER_USERNAME`}}",
+    "packer_vcenter_password": "{{env `PACKER_VCENTER_PASSWORD`}}",
+    "packer_vcenter_dc": "{{env `PACKER_VCENTER_DC`}}",
+    "packer_vcenter_cluster": "{{env `PACKER_VCENTER_CLUSTER`}}",
+    "packer_vcenter_datastore": "{{env `PACKER_VCENTER_DATASTORE`}}",
+    "packer_vcenter_folder": "{{env `PACKER_VCENTER_FOLDER`}}",
+    "packer_vcenter_net": "{{env `PACKER_VCENTER_NET`}}",
+    "packer_vcenter_insecure": "{{env `PACKER_VCENTER_INSECURE`}}",
+    "packer_sha": "{{env `PACKER_SHA`}}",
+    "packer_source_dir": "{{env `PACKER_VM_SRC_DIR`}}",
+    "packer_output_dir": "{{env `PACKER_VM_OUT_DIR`}}"
+  },
+
+  "description": "Builds a Windows Server 2008 SP2 template VM for use in VMware",
+
+  "builders": [
+    {
+      "name": "{{user `template_name`}}-{{user `provisioner`}}-vsphere-cygwin",
+      "vm_name": "packer-{{build_name}}",
+      "type": "vmware-vmx",
+      "source_path": "{{user `packer_source_dir`}}/output-{{user `template_name`}}-{{user `provisioner`}}-base/packer-{{user `template_name`}}-{{user `provisioner`}}-base.vmx",
+      "output_directory": "{{user `packer_output_dir`}}/output-{{build_name}}",
+
+      "headless": "{{user `headless`}}",
+
+      "communicator": "winrm",
+      "winrm_username": "{{user `winrm_username`}}",
+      "winrm_password": "{{user `winrm_password`}}",
+      "winrm_timeout": "8h",
+
+      "shutdown_command": "A:\\shutdown-packer.bat",
+      "shutdown_timeout": "1h",
+
+
+      "floppy_files": [
+        "../../scripts/windows/bootstrap-base.bat",
+        "../../scripts/windows/cleanup-host.ps1",
+        "../../scripts/windows/install-win-packages.ps1",
+        "../../scripts/windows/install-cygwin.ps1",
+        "../../scripts/windows/cygwin-packages",
+        "../../scripts/windows/gitforwin.inf",
+        "../../scripts/windows/puppet-configure.ps1",
+        "../../scripts/windows/shutdown-packer.bat",
+        "../../scripts/windows/windows-env.ps1",
+        "../../scripts/windows/Low-SecurityPasswordPolicy.inf",
+        "files/shutdown-packer-2008.ps1",
+        "files/config-vmware-vsphere-cygwin.ps1"
+      ],
+
+      "vmx_data": {
+        "gui.fitguestusingnativedisplayresolution": "FALSE",
+        "annotation": "Packer build: {{user `template_name`}}-{{user `version`}} built {{isotime}} SHA: {{user `packer_sha`}}",
+
+        "guest_os_type": "longhorn-64",
+        "memsize": "4096",
+        "numvcpus": "2",
+        "ethernet0.virtualdev" : "vmxnet3",
+        "scsi0.virtualdev": "lsisas1068",
+        "virtualHW.version": "10",
+        "devices.hotplug": "false",
+
+        "vcpu.hotadd": "TRUE",
+        "mem.hotadd": "TRUE",
+
+        "tools.syncTime": "FALSE",
+        "time.synchronize.continue": "FALSE",
+        "time.synchronize.restore": "FALSE",
+        "time.synchronize.resume.disk": "FALSE",
+        "time.synchronize.shrink": "FALSE",
+        "time.synchronize.tools.startup": "FALSE",
+        "time.synchronize.tools.enable": "FALSE",
+        "time.synchronize.resume.host": "FALSE"
+      }
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "powershell",
+      "elevated_user": "{{user `winrm_username`}}",
+      "elevated_password": "{{user `winrm_password`}}",
+      "inline": [
+        "md -Path C:\\Packer\\puppet\\modules",
+        "md -Path C:\\Packer\\Downloads",
+        "md -Path C:\\Packer\\Downloads\\Cygwin",
+        "md -Path C:\\Packer\\Init",
+        "md -Path C:\\Packer\\Logs",
+        "md -Path C:\\Packer\\Sysinternals"
+      ]
+    },
+    {
+      "type": "powershell",
+      "elevated_user": "{{user `winrm_username`}}",
+      "elevated_password": "{{user `winrm_password`}}",
+      "inline": [
+        "A:\\install-win-packages.ps1"
+      ]
+    },
+    {
+      "type": "powershell",
+      "elevated_user": "{{user `winrm_username`}}",
+      "elevated_password": "{{user `winrm_password`}}",
+      "inline": [
+        "A:\\install-cygwin.ps1"
+      ],
+      "environment_vars": [
+        "QA_ROOT_PASSWD={{user `qa_root_passwd`}}"
+      ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "file",
+      "source": "../../manifests/windows",
+      "destination": "C:\\Packer\\puppet\\modules"
+    },
+    {
+      "type": "file",
+      "source": "files/win-2008-x86_64-std.pp",
+      "destination": "C:\\Packer\\puppet\\win-2008-x86_64-std.pp"
+    },
+    {
+      "type": "powershell",
+      "elevated_user": "{{user `winrm_username`}}",
+      "elevated_password": "{{user `winrm_password`}}",
+      "inline": [
+        "A:\\puppet-configure.ps1 -PackerTemplateName {{user `template_name`}}-{{user `version`}} -PackerSHA '{{user `packer_sha`}}'"
+      ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "powershell",
+      "elevated_user": "{{user `winrm_username`}}",
+      "elevated_password": "{{user `winrm_password`}}",
+      "inline": [
+        "A:\\config-vmware-vsphere-cygwin.ps1"
+      ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "powershell",
+      "elevated_user": "{{user `winrm_username`}}",
+      "elevated_password": "{{user `winrm_password`}}",
+      "inline": [
+        "A:\\cleanup-host.ps1"
+      ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "file",
+      "source": "../../scripts/windows/init",
+      "destination": "C:\\Packer\\Init"
+    },
+    {
+      "type": "file",
+      "source": "./files/post-clone.autounattend.xml",
+      "destination": "C:\\Packer\\Init\\post-clone.autounattend.xml"
+    },
+    {
+      "type": "powershell",
+      "elevated_user": "{{user `winrm_username`}}",
+      "elevated_password": "{{user `winrm_password`}}",
+      "inline": [
+        "C:\\Packer\\Init\\vmpooler-arm-host.ps1"
+      ]
+    },
+    {
+      "type": "powershell",
+      "elevated_user": "{{user `winrm_username`}}",
+      "elevated_password": "{{user `winrm_password`}}",
+      "inline": [
+        "A:\\shutdown-packer-2008.ps1"
+      ]
+    }
+  ],
+  "post-processors": [
+    {
+      "type": "vsphere",
+      "host": "{{user `packer_vcenter_host`}}",
+      "username": "{{user `packer_vcenter_username`}}",
+      "password": "{{user `packer_vcenter_password`}}",
+      "datacenter": "{{user `packer_vcenter_dc`}}",
+      "cluster": "{{user `packer_vcenter_cluster`}}",
+      "datastore": "{{user `packer_vcenter_datastore`}}",
+      "vm_folder": "{{user `packer_vcenter_folder`}}",
+      "vm_name": "{{user `template_name`}}-{{user `version`}}",
+      "vm_network": "{{user `packer_vcenter_net`}}",
+      "insecure" : "{{user `packer_vcenter_insecure`}}",
+      "overwrite" : "true"
+    }
+  ]
+}

--- a/util/windows/win-2008/win-2008-slipstream.ps1
+++ b/util/windows/win-2008/win-2008-slipstream.ps1
@@ -1,0 +1,88 @@
+# Generates Slipstream ISO from image
+
+# This script was used on a seperate Win-2012R2 machine to generate the slipstream as
+# windows 2008 doesn't have DISM included with the base OS distribution. While it
+# can be included using the WAIK this still can lead to problems adding updates.
+
+$OSName = "Win-2008"
+$ImageIndex = "1"
+
+$DismBase = "C:\DISM\Win-2008"
+$UpdateDirectory = "$DismBase\CABS-Merge"
+$MountPoint = "$DismBase\Mount"
+$WinIsoPath = "$DismBase\$OSName-SlipStream.iso"
+$WinDistPath = "$DismBase\$OSName"
+$WinImageFile = "$WinDistPath\sources\install.wim"
+$WinPS2Files = "$DismBase\Powershell"
+
+function Download-File {
+param (
+  [string]$url,
+  [string]$file
+ )
+  $downloader = new-object System.Net.WebClient
+  $downloader.Proxy.Credentials=[System.Net.CredentialCache]::DefaultNetworkCredentials;
+
+  Write-Output "Downloading $url to $file"
+  $completed = $false
+  $retrycount = 0
+  $maxretries = 20
+  $delay = 10
+  while (-not $completed) {
+    try {
+      $downloader.DownloadFile($url, $file)
+      $completed = $true
+    } catch {
+      if ($retrycount -ge $maxretries) {
+        Write-Host "Max Attempts exceeded"
+        throw "Download aborting"
+      } else {
+        $retrycount++
+        Write-Host "Download Failed $retrycount of $maxretries - Sleeping $delay"
+        Start-Sleep -Seconds $delay
+      }
+    }
+  }
+}
+
+# Need extra disk for this bit.
+$IsoGen = "C:\Program Files (x86)\Windows Kits\10\Assessment and Deployment Kit\Deployment Tools\amd64\Oscdimg\oscdimg.exe"
+
+
+# Read in the exclude list of CABS to be downloaded and applied.
+#
+
+
+# Search for all CAB Files in Date Order - exclude express cab files if present as they can't be applied in a DISM command
+
+$Cabs = Get-ChildItem -Path $UpdateDirectory -Recurse -Include *.cab -exclude *express*.cab | Sort LastWriteTime
+
+Write-Host "Mounting $WinImageFile"
+Set-ItemProperty $WinImageFile -name IsReadOnly -value $false
+dism /mount-wim /wimfile:$WinImageFile /index:$ImageIndex /mountdir:$MountPoint
+
+$Cabtotal = $Cabs.Count
+ForEach ($Cab in $Cabs) {
+	$CabCount++
+  Write-Host "======================================================="
+	Write-Host "Working on CAB File ($CabCount of $Cabtotal)  $Cab"
+
+    $DismFile = $Cab
+
+    DISM /image:$MountPoint /add-package /packagepath:$DismFile  /loglevel:1 /logpath=$DismBase\dism-slip.log
+    if ($? -eq $TRUE){
+		$Cab.Name | Out-File -FilePath $DismBase\Updates-Sucessful.log -Append
+		Write-Host "Update $Cab Succeeded"
+    } else {
+		Write-Host "***** Update $Cab FAILED *******"
+		$Cab.Name | Out-File -FilePath $DismBase\Updates-Failed.log -Append
+	}
+}
+
+
+dism /unmount-wim /mountdir:$MountPoint /commit
+
+& $IsoGen -m -o -u2 -udfver102 -bootdata:"2#p0,e,b$WinDistPath\boot\etfsboot.com#pEF,e,b$WinDistPath\efi\microsoft\boot\efisys.bin" $WinDistPath $WinIsoPath
+
+
+exit 0


### PR DESCRIPTION
Create the base and vSphere templates for Windows-2008

This packer build differs a bit from the other windows:
1. Slipstream had to be prepared manually in a few stages due to the
   necessity of adding Powershell, .Net 3.5 SP1 and .Net 4.5.2 before
   boxstarter could be used to collect the updates. Further DISM
   is not available yet for Win-2008, so the actual .iso build and
   offline servicing had to be done on a Windows-2012R2 machine.
2. The base build assumes Powershell has been injected into the image
   through the slipstream process which allows boxstarter to start
   and automatically pull in the final set of required updates.
3. Powershell scripts need to be run elevated explicitly - this is
   probably due to the UAC model for Vista/2008 SP2. But it also means
   a nasty workaround has to be employed (see windows_env.ps1) to get
   the scripts to actually work. This impacted the puppet run the most
   as it does not download/install modules unless running elevated.
4. Additional logic had to be included in several scripts to filter
   for 2008 SP2, e.g. DISM or cleanmgr is not present.
5. No attempt is made to clean WinSxS as the tools are not available
   for this release, which leads to a much larger image.
6. An extra shutdown script had to be added for the final shutdown to
   ensure the shutdown happens in a controlled manner. This seems to
   be due to the "standard" script not running in elevated mode.
7. ESX 5.5 (vSphere) doesn't play nicely with EFI for Win-2008, so have
   switched to BIOS firmware.
8. Cygwin setup needs to be called with start-process -wait to ensure it
   completes successfully, so took opportunity to refactor cygwin
   and 7zip calls to use start-process for consistency.