### PR TITLE
(maint) centos7 vsphere fixups

### DIFF
--- a/manifests/modules/packer/manifests/vmtools.pp
+++ b/manifests/modules/packer/manifests/vmtools.pp
@@ -14,7 +14,7 @@ class packer::vmtools inherits packer::vmtools::params {
     }
 
     redhat: {
-      if $::operatingsystemrelease in ['25'] {
+      if $::operatingsystemmajrelease in ['25', '7'] {
         package { 'open-vm-tools':
           ensure => installed,
         }
@@ -73,6 +73,6 @@ class packer::vmtools inherits packer::vmtools::params {
         match   => '/tmp/vmtools',
         require => Exec[ 'remove /tmp/vmtools' ],
       }
-    } 
+    }
   }
 }

--- a/manifests/modules/packer/manifests/vsphere/networking.pp
+++ b/manifests/modules/packer/manifests/vsphere/networking.pp
@@ -25,7 +25,7 @@ class packer::vsphere::networking inherits packer::networking::params {
             ensure => absent,
           }
         }
-        network::interface { 'ens32':
+        network::interface { 'ens160':
           enable_dhcp   => true,
         }
       }

--- a/manifests/modules/packer/templates/vsphere/redhat.rb.erb
+++ b/manifests/modules/packer/templates/vsphere/redhat.rb.erb
@@ -21,12 +21,12 @@ puts '- Re-obtaining DHCP lease...'
 
 <% if (@operatingsystem == 'CentOS') or (@operatingsystem == 'Scientific') -%>
   <% if @operatingsystemmajrelease == '7' -%>
-    File.open('/var/lib/NetworkManager/dhclient-ens32.conf', 'a') do |f|
+    File.open('/var/lib/NetworkManager/dhclient-ens160.conf', 'a') do |f|
       f << "send host-name #{hostname}"
     end
     Kernel.system('/sbin/service NetworkManager restart')
-    Kernel.system('/usr/bin/nmcli con down id ens32')
-    Kernel.system('/usr/bin/nmcli con up id ens32')
+    Kernel.system('/usr/sbin/ifdown ens160')
+    Kernel.system('/usr/sbin/ifup ens160')
   <% end -%>
   <% if @operatingsystemmajrelease == '6' -%>
     File.open('/etc/dhcp/dhclient-eth0.conf', 'a') do |f|

--- a/templates/centos-7.2/x86_64.vmware.base.json
+++ b/templates/centos-7.2/x86_64.vmware.base.json
@@ -14,13 +14,19 @@
 
       "provisioner": "vmware",
       "required_modules": "puppetlabs-stdlib saz-ssh",
-      "puppet_nfs": "{{env `PUPPET_NFS`}}"
+      "puppet_aio": "http://yum.puppetlabs.com/el/7/PC1/x86_64/puppet-agent-1.8.3-1.el7.x86_64.rpm",
+
+
+      "output_directory": "{{env `OUTPUT_DIRECTORY`}}"
+
     },
 
   "builders": [
     {
       "name": "{{user `template_name`}}-{{user `provisioner`}}",
+      "output_directory": "{{user `output_directory`}}output-{{build_name}}",
       "type": "vmware-iso",
+      "headless": true,
       "boot_command": [
         "<tab> <wait>",
         "text <wait>",
@@ -54,16 +60,16 @@
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
-        "PUPPET_NFS={{user `puppet_nfs`}}"
+        "PUPPET_AIO={{user `puppet_aio`}}"
       ],
       "scripts": [
-        "../../scripts/bootstrap-puppet.sh"
+        "../../scripts/bootstrap-aio.sh"
       ]
     },
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --parser=future --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppetlabs/bin /opt/puppetlabs/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}"
       },
@@ -76,10 +82,10 @@
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
-        "PUPPET_NFS={{user `puppet_nfs`}}"
+        "PUPPET_AIO={{user `puppet_aio`}}"
       ],
       "scripts": [
-        "../../scripts/cleanup-puppet.sh",
+        "../../scripts/cleanup-aio.sh",
         "../../scripts/cleanup-packer.sh"
       ]
     }

--- a/templates/centos-7.2/x86_64.vmware.vsphere.nocm.json
+++ b/templates/centos-7.2/x86_64.vmware.vsphere.nocm.json
@@ -3,11 +3,11 @@
   "variables":
     {
       "template_name": "centos-7.2-x86_64",
-      "version": "0.0.2",
+      "version": "0.0.3",
 
       "provisioner": "vmware",
       "required_modules": "puppetlabs-stdlib example42-network puppetlabs-firewall",
-      "puppet_nfs": "{{env `PUPPET_NFS`}}",
+      "puppet_aio": "http://yum.puppetlabs.com/el/7/PC1/x86_64/puppet-agent-1.8.3-1.el7.x86_64.rpm",
       "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
       "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",
       "packer_vcenter_username": "{{env `PACKER_VCENTER_USERNAME`}}",
@@ -20,7 +20,10 @@
       "packer_vcenter_insecure": "{{env `PACKER_VCENTER_INSECURE`}}",
 
       "memory_size": "4096",
-      "cpu_count": "2"
+      "cpu_count": "2",
+
+      "output_directory": "{{env `OUTPUT_DIRECTORY`}}"
+
 
     },
 
@@ -29,7 +32,8 @@
       "name": "{{user `template_name`}}-{{user `provisioner`}}-vsphere-nocm",
       "vm_name": "packer-{{build_name}}",
       "type": "vmware-vmx",
-      "source_path": "output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
+      "headless": true,
+      "source_path": "{{user `output_directory`}}output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
       "ssh_username": "root",
       "ssh_password": "puppet",
       "ssh_port": 22,
@@ -41,7 +45,8 @@
       "vmx_data_post": {
         "memsize": "{{user `memory_size`}}",
         "numvcpus": "{{user `cpu_count`}}",
-        "cpuid.coresPerSocket": "1"
+        "cpuid.coresPerSocket": "1",
+        "ethernet0.virtualDev": "vmxnet3"
       }
     }
   ],
@@ -52,10 +57,10 @@
       "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
-        "PUPPET_NFS={{user `puppet_nfs`}}"
+        "PUPPET_AIO={{user `puppet_aio`}}"
       ],
       "scripts": [
-        "../../scripts/bootstrap-puppet.sh"
+        "../../scripts/bootstrap-aio.sh"
       ]
     },
 
@@ -67,7 +72,7 @@
 
     {
       "type": "puppet-masterless",
-      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppet/bin /opt/puppet/bin/puppet apply --parser=future --verbose --detailed-exitcodes --hiera_config='/tmp/packer-puppet-masterless/hiera/hiera.yaml' --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppetlabs/bin /opt/puppetlabs/bin/puppet apply --verbose --detailed-exitcodes --hiera_config='/tmp/packer-puppet-masterless/hiera/hiera.yaml' --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter": {
         "provisioner": "{{user `provisioner`}}",
         "qa_root_passwd": "{{user `qa_root_passwd`}}"
@@ -80,10 +85,10 @@
       "type": "shell",
       "environment_vars": [
         "TEMPLATE={{user `template_name`}}",
-        "PUPPET_NFS={{user `puppet_nfs`}}"
+        "PUPPET_AIO={{user `puppet_aio`}}"
       ],
       "scripts": [
-        "../../scripts/cleanup-puppet.sh",
+        "../../scripts/cleanup-aio.sh",
         "../../scripts/cleanup-packer.sh",
         "../../scripts/cleanup-scrub.sh"
       ]


### PR DESCRIPTION
The related bits around building CentOS 7 for use with the vmpooler have not been updated in ages and requires some modifications.

- Use open-vm-tools instead of installing from the tools ISO.
- Use vmxnet3 for vSphere artificats
- vmpooler bootstrap and config file fixups due to networking changes
- Switch to the AIO method for provisioning.

I'm still waiting to get a build through jenkins-imaging, but a local build appears to behave as expected.

```shell
[root@c3f8ab4jpwyhwpg tmp]# cat vsphere-bootstrap.log
Nice to meet you, my VM name is 'c3f8ab4jpwyhwpg'.

- Setting local hostname...
- Re-obtaining DHCP lease...
Redirecting to /bin/systemctl restart  NetworkManager.service
Device 'ens160' successfully disconnected.
Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/1)
- Cleaning up...

Done!
[root@c3f8ab4jpwyhwpg tmp]#
```