### PR TITLE
(IMAGES-539) Disable Google Update Services

### DIFF
--- a/manifests/windows/windows_template/manifests/configure_services.pp
+++ b/manifests/windows/windows_template/manifests/configure_services.pp
@@ -21,4 +21,14 @@ class windows_template::configure_services()
       ensure => 'stopped',
       enable => false,
     }
+
+    # Disable Google Update Services to prevent pending reboot requests
+    service { 'gupdate':
+      ensure => 'stopped',
+      enable => false,
+    }
+    service { 'gupdatem':
+      ensure => 'stopped',
+      enable => false,
+    }
 }

--- a/templates/windows-2012r2-wmf5/x86_64.vmware.base.json
+++ b/templates/windows-2012r2-wmf5/x86_64.vmware.base.json
@@ -4,9 +4,9 @@
     "template_config": "base",
 
     "provisioner": "vmware",
-    "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2012_r2_with_update_x64_dvd_6052708_SlipStream_01.iso",
+    "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2012_r2_with_update_x64_dvd_6052708_SlipStream_02.iso",
     "iso_checksum_type": "md5",
-    "iso_checksum": "5006c404bded89c4f7f24e7df8c6a266",
+    "iso_checksum": "3feae58c235f88126a1c099d58abfb8f",
     "headless": "true",
     "tools_iso": "{{env `VMWARE_TOOLS_ISO`}}/windows.iso",
     "packer_output_dir": "{{env `PACKER_VM_OUT_DIR`}}"

--- a/templates/windows-2012r2/x86_64.virtualbox.base.json
+++ b/templates/windows-2012r2/x86_64.virtualbox.base.json
@@ -5,9 +5,9 @@
     "template_config": "base",
     "template_os"      : "Windows2012_64",
 
-    "iso_url"          : "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2012_r2_with_update_x64_dvd_6052708_SlipStream_01.iso",
+    "iso_url"          : "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2012_r2_with_update_x64_dvd_6052708_SlipStream_02.iso",
     "iso_checksum_type": "md5",
-    "iso_checksum"     : "5006c404bded89c4f7f24e7df8c6a266",
+    "iso_checksum"     : "3feae58c235f88126a1c099d58abfb8f",
     "headless"         : "true",
     "memory_size"      : "2048",
     "cpu_count"        : "2",

--- a/templates/windows-2012r2/x86_64.vmware.base.json
+++ b/templates/windows-2012r2/x86_64.vmware.base.json
@@ -4,9 +4,9 @@
     "template_config": "base",
 
     "provisioner": "vmware",
-    "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2012_r2_with_update_x64_dvd_6052708_SlipStream_01.iso",
+    "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2012_r2_with_update_x64_dvd_6052708_SlipStream_02.iso",
     "iso_checksum_type": "md5",
-    "iso_checksum": "5006c404bded89c4f7f24e7df8c6a266",
+    "iso_checksum": "3feae58c235f88126a1c099d58abfb8f",
     "headless": "true",
     "tools_iso": "{{env `VMWARE_TOOLS_ISO`}}/windows.iso",
     "packer_output_dir": "{{env `PACKER_VM_OUT_DIR`}}"


### PR DESCRIPTION
The Udpate services cause a pending reboot request which interferes with
module testing, so disable this.