### PR TITLE
corrects faulty ignore of packer manifests files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ vendor/*
 hiera/*
 drivers/
 packer
+!manifests/modules/packer
 .DS_Store
 Gemfile.lock
 Gemfile.local


### PR DESCRIPTION
Think this was introduced while adding tests.  
manifests/modules/packer/* was also ignores, which seems not correct.