### PR TITLE
(maint) address upstream packaging issue on yakkety

### DIFF
--- a/manifests/modules/packer/manifests/vsphere/repos.pp
+++ b/manifests/modules/packer/manifests/vsphere/repos.pp
@@ -49,6 +49,19 @@ class packer::vsphere::repos inherits packer::vsphere::params {
           'deb' => true,
         },
       }
+
+      if $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease == '16.10' {
+        apt::pin { 'apt-puppet-agent':
+          packages => 'puppet-agent',
+          origin   => 'apt.puppetlabs.com',
+          priority => 1001,
+        }
+        apt::pin { 'builds-puppet-agent':
+          packages => 'puppet-agent',
+          origin   => 'builds.delivery.puppetlabs.net',
+          priority => 1001,
+        }
+      }
     }
 
     redhat: {

--- a/templates/ubuntu-16.10/i386.vmware.vsphere.nocm.json
+++ b/templates/ubuntu-16.10/i386.vmware.vsphere.nocm.json
@@ -3,7 +3,7 @@
   "variables":
     {
       "template_name": "ubuntu-16.10-i386",
-      "version": "0.0.2",
+      "version": "0.0.3",
 
       "provisioner": "vmware",
       "required_modules": "puppetlabs-stdlib example42-network puppetlabs-apt",

--- a/templates/ubuntu-16.10/x86_64.vmware.vsphere.nocm.json
+++ b/templates/ubuntu-16.10/x86_64.vmware.vsphere.nocm.json
@@ -3,7 +3,7 @@
   "variables":
     {
       "template_name": "ubuntu-16.10-x86_64",
-      "version": "0.0.2",
+      "version": "0.0.3",
 
       "provisioner": "vmware",
       "required_modules": "puppetlabs-stdlib example42-network puppetlabs-apt",


### PR DESCRIPTION
Due to yakkety including a puppet-agent package, we need to pin to
ensure apt prefers out AIO package.