### PR TITLE
Updates for SLES-12 sp1 and sp2 builds

### DIFF
--- a/manifests/modules/packer/manifests/updates.pp
+++ b/manifests/modules/packer/manifests/updates.pp
@@ -37,5 +37,9 @@ class packer::updates {
     file { '/etc/apt/apt.conf.d/10disable-periodic':
       content => 'APT::Periodic::Enable \"0\";'
     }
+  } elsif $::osfamily == 'Suse' {
+    file { '/etc/zypp/locks':
+      ensure => absent
+    }
   }
 }

--- a/manifests/modules/packer/templates/vsphere/sles.rb.erb
+++ b/manifests/modules/packer/templates/vsphere/sles.rb.erb
@@ -24,6 +24,7 @@ Kernel.system('systemctl restart wicked.service')
 puts '- Cleaning up...'
 
 Kernel.system('rm /etc/vsphere-bootstrap.rb')
+Kernel.system('rm /etc/zypp/repos.d/SLES*.repo')
 Kernel.system('echo "exit 0" > /etc/rc.d/after.local')
 
 puts "\n"

--- a/templates/sles-12.1/files/sles-12-sp1-x86_64-autoinst.xml
+++ b/templates/sles-12.1/files/sles-12-sp1-x86_64-autoinst.xml
@@ -127,7 +127,7 @@
         <partition>
           <create config:type="boolean">true</create>
           <crypt_fs config:type="boolean">false</crypt_fs>
-          <filesystem config:type="symbol">btrfs</filesystem>
+          <filesystem config:type="symbol">ext4</filesystem>
           <format config:type="boolean">true</format>
           <loop_fs config:type="boolean">false</loop_fs>
           <mount>/</mount>

--- a/templates/sles-12.1/x86_64.vmware.base.json
+++ b/templates/sles-12.1/x86_64.vmware.base.json
@@ -2,7 +2,7 @@
 
   "variables":
     {
-      "template_name": "sles-12.1-x86_64",
+      "template_name": "sles-12sp1-x86_64",
       "template_os": "linux",
 
       "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/SLE-12-SP1-Server-DVD-x86_64-GM-DVD1.iso",

--- a/templates/sles-12.1/x86_64.vmware.vsphere.nocm.json
+++ b/templates/sles-12.1/x86_64.vmware.vsphere.nocm.json
@@ -3,7 +3,7 @@
   "variables":
     {
       "template_name": "sles-12sp1-x86_64",
-      "version": "0.0.1",
+      "version": "0.0.2",
 
       "provisioner": "vmware",
       "required_modules": "puppetlabs-stdlib example42-network darin-zypprepo",

--- a/templates/sles-12.1/x86_64.vmware.vsphere.nocm.json
+++ b/templates/sles-12.1/x86_64.vmware.vsphere.nocm.json
@@ -2,7 +2,7 @@
 
   "variables":
     {
-      "template_name": "sles-12.1-x86_64",
+      "template_name": "sles-12sp1-x86_64",
       "version": "0.0.1",
 
       "provisioner": "vmware",

--- a/templates/sles-12.2/files/sles-12-sp2-x86_64-autoinst.xml
+++ b/templates/sles-12.2/files/sles-12-sp2-x86_64-autoinst.xml
@@ -127,7 +127,7 @@
         <partition>
           <create config:type="boolean">true</create>
           <crypt_fs config:type="boolean">false</crypt_fs>
-          <filesystem config:type="symbol">btrfs</filesystem>
+          <filesystem config:type="symbol">ext4</filesystem>
           <format config:type="boolean">true</format>
           <loop_fs config:type="boolean">false</loop_fs>
           <mount>/</mount>

--- a/templates/sles-12.2/x86_64.vmware.vsphere.nocm.json
+++ b/templates/sles-12.2/x86_64.vmware.vsphere.nocm.json
@@ -3,7 +3,7 @@
   "variables":
     {
       "template_name": "sles-12sp2-x86_64",
-      "version": "0.0.2",
+      "version": "0.0.3",
 
       "provisioner": "vmware",
       "required_modules": "puppetlabs-stdlib example42-network darin-zypprepo",


### PR DESCRIPTION
This adds a step to make sure sles isn't adding locks to packages and updates the template names to be consistent between sp1 and sp2