### PR TITLE
(IMAGES-546) Address Win-2008 -> Win-2012 Build Stability Issues

### DIFF
--- a/manifests/windows/windows_template/manifests/configure_services.pp
+++ b/manifests/windows/windows_template/manifests/configure_services.pp
@@ -21,4 +21,14 @@ class windows_template::configure_services()
       ensure => 'stopped',
       enable => false,
     }
+
+    # Disable Google Update Services to prevent pending reboot requests
+    service { 'gupdate':
+      ensure => 'stopped',
+      enable => false,
+    }
+    service { 'gupdatem':
+      ensure => 'stopped',
+      enable => false,
+    }
 }

--- a/scripts/windows/cleanup-host.ps1
+++ b/scripts/windows/cleanup-host.ps1
@@ -11,24 +11,29 @@ Start-Process -Wait "msiexec" -ArgumentList "/x $PackerDownloads\puppet-agent.ms
 
 # Remove Boxstarter
 Write-Host "Uninstalling boxstarter..."
-choco uninstall boxstarter --yes
+choco uninstall boxstarter --yes --force
 
 # Remove Chocolatey - using instructions at https://chocolatey.org/docs/uninstallation
 Write-Host "Uninstalling Chocolatey and all its bits..."
 
-Remove-Item -Recurse -Force "$env:ChocolateyInstall"
-[System.Text.RegularExpressions.Regex]::Replace( `
-[Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment').GetValue('PATH', '',  `
-[Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames).ToString(),  `
-[System.Text.RegularExpressions.Regex]::Escape("$env:ChocolateyInstall\bin") + '(?>;)?', '', `
-[System.Text.RegularExpressions.RegexOptions]::IgnoreCase) | `
-%{[System.Environment]::SetEnvironmentVariable('PATH', $_, 'User')}
-[System.Text.RegularExpressions.Regex]::Replace( `
-[Microsoft.Win32.Registry]::LocalMachine.OpenSubKey('SYSTEM\CurrentControlSet\Control\Session Manager\Environment\').GetValue('PATH', '', `
-[Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames).ToString(),  `
-[System.Text.RegularExpressions.Regex]::Escape("$env:ChocolateyInstall\bin") + '(?>;)?', '', `
-[System.Text.RegularExpressions.RegexOptions]::IgnoreCase) | `
-%{[System.Environment]::SetEnvironmentVariable('PATH', $_, 'Machine')}
+try {
+  Remove-Item -Recurse -Force "$env:ChocolateyInstall"
+  [System.Text.RegularExpressions.Regex]::Replace( `
+  [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment').GetValue('PATH', '',  `
+  [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames).ToString(),  `
+  [System.Text.RegularExpressions.Regex]::Escape("$env:ChocolateyInstall\bin") + '(?>;)?', '', `
+  [System.Text.RegularExpressions.RegexOptions]::IgnoreCase) | `
+  %{[System.Environment]::SetEnvironmentVariable('PATH', $_, 'User')}
+  [System.Text.RegularExpressions.Regex]::Replace( `
+  [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey('SYSTEM\CurrentControlSet\Control\Session Manager\Environment\').GetValue('PATH', '', `
+  [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames).ToString(),  `
+  [System.Text.RegularExpressions.Regex]::Escape("$env:ChocolateyInstall\bin") + '(?>;)?', '', `
+  [System.Text.RegularExpressions.RegexOptions]::IgnoreCase) | `
+  %{[System.Environment]::SetEnvironmentVariable('PATH', $_, 'Machine')}
+}
+catch {
+    Write-Host "Ignoring Error deleting: $filetodelete - Continue"
+}
 
 if ($env:ChocolateyBinRoot -ne '' -and $env:ChocolateyBinRoot -ne $null) { ForceFullyDelete-Paths "$env:ChocolateyBinRoot" }
 if ($env:ChocolateyToolsRoot -ne '' -and $env:ChocolateyToolsRoot -ne $null) { ForceFullyDelete-Paths "$env:ChocolateyToolsRoot" }

--- a/scripts/windows/install-cygwin.ps1
+++ b/scripts/windows/install-cygwin.ps1
@@ -61,7 +61,8 @@ $ENV:QA_ROOT_PASSWD | Out-File "$CygwinDownloads\qapasswd"
 Write-Host "Downloading Cygwin Packages"
 Download-File "http://buildsources.delivery.puppetlabs.net/windows/cygwin/packages-$ARCH.zip" "$CygwinDownloads\packages_$ARCH.zip"
 Write-Host "Extracting $CygwinDownloads\packages_$ARCH.zip"
-Start-Process -Wait "$7zip" -PassThru -NoNewWindow -ArgumentList "x $CygwinDownloads\packages_$ARCH.zip -y -o$CygwinDownloads"
+$zproc = Start-Process "$7zip" -PassThru -NoNewWindow -ArgumentList "x $CygwinDownloads\packages_$ARCH.zip -y -o$CygwinDownloads"
+$zproc.WaitForExit()
 
 Write-Host "Downloading Cygwin Setup"
 $CygWinSetup = "$CygwinDownloads\setup-$ARCH.exe"

--- a/scripts/windows/start-boxstarter.ps1
+++ b/scripts/windows/start-boxstarter.ps1
@@ -18,8 +18,34 @@ if ($packageFile -eq $null) {
   return
 }
 
-iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/mwrock/boxstarter/master/BuildScripts/bootstrapper.ps1'))
-Get-Boxstarter -Force
+if ($WindowsVersion -like $WindowsServer2008 ) {
+  # Compatibility issues with latest updates for boxstarter/chocolatey, so pin to earlier versions.
+  $env:chocolateyVersion = "0.10.3"
+  Write-Host "Pinning to chocolatey Version $env:chocolateyVersion and Boxstarter Version $env:boxstarterVersion"
+  iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+
+  # Install each of the boxstarter modules with dependencies disabled to ensure Version 2.8.29 is used across the board.
+  # Also resort to pinning the packages to see if this stops boxstarter gratuitously upgrading them
+  # This is probably way too verbose, the but the order and combination below was necessary to ensure an error free
+  # install and ability to run box-starter on the older windows platforms.
+
+  $BoxstarterPackages = @(
+    'boxstarter',
+    'boxstarter.common',
+    'boxstarter.winconfig',
+    'boxstarter.bootstrapper',
+    'boxstarter.chocolatey',
+    'boxstarter.hyperv'
+  )
+  $BoxstarterPackages | % {
+    choco install $_ -y --force --version "2.8.29" --argsglobal=true --paramsglobal=true --ignoredependencies=true
+    choco pin add --name="$_"
+  }
+}
+else {
+  iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/mwrock/boxstarter/master/BuildScripts/bootstrapper.ps1'))
+  Get-Boxstarter -Force
+}
 
 # Cleanup after boxstarter install
 Remove-Item -Path "$($Env:USERPROFILE)\Desktop\Boxstarter Shell.lnk" -Confirm:$false -Force -ErrorAction SilentlyContinue | Out-Null
@@ -29,5 +55,8 @@ Remove-Item -Path "$($Env:APPDATA)\Microsoft\Windows\Start Menu\Programs\Boxstar
 $secpasswd = ConvertTo-SecureString "$LoginPassword" -AsPlainText -Force
 $cred = New-Object System.Management.Automation.PSCredential ("$LoginUser", $secpasswd)
 
+Write-Host "Importing Modules"
 Import-Module $env:appdata\boxstarter\boxstarter.chocolatey\boxstarter.chocolatey.psd1
+
+Write-Host "Executing Boxstarter Package"
 Install-BoxstarterPackage -PackageName ($packageFile.Fullname) -Credential $cred

--- a/scripts/windows/windows-env.ps1
+++ b/scripts/windows/windows-env.ps1
@@ -216,6 +216,16 @@ Function Do-Packer-Final-Reboot
 
 Function Install-PackerWindowsUpdates
 {
+  param (
+    [switch]$DisableWUSA
+  )
+
+  # If DisableWUSA is set, then touch the "WUSA.redirect" file to disable it
+  if ( $DisableWUSA ) {
+    Write-Host "Disable WUSA Re-direct"
+    Touch-File "A:\WSUS.redirect"
+  }
+
   if (-not (Test-Path "A:\WSUS.redirect"))
   {
     Touch-File "A:\WSUS.redirect"

--- a/templates/windows-2008/files/x86_64/vmware/windows-2008-x86_64-vmware-base.package.ps1
+++ b/templates/windows-2008/files/x86_64/vmware/windows-2008-x86_64-vmware-base.package.ps1
@@ -56,13 +56,14 @@ if (-not (Test-Path "A:\NET45.installed"))
 {
   # Install .Net Framework 4.5.2
   Write-BoxstarterMessage "Installing .Net 4.5"
+  choco feature enable -n allowemptychecksums
   choco install dotnet4.5 -y
   Touch-File "A:\NET45.installed"
   if (Test-PendingReboot) { Invoke-Reboot }
 }
 
 # Run the Packer Update Sequence
-Install-PackerWindowsUpdates
+Install-PackerWindowsUpdates -DisableWUSA
 
 # Enable RDP
 Write-BoxstarterMessage "Enable Remote Desktop"

--- a/templates/windows-2008/files/x86_64/vmware/windows-2008-x86_64-vmware-base.package.ps1
+++ b/templates/windows-2008/files/x86_64/vmware/windows-2008-x86_64-vmware-base.package.ps1
@@ -57,7 +57,8 @@ if (-not (Test-Path "A:\NET45.installed"))
   # Install .Net Framework 4.5.2
   Write-BoxstarterMessage "Installing .Net 4.5"
   choco feature enable -n allowemptychecksums
-  choco install dotnet4.5 -y
+  Download-File "http://buildsources.delivery.puppetlabs.net/windows/dotnet45/dotnetfx45_full_x86_x64.exe" "$Env:TEMP/dotnetfx45_full_x86_x64.exe"
+  Start-Process -Wait "$Env:TEMP/dotnetfx45_full_x86_x64.exe" -NoNewWindow -PassThru -ArgumentList "/quiet /norestart"
   Touch-File "A:\NET45.installed"
   if (Test-PendingReboot) { Invoke-Reboot }
 }

--- a/templates/windows-2008/files/x86_64/windows-2008-slipstream.package.ps1
+++ b/templates/windows-2008/files/x86_64/windows-2008-slipstream.package.ps1
@@ -17,7 +17,8 @@ if (-not (Test-Path "A:\NET45.installed"))
 {
   # Install .Net Framework 4.5.2
   Write-BoxstarterMessage "Installing .Net 4.5"
-  choco install dotnet4.5 -y
+  Download-File "http://buildsources.delivery.puppetlabs.net/windows/dotnet45/dotnetfx45_full_x86_x64.exe" "$Env:TEMP/dotnetfx45_full_x86_x64.exe"
+  Start-Process -Wait "$Env:TEMP/dotnetfx45_full_x86_x64.exe" -NoNewWindow -PassThru -ArgumentList "/quiet /norestart"
   Touch-File "A:\NET45.installed"
   if (Test-PendingReboot) { Invoke-Reboot }
 }

--- a/templates/windows-2008/x86_64.vmware.base.json
+++ b/templates/windows-2008/x86_64.vmware.base.json
@@ -32,7 +32,7 @@
       "communicator": "winrm",
       "winrm_username": "Administrator",
       "winrm_password": "PackerAdmin",
-      "winrm_timeout": "4h",
+      "winrm_timeout": "8h",
 
       "shutdown_command": "shutdown /s /t 1 /c \"Packer Shutdown\" /f /d p:4:1",
       "shutdown_timeout": "1h",

--- a/templates/windows-2008r2-wmf5/files/x86_64/vmware/windows-2008r2-wmf5-x86_64-vmware-base.package.ps1
+++ b/templates/windows-2008r2-wmf5/files/x86_64/vmware/windows-2008r2-wmf5-x86_64-vmware-base.package.ps1
@@ -38,7 +38,8 @@ if (-not (Test-Path "A:\NET45.installed"))
 {
   # Install .Net Framework 4.5.2
   Write-BoxstarterMessage "Installing .Net 4.5"
-  choco install dotnet4.5 -y
+  Download-File "http://buildsources.delivery.puppetlabs.net/windows/dotnet45/dotnetfx45_full_x86_x64.exe" "$Env:TEMP/dotnetfx45_full_x86_x64.exe"
+  Start-Process -Wait "$Env:TEMP/dotnetfx45_full_x86_x64.exe" -NoNewWindow -PassThru -ArgumentList "/quiet /norestart"
   Touch-File "A:\NET45.installed"
   if (Test-PendingReboot) { Invoke-Reboot }
 }

--- a/templates/windows-2008r2/files/slipstream-filter
+++ b/templates/windows-2008r2/files/slipstream-filter
@@ -1,0 +1,1 @@
+# CAB files to be filtered out in case of DISM Issues

--- a/templates/windows-2008r2/files/x86_64/vmware/windows-2008r2-x86_64-vmware-base.package.ps1
+++ b/templates/windows-2008r2/files/x86_64/vmware/windows-2008r2-x86_64-vmware-base.package.ps1
@@ -39,7 +39,8 @@ if (-not (Test-Path "A:\NET45.installed"))
 {
   # Install .Net Framework 4.5.2
   Write-BoxstarterMessage "Installing .Net 4.5"
-  choco install dotnet4.5 -y
+  Download-File "http://buildsources.delivery.puppetlabs.net/windows/dotnet45/dotnetfx45_full_x86_x64.exe" "$Env:TEMP/dotnetfx45_full_x86_x64.exe"
+  Start-Process -Wait "$Env:TEMP/dotnetfx45_full_x86_x64.exe" -NoNewWindow -PassThru -ArgumentList "/quiet /norestart"
   Touch-File "A:\NET45.installed"
   if (Test-PendingReboot) { Invoke-Reboot }
 }

--- a/templates/windows-2008r2/files/x86_64/windows-2008r2-slipstream.package.ps1
+++ b/templates/windows-2008r2/files/x86_64/windows-2008r2-slipstream.package.ps1
@@ -1,0 +1,99 @@
+$ErrorActionPreference = "Stop"
+
+# Customised Slipstream script for Windows-2008r2 - this proves a bit more difficult than the "usual"
+# Slipstream update process.
+# Use a rollup update.
+
+. A:\windows-env.ps1
+
+# Boxstarter options
+$Boxstarter.RebootOk=$true # Allow reboots?
+$Boxstarter.NoPassword=$false # Is this a machine with no login password?
+$Boxstarter.AutoLogin=$true # Save my password securely and auto-login after a reboot
+
+if (Test-PendingReboot){ Invoke-Reboot }
+
+# Need to guard against system going into standby for long updates
+Write-BoxstarterMessage "Disabling Sleep timers"
+Disable-PC-Sleep
+
+if (-not (Test-Path "A:\NET45.installed"))
+{
+  # Install .Net Framework 4.5.2
+  Write-BoxstarterMessage "Installing .Net 4.5"
+  Download-File "http://buildsources.delivery.puppetlabs.net/windows/dotnet45/dotnetfx45_full_x86_x64.exe" "$Env:TEMP/dotnetfx45_full_x86_x64.exe"
+  Start-Process -Wait "$Env:TEMP/dotnetfx45_full_x86_x64.exe" -NoNewWindow -PassThru -ArgumentList "/quiet /norestart"
+  Touch-File "A:\NET45.installed"
+  if (Test-PendingReboot) { Invoke-Reboot }
+}
+
+if (-not (Test-Path "A:\KB3020369.installed"))
+{
+  # Install the WinSxS cleanup patch
+  Write-BoxstarterMessage "Installing Windows Update Cleanup Hotfix KB2852386"
+  Install_Win_Patch "http://osmirror.delivery.puppetlabs.net/iso/windows/win-2008r2-msu/Windows6.1-KB3020369-x64.msu"
+  Touch-File "A:\KB3020369.installed"
+  if (Test-PendingReboot) { Invoke-Reboot }
+}
+
+if (-not (Test-Path "A:\KB2852386.installed"))
+{
+  # Install the WinSxS cleanup patch
+  Write-BoxstarterMessage "Installing Windows Update Cleanup Hotfix KB2852386"
+  Install_Win_Patch "http://osmirror.delivery.puppetlabs.net/iso/windows/win-2008r2-msu/Windows6.1-KB2852386-v2-x64.msu"
+  Touch-File "A:\KB2852386.installed"
+  if (Test-PendingReboot) { Invoke-Reboot }
+}
+
+$Win2008r2RollupMsu = "windows6.1-kb3125574-v4-x64_2dafb1d203c8964239af3048b5dd4b1264cd93b9.msu"
+if (-not (Test-Path "A:\Win2008r2MSU.installed"))
+{
+  # Install Windows Rollup Update first.
+  Write-Host "Install Windows 2008r2 Rollup update"
+  Download-File "http://osmirror.delivery.puppetlabs.net/iso/windows/win-2008r2-msu/$Win2008r2RollupMsu"  "$ENV:TEMP\$Win2008r2RollupMsu"
+  Write-Host "Applying $Win2008r2RollupMsu Patch"
+  Start-Process -Wait "wusa.exe" -ArgumentList "$ENV:TEMP\$Win2008r2RollupMsu /quiet /norestart"
+  Touch-File "A:\Win2008r2MSU.installed"
+  Invoke-Reboot
+}
+
+# Run the Packer Update Sequence
+Install-PackerWindowsUpdates
+
+# Create Dism directories and copy files over.
+# This allows errors to be handled manually in event of dism failures
+
+New-Item -ItemType directory -Force -Path C:\Packer
+New-Item -ItemType directory -Force -Path C:\Packer\Dism
+New-Item -ItemType directory -Force -Path C:\Packer\Downloads
+New-Item -ItemType directory -Force -Path C:\Packer\Dism\Mount
+New-Item -ItemType directory -Force -Path C:\Packer\Dism\Logs
+
+Copy-Item A:\windows-env.ps1 C:\Packer\Dism
+Copy-Item A:\generate-slipstream.ps1 C:\Packer\Dism
+Copy-Item A:\slipstream-filter C:\Packer\Dism
+
+# Add WinRM Firewall Rule
+Write-BoxstarterMessage "Setting up winrm"
+netsh advfirewall firewall add rule name="WinRM-HTTP" dir=in localport=5985 protocol=TCP action=allow
+
+$enableArgs=@{Force=$true}
+try {
+ $command=Get-Command Enable-PSRemoting
+  if($command.Parameters.Keys -contains "skipnetworkprofilecheck"){
+      $enableArgs.skipnetworkprofilecheck=$true
+  }
+}
+catch {
+  $global:error.RemoveAt(0)
+}
+Enable-PSRemoting @enableArgs
+Enable-WSManCredSSP -Force -Role Server
+# NOTE - This is insecure but can be shored up in later customisation.  Required for Vagrant and other provisioning tools
+winrm set winrm/config/client/auth '@{Basic="true"}'
+winrm set winrm/config/service/auth '@{Basic="true"}'
+winrm set winrm/config/service '@{AllowUnencrypted="true"}'
+winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="2048"}'
+Write-BoxstarterMessage "WinRM setup complete"
+
+# End

--- a/templates/windows-2008r2/x86_64.vmware.base.json
+++ b/templates/windows-2008r2/x86_64.vmware.base.json
@@ -4,9 +4,9 @@
     "template_config": "base",
 
     "provisioner": "vmware",
-    "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2008_r2_with_sp1_x64_dvd_617601_SlipStream_01.iso",
+    "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2008_r2_with_sp1_x64_dvd_617601_SlipStream_02.iso",
     "iso_checksum_type": "md5",
-    "iso_checksum": "1d1941c6d90389ba28c2068ac0d5b6ba",
+    "iso_checksum": "3689de89d445febc77a4df0ae37d1b03",
     "headless": "true",
     "tools_iso": "{{env `VMWARE_TOOLS_ISO`}}/windows.iso",
     "packer_output_dir": "{{env `PACKER_VM_OUT_DIR`}}"

--- a/templates/windows-2008r2/x86_64.vmware.slipstream.json
+++ b/templates/windows-2008r2/x86_64.vmware.slipstream.json
@@ -1,18 +1,18 @@
 {
   "variables": {
-    "template_name": "windows-2008r2-wmf5-x86_64",
+    "template_name": "windows-2008r2-x86_64",
+    "os_name" : "Win-2008r2",
     "template_config": "base",
 
     "provisioner": "vmware",
-    "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2008_r2_with_sp1_x64_dvd_617601_SlipStream_02.iso",
+    "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2008_r2_with_sp1_x64_dvd_617601.iso",
     "iso_checksum_type": "md5",
-    "iso_checksum": "3689de89d445febc77a4df0ae37d1b03",
-    "headless": "true",
-    "tools_iso": "{{env `VMWARE_TOOLS_ISO`}}/windows.iso",
-    "packer_output_dir": "{{env `PACKER_VM_OUT_DIR`}}"
+    "iso_checksum": "8dcde01d0da526100869e2457aafb7ca",
+    "headless": "false",
+    "tools_iso": "{{env `VMWARE_TOOLS_ISO`}}/windows.iso"
   },
 
-  "description": "Builds a Windows Server 2008R2 template VM for use in VMware",
+  "description": "Customised Win-2008r2 build to prepare slipstream ISO",
 
   "_comment": [
       "The boot_command is hacky because the UEFI boot file used requires the 'Press any key' to be done"
@@ -25,14 +25,12 @@
       "iso_url": "{{user `iso_url`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "output_directory": "{{user `packer_output_dir`}}/output-{{build_name}}",
-
       "headless": "{{user `headless`}}",
 
       "communicator": "winrm",
       "winrm_username": "Administrator",
       "winrm_password": "PackerAdmin",
-      "winrm_timeout": "4h",
+      "winrm_timeout": "48h",
 
       "shutdown_command": "shutdown /s /t 1 /c \"Packer Shutdown\" /f /d p:4:1",
       "shutdown_timeout": "1h",
@@ -41,18 +39,18 @@
       "disk_type_id": "0",
       "floppy_files": [
         "files/x86_64/vmware/autounattend.xml",
-        "files/x86_64/vmware/generalize-packer.autounattend.xml",
-        "files/x86_64/vmware/{{build_name}}.package.ps1",
         "../../scripts/windows/bootstrap-base.bat",
         "../../scripts/windows/start-boxstarter.ps1",
         "../../scripts/windows/windows-env.ps1",
         "../../scripts/windows/shutdown-packer.bat",
         "../../scripts/windows/generalize-packer.bat",
-        "../../scripts/windows/clean-disk-dism.ps1",
-        "../../scripts/windows/clean-disk-sdelete.ps1"
+        "../../scripts/windows/generate-slipstream.ps1",
+        "files/slipstream-filter",
+        "files/x86_64/vmware/generalize-packer.autounattend.xml",
+        "files/x86_64/windows-2008r2-slipstream.package.ps1"
       ],
 
-      "boot_command": [ "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter>"],
+      "boot_command": [ "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait>"],
       "boot_wait": "1s",
 
       "vmx_data": {
@@ -88,23 +86,6 @@
         "scsi0:1.devicetype":  "",
         "scsi0:1.filename": ""
       }
-    }
-  ],
-  "provisioners": [
-    {
-      "type": "powershell",
-      "inline": [
-        "A:\\clean-disk-dism.ps1"
-      ]
-    },
-    {
-      "type": "windows-restart"
-    },
-    {
-      "type": "powershell",
-      "inline": [
-        "A:\\clean-disk-sdelete.ps1"
-      ]
     }
   ]
 }

--- a/templates/windows-2012/files/x86_64/windows-2012-slipstream.package.ps1
+++ b/templates/windows-2012/files/x86_64/windows-2012-slipstream.package.ps1
@@ -21,7 +21,8 @@ if (-not (Test-Path "A:\NET45.installed"))
 {
   # Install .Net Framework 4.5.2
   Write-BoxstarterMessage "Installing .Net 4.5"
-  choco install dotnet4.5 -y
+  Download-File "http://buildsources.delivery.puppetlabs.net/windows/dotnet45/dotnetfx45_full_x86_x64.exe" "$Env:TEMP/dotnetfx45_full_x86_x64.exe"
+  Start-Process -Wait "$Env:TEMP/dotnetfx45_full_x86_x64.exe" -NoNewWindow -PassThru -ArgumentList "/quiet /norestart"
   Touch-File "A:\NET45.installed"
   if (Test-PendingReboot) { Invoke-Reboot }
 }

--- a/templates/windows-2012/x86_64.vmware.base.json
+++ b/templates/windows-2012/x86_64.vmware.base.json
@@ -32,7 +32,7 @@
       "communicator": "winrm",
       "winrm_username": "Administrator",
       "winrm_password": "PackerAdmin",
-      "winrm_timeout": "4h",
+      "winrm_timeout": "8h",
 
       "shutdown_command": "shutdown /s /t 1 /c \"Packer Shutdown\" /f /d p:4:1",
       "shutdown_timeout": "1h",

--- a/templates/windows-2012r2-wmf5/x86_64.vmware.base.json
+++ b/templates/windows-2012r2-wmf5/x86_64.vmware.base.json
@@ -4,9 +4,9 @@
     "template_config": "base",
 
     "provisioner": "vmware",
-    "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2012_r2_with_update_x64_dvd_6052708_SlipStream_01.iso",
+    "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2012_r2_with_update_x64_dvd_6052708_SlipStream_02.iso",
     "iso_checksum_type": "md5",
-    "iso_checksum": "5006c404bded89c4f7f24e7df8c6a266",
+    "iso_checksum": "3feae58c235f88126a1c099d58abfb8f",
     "headless": "true",
     "tools_iso": "{{env `VMWARE_TOOLS_ISO`}}/windows.iso",
     "packer_output_dir": "{{env `PACKER_VM_OUT_DIR`}}"

--- a/templates/windows-2012r2/x86_64.virtualbox.base.json
+++ b/templates/windows-2012r2/x86_64.virtualbox.base.json
@@ -5,9 +5,9 @@
     "template_config": "base",
     "template_os"      : "Windows2012_64",
 
-    "iso_url"          : "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2012_r2_with_update_x64_dvd_6052708_SlipStream_01.iso",
+    "iso_url"          : "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2012_r2_with_update_x64_dvd_6052708_SlipStream_02.iso",
     "iso_checksum_type": "md5",
-    "iso_checksum"     : "5006c404bded89c4f7f24e7df8c6a266",
+    "iso_checksum"     : "3feae58c235f88126a1c099d58abfb8f",
     "headless"         : "true",
     "memory_size"      : "2048",
     "cpu_count"        : "2",

--- a/templates/windows-2012r2/x86_64.vmware.base.json
+++ b/templates/windows-2012r2/x86_64.vmware.base.json
@@ -4,9 +4,9 @@
     "template_config": "base",
 
     "provisioner": "vmware",
-    "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2012_r2_with_update_x64_dvd_6052708_SlipStream_01.iso",
+    "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2012_r2_with_update_x64_dvd_6052708_SlipStream_02.iso",
     "iso_checksum_type": "md5",
-    "iso_checksum": "5006c404bded89c4f7f24e7df8c6a266",
+    "iso_checksum": "3feae58c235f88126a1c099d58abfb8f",
     "headless": "true",
     "tools_iso": "{{env `VMWARE_TOOLS_ISO`}}/windows.iso",
     "packer_output_dir": "{{env `PACKER_VM_OUT_DIR`}}"

--- a/templates/windows-7/files/x86_64/vmware/windows-7-x86_64-vmware-base.package.ps1
+++ b/templates/windows-7/files/x86_64/vmware/windows-7-x86_64-vmware-base.package.ps1
@@ -17,7 +17,8 @@ if (-not (Test-Path "A:\NET45.installed"))
 {
   # Install .Net Framework 4.5.2
   Write-BoxstarterMessage "Installing .Net 4.5"
-  choco install dotnet4.5 -y
+  Download-File "http://buildsources.delivery.puppetlabs.net/windows/dotnet45/dotnetfx45_full_x86_x64.exe" "$Env:TEMP/dotnetfx45_full_x86_x64.exe"
+  Start-Process -Wait "$Env:TEMP/dotnetfx45_full_x86_x64.exe" -NoNewWindow -PassThru -ArgumentList "/quiet /norestart"
   Touch-File "A:\NET45.installed"
   if (Test-PendingReboot) { Invoke-Reboot }
 }

--- a/templates/windows-7/files/x86_64/windows-7-slipstream.package.ps1
+++ b/templates/windows-7/files/x86_64/windows-7-slipstream.package.ps1
@@ -21,7 +21,8 @@ if (-not (Test-Path "A:\NET45.installed"))
 {
   # Install .Net Framework 4.5.2
   Write-BoxstarterMessage "Installing .Net 4.5"
-  choco install dotnet4.5 -y
+  Download-File "http://buildsources.delivery.puppetlabs.net/windows/dotnet45/dotnetfx45_full_x86_x64.exe" "$Env:TEMP/dotnetfx45_full_x86_x64.exe"
+  Start-Process -Wait "$Env:TEMP/dotnetfx45_full_x86_x64.exe" -NoNewWindow -PassThru -ArgumentList "/quiet /norestart"
   Touch-File "A:\NET45.installed"
   if (Test-PendingReboot) { Invoke-Reboot }
 }

--- a/templates/windows-7/x86_64.vmware.slipstream.json
+++ b/templates/windows-7/x86_64.vmware.slipstream.json
@@ -38,7 +38,7 @@
       "disk_size": 61440,
       "disk_type_id": "0",
       "floppy_files": [
-        "files/autounattend.xml",
+        "files/x86_64/vmware/autounattend.xml",
         "../../scripts/windows/bootstrap-base.bat",
         "../../scripts/windows/start-boxstarter.ps1",
         "../../scripts/windows/windows-env.ps1",
@@ -46,8 +46,8 @@
         "../../scripts/windows/generalize-packer.bat",
         "../../scripts/windows/generate-slipstream.ps1",
         "files/slipstream-filter",
-        "files/generalize-packer.autounattend.xml",
-        "files/windows-7-slipstream.package.ps1"
+        "files/x86_64/vmware/generalize-packer.autounattend.xml",
+        "files/x86_64/windows-7-slipstream.package.ps1"
       ],
 
       "boot_command": [ "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait>"],


### PR DESCRIPTION
Fix instability issues in early Windows builds (Win-2008 -> Win-2012).
Most of the instability was caused by two issues:
1. Boxstarter Update which broke Win-2008.
2. Chocolatey failure to install .Net 4.5.1 which impacted 2008, 2008r2, 2012 & 7.

This PR also includes fixes for some other issues including:
- Occasional build script failures (e.g. unzip in cygwin install, chocolatey cleanup).
- Google Update Services causing PendingFile Change reboot in vmpooler image.
- Automated and refreshed Slipstreams for Win-2008r2 and Win-2012r2