### PR TITLE
(IMAGES-447) Win-2016 Slipstream Automation 

### DIFF
--- a/manifests/windows/windows_template/manifests/configure_services.pp
+++ b/manifests/windows/windows_template/manifests/configure_services.pp
@@ -22,13 +22,16 @@ class windows_template::configure_services()
       enable => false,
     }
 
-    # Disable Google Update Services to prevent pending reboot requests
-    service { 'gupdate':
-      ensure => 'stopped',
-      enable => false,
-    }
-    service { 'gupdatem':
-      ensure => 'stopped',
-      enable => false,
+    # Disable Google Update Services to prevent pending reboot requests (except win-2008)
+    if ($::operatingsystemrelease != '2008')
+    {
+      service { 'gupdate':
+        ensure => 'stopped',
+        enable => false,
+      }
+      service { 'gupdatem':
+        ensure => 'stopped',
+        enable => false,
+      }
     }
 }

--- a/templates/windows-10/files/i386/vmware/windows-10-i386-vmware-base.package.ps1
+++ b/templates/windows-10/files/i386/vmware/windows-10-i386-vmware-base.package.ps1
@@ -17,7 +17,7 @@ if (-not (Test-Path "A:\NET45.installed"))
 {
   # Install .Net Framework 4.5.2
   Write-BoxstarterMessage "Installing .Net 4.5"
-  choco install dotnet4.5 -y
+  choco install dotnet4.5.2 -y
   Touch-File "A:\NET45.installed"
   if (Test-PendingReboot) { Invoke-Reboot }
 }

--- a/templates/windows-10/files/i386/vmware/windows-10-i386-vmware-base.package.ps1
+++ b/templates/windows-10/files/i386/vmware/windows-10-i386-vmware-base.package.ps1
@@ -26,6 +26,9 @@ if (-not (Test-Path "A:\NET45.installed"))
 Write-BoxstarterMessage "Set all network adapters private"
 $net = get-netconnectionprofile;Set-NetConnectionProfile -Name $net.Name -NetworkCategory Private
 
+# Remove Win-10 packages that break sysprep
+Remove-Win10Packages
+
 # Run the Packer Update Sequence
 Install-PackerWindowsUpdates
 

--- a/templates/windows-10/files/i386/windows-10-slipstream.package.ps1
+++ b/templates/windows-10/files/i386/windows-10-slipstream.package.ps1
@@ -21,7 +21,7 @@ if (-not (Test-Path "A:\NET45.installed"))
 {
   # Install .Net Framework 4.5.2
   Write-BoxstarterMessage "Installing .Net 4.5"
-  choco install dotnet4.5 -y
+  choco install dotnet4.5.2 -y
   Touch-File "A:\NET45.installed"
   if (Test-PendingReboot) { Invoke-Reboot }
 }

--- a/templates/windows-10/files/x86_64/vmware/windows-10-x86_64-vmware-base.package.ps1
+++ b/templates/windows-10/files/x86_64/vmware/windows-10-x86_64-vmware-base.package.ps1
@@ -17,7 +17,7 @@ if (-not (Test-Path "A:\NET45.installed"))
 {
   # Install .Net Framework 4.5.2
   Write-BoxstarterMessage "Installing .Net 4.5"
-  choco install dotnet4.5 -y
+  choco install dotnet4.5.2 -y
   Touch-File "A:\NET45.installed"
   if (Test-PendingReboot) { Invoke-Reboot }
 }

--- a/templates/windows-10/files/x86_64/vmware/windows-10-x86_64-vmware-base.package.ps1
+++ b/templates/windows-10/files/x86_64/vmware/windows-10-x86_64-vmware-base.package.ps1
@@ -26,6 +26,9 @@ if (-not (Test-Path "A:\NET45.installed"))
 Write-BoxstarterMessage "Set all network adapters private"
 $net = get-netconnectionprofile;Set-NetConnectionProfile -Name $net.Name -NetworkCategory Private
 
+# Remove Win-10 packages that break sysprep
+Remove-Win10Packages
+
 # Run the Packer Update Sequence
 Install-PackerWindowsUpdates
 

--- a/templates/windows-10/files/x86_64/windows-10-slipstream.package.ps1
+++ b/templates/windows-10/files/x86_64/windows-10-slipstream.package.ps1
@@ -21,7 +21,7 @@ if (-not (Test-Path "A:\NET45.installed"))
 {
   # Install .Net Framework 4.5.2
   Write-BoxstarterMessage "Installing .Net 4.5"
-  choco install dotnet4.5 -y
+  choco install dotnet4.5.2 -y
   Touch-File "A:\NET45.installed"
   if (Test-PendingReboot) { Invoke-Reboot }
 }

--- a/templates/windows-10/i386.vmware.slipstream.json
+++ b/templates/windows-10/i386.vmware.slipstream.json
@@ -41,7 +41,7 @@
       "disk_size": 61440,
       "disk_type_id": "0",
       "floppy_files": [
-        "files/i386/autounattend.xml",
+        "files/i386/vmware/autounattend.xml",
         "../../scripts/windows/bootstrap-base.bat",
         "../../scripts/windows/start-boxstarter.ps1",
         "../../scripts/windows/windows-env.ps1",
@@ -49,7 +49,7 @@
         "../../scripts/windows/generalize-packer.bat",
         "../../scripts/windows/generate-slipstream.ps1",
         "files/slipstream-filter",
-        "files/i386/generalize-packer.autounattend.xml",
+        "files/i386/vmware/generalize-packer.autounattend.xml",
         "files/i386/windows-10-slipstream.package.ps1"
       ],
 

--- a/templates/windows-10/x86_64.vmware.slipstream.json
+++ b/templates/windows-10/x86_64.vmware.slipstream.json
@@ -41,7 +41,7 @@
       "disk_size": 61440,
       "disk_type_id": "0",
       "floppy_files": [
-        "files/x86_64/autounattend.xml",
+        "files/x86_64/vmware/autounattend.xml",
         "../../scripts/windows/bootstrap-base.bat",
         "../../scripts/windows/start-boxstarter.ps1",
         "../../scripts/windows/windows-env.ps1",
@@ -49,7 +49,7 @@
         "../../scripts/windows/generalize-packer.bat",
         "../../scripts/windows/generate-slipstream.ps1",
         "files/slipstream-filter",
-        "files/x86_64/generalize-packer.autounattend.xml",
+        "files/x86_64/vmware/generalize-packer.autounattend.xml",
         "files/x86_64/windows-10-slipstream.package.ps1"
       ],
 

--- a/templates/windows-2008r2-wmf5/files/x86_64/vmware/windows-2008r2-wmf5-x86_64-vmware-base.package.ps1
+++ b/templates/windows-2008r2-wmf5/files/x86_64/vmware/windows-2008r2-wmf5-x86_64-vmware-base.package.ps1
@@ -38,8 +38,7 @@ if (-not (Test-Path "A:\NET45.installed"))
 {
   # Install .Net Framework 4.5.2
   Write-BoxstarterMessage "Installing .Net 4.5"
-  Download-File "http://buildsources.delivery.puppetlabs.net/windows/dotnet45/dotnetfx45_full_x86_x64.exe" "$Env:TEMP/dotnetfx45_full_x86_x64.exe"
-  Start-Process -Wait "$Env:TEMP/dotnetfx45_full_x86_x64.exe" -NoNewWindow -PassThru -ArgumentList "/quiet /norestart"
+  choco install dotnet4.5.2 -y
   Touch-File "A:\NET45.installed"
   if (Test-PendingReboot) { Invoke-Reboot }
 }

--- a/templates/windows-2008r2/files/x86_64/vmware/windows-2008r2-x86_64-vmware-base.package.ps1
+++ b/templates/windows-2008r2/files/x86_64/vmware/windows-2008r2-x86_64-vmware-base.package.ps1
@@ -39,8 +39,7 @@ if (-not (Test-Path "A:\NET45.installed"))
 {
   # Install .Net Framework 4.5.2
   Write-BoxstarterMessage "Installing .Net 4.5"
-  Download-File "http://buildsources.delivery.puppetlabs.net/windows/dotnet45/dotnetfx45_full_x86_x64.exe" "$Env:TEMP/dotnetfx45_full_x86_x64.exe"
-  Start-Process -Wait "$Env:TEMP/dotnetfx45_full_x86_x64.exe" -NoNewWindow -PassThru -ArgumentList "/quiet /norestart"
+  choco install dotnet4.5.2 -y
   Touch-File "A:\NET45.installed"
   if (Test-PendingReboot) { Invoke-Reboot }
 }

--- a/templates/windows-2008r2/files/x86_64/windows-2008r2-slipstream.package.ps1
+++ b/templates/windows-2008r2/files/x86_64/windows-2008r2-slipstream.package.ps1
@@ -21,8 +21,7 @@ if (-not (Test-Path "A:\NET45.installed"))
 {
   # Install .Net Framework 4.5.2
   Write-BoxstarterMessage "Installing .Net 4.5"
-  Download-File "http://buildsources.delivery.puppetlabs.net/windows/dotnet45/dotnetfx45_full_x86_x64.exe" "$Env:TEMP/dotnetfx45_full_x86_x64.exe"
-  Start-Process -Wait "$Env:TEMP/dotnetfx45_full_x86_x64.exe" -NoNewWindow -PassThru -ArgumentList "/quiet /norestart"
+  choco install dotnet4.5.2 -y
   Touch-File "A:\NET45.installed"
   if (Test-PendingReboot) { Invoke-Reboot }
 }

--- a/templates/windows-2012/files/x86_64/vmware/windows-2012-x86_64-vmware-base.package.ps1
+++ b/templates/windows-2012/files/x86_64/vmware/windows-2012-x86_64-vmware-base.package.ps1
@@ -26,7 +26,7 @@ if (-not (Test-Path "A:\NET45.installed"))
 {
   # Install .Net Framework 4.5.2
   Write-BoxstarterMessage "Installing .Net 4.5"
-  choco install dotnet4.5 -y
+  choco install dotnet4.5.2 -y
   Touch-File "A:\NET45.installed"
   if (Test-PendingReboot) { Invoke-Reboot }
 }

--- a/templates/windows-2012/files/x86_64/windows-2012-slipstream.package.ps1
+++ b/templates/windows-2012/files/x86_64/windows-2012-slipstream.package.ps1
@@ -21,8 +21,7 @@ if (-not (Test-Path "A:\NET45.installed"))
 {
   # Install .Net Framework 4.5.2
   Write-BoxstarterMessage "Installing .Net 4.5"
-  Download-File "http://buildsources.delivery.puppetlabs.net/windows/dotnet45/dotnetfx45_full_x86_x64.exe" "$Env:TEMP/dotnetfx45_full_x86_x64.exe"
-  Start-Process -Wait "$Env:TEMP/dotnetfx45_full_x86_x64.exe" -NoNewWindow -PassThru -ArgumentList "/quiet /norestart"
+  choco install dotnet4.5.2 -y
   Touch-File "A:\NET45.installed"
   if (Test-PendingReboot) { Invoke-Reboot }
 }

--- a/templates/windows-2012r2-ja/files/x86_64/virtualbox/windows-2012r2-ja-x86_64-virtualbox-base.package.ps1
+++ b/templates/windows-2012r2-ja/files/x86_64/virtualbox/windows-2012r2-ja-x86_64-virtualbox-base.package.ps1
@@ -37,7 +37,7 @@ if (-not (Test-Path "A:\NET45.installed"))
 {
   # Install .Net Framework 4.5.2
   Write-BoxstarterMessage "Installing .Net 4.5"
-  choco install dotnet4.5 -y
+  choco install dotnet4.5.2 -y
   Touch-File "A:\NET45.installed"
   if (Test-PendingReboot) { Invoke-Reboot }
 }

--- a/templates/windows-2012r2-ja/files/x86_64/vmware/windows-2012r2-ja-x86_64-vmware-base.package.ps1
+++ b/templates/windows-2012r2-ja/files/x86_64/vmware/windows-2012r2-ja-x86_64-vmware-base.package.ps1
@@ -26,7 +26,7 @@ if (-not (Test-Path "A:\NET45.installed"))
 {
   # Install .Net Framework 4.5.2
   Write-BoxstarterMessage "Installing .Net 4.5"
-  choco install dotnet4.5 -y
+  choco install dotnet4.5.2 -y
   Touch-File "A:\NET45.installed"
   if (Test-PendingReboot) { Invoke-Reboot }
 }

--- a/templates/windows-2012r2-ja/files/x86_64/windows-ja-slipstream.package.ps1
+++ b/templates/windows-2012r2-ja/files/x86_64/windows-ja-slipstream.package.ps1
@@ -21,7 +21,7 @@ if (-not (Test-Path "A:\NET45.installed"))
 {
   # Install .Net Framework 4.5.2
   Write-BoxstarterMessage "Installing .Net 4.5"
-  choco install dotnet4.5 -y
+  choco install dotnet4.5.2 -y
   Touch-File "A:\NET45.installed"
   if (Test-PendingReboot) { Invoke-Reboot }
 }

--- a/templates/windows-2012r2-wmf5/files/x86_64/vmware/windows-2012r2-wmf5-x86_64-vmware-base.package.ps1
+++ b/templates/windows-2012r2-wmf5/files/x86_64/vmware/windows-2012r2-wmf5-x86_64-vmware-base.package.ps1
@@ -26,7 +26,7 @@ if (-not (Test-Path "A:\NET45.installed"))
 {
   # Install .Net Framework 4.5.2
   Write-BoxstarterMessage "Installing .Net 4.5"
-  choco install dotnet4.5 -y
+  choco install dotnet4.5.2 -y
   Touch-File "A:\NET45.installed"
   if (Test-PendingReboot) { Invoke-Reboot }
 }

--- a/templates/windows-2012r2/files/x86_64/virtualbox/windows-2012r2-x86_64-virtualbox-base.package.ps1
+++ b/templates/windows-2012r2/files/x86_64/virtualbox/windows-2012r2-x86_64-virtualbox-base.package.ps1
@@ -37,7 +37,7 @@ if (-not (Test-Path "A:\NET45.installed"))
 {
   # Install .Net Framework 4.5.2
   Write-BoxstarterMessage "Installing .Net 4.5"
-  choco install dotnet4.5 -y
+  choco install dotnet4.5.2 -y
   Touch-File "A:\NET45.installed"
   if (Test-PendingReboot) { Invoke-Reboot }
 }

--- a/templates/windows-2012r2/files/x86_64/vmware/windows-2012r2-x86_64-vmware-base.package.ps1
+++ b/templates/windows-2012r2/files/x86_64/vmware/windows-2012r2-x86_64-vmware-base.package.ps1
@@ -26,7 +26,7 @@ if (-not (Test-Path "A:\NET45.installed"))
 {
   # Install .Net Framework 4.5.2
   Write-BoxstarterMessage "Installing .Net 4.5"
-  choco install dotnet4.5 -y
+  choco install dotnet4.5.2 -y
   Touch-File "A:\NET45.installed"
   if (Test-PendingReboot) { Invoke-Reboot }
 }

--- a/templates/windows-2016/files/slipstream-filter
+++ b/templates/windows-2016/files/slipstream-filter
@@ -1,0 +1,1 @@
+# CAB files to be filtered out in case of DISM Issues

--- a/templates/windows-2016/files/x86_64/vmware/windows-2016-x86_64-vmware-base.package.ps1
+++ b/templates/windows-2016/files/x86_64/vmware/windows-2016-x86_64-vmware-base.package.ps1
@@ -26,7 +26,7 @@ if (-not (Test-Path "A:\NET45.installed"))
 {
   # Install .Net Framework 4.5.2
   Write-BoxstarterMessage "Installing .Net 4.5"
-  choco install dotnet4.5 -y
+  choco install dotnet4.5.2 -y
   Touch-File "A:\NET45.installed"
   if (Test-PendingReboot) { Invoke-Reboot }
 }

--- a/templates/windows-2016/files/x86_64/windows-2016-slipstream.package.ps1
+++ b/templates/windows-2016/files/x86_64/windows-2016-slipstream.package.ps1
@@ -1,0 +1,74 @@
+$ErrorActionPreference = "Stop"
+
+. A:\windows-env.ps1
+
+# Boxstarter options
+$Boxstarter.RebootOk=$true # Allow reboots?
+$Boxstarter.NoPassword=$false # Is this a machine with no login password?
+$Boxstarter.AutoLogin=$true # Save my password securely and auto-login after a reboot
+
+if (Test-PendingReboot){ Invoke-Reboot }
+
+# Need to guard against system going into standby for long updates
+Write-BoxstarterMessage "Disabling Sleep timers"
+Disable-PC-Sleep
+
+if (-not (Test-Path "A:\DesktopExperience.installed"))
+{
+  # Enable Desktop experience to get cleanmgr
+  Write-BoxstarterMessage "Enable Desktop-Experience"
+  Add-WindowsFeature Desktop-Experience -ErrorAction SilentlyContinue
+  Touch-File "A:\DesktopExperience.installed"
+  if (Test-PendingReboot) { Invoke-Reboot }
+}
+
+if (-not (Test-Path "A:\NET45.installed"))
+{
+  # Install .Net Framework 4.5.2
+  Write-BoxstarterMessage "Installing .Net 4.5"
+  choco install dotnet4.5.2 -y
+  Touch-File "A:\NET45.installed"
+  if (Test-PendingReboot) { Invoke-Reboot }
+}
+
+# Run the Packer Update Sequence
+Install-PackerWindowsUpdates
+
+# Create Dism directories and copy files over.
+# This allows errors to be handled manually in event of dism failures
+
+New-Item -ItemType directory -Force -Path C:\Packer
+New-Item -ItemType directory -Force -Path C:\Packer\Dism
+New-Item -ItemType directory -Force -Path C:\Packer\Downloads
+New-Item -ItemType directory -Force -Path C:\Packer\Dism\Mount
+New-Item -ItemType directory -Force -Path C:\Packer\Dism\Logs
+
+# Setup Dism Directories
+Copy-Item A:\windows-env.ps1 C:\Packer\Dism
+Copy-Item A:\generate-slipstream.ps1 C:\Packer\Dism
+Copy-Item A:\slipstream-filter C:\Packer\Dism
+
+# Add WinRM Firewall Rule
+Write-BoxstarterMessage "Setting up winrm"
+netsh advfirewall firewall add rule name="WinRM-HTTP" dir=in localport=5985 protocol=TCP action=allow
+
+$enableArgs=@{Force=$true}
+try {
+ $command=Get-Command Enable-PSRemoting
+  if($command.Parameters.Keys -contains "skipnetworkprofilecheck"){
+      $enableArgs.skipnetworkprofilecheck=$true
+  }
+}
+catch {
+  $global:error.RemoveAt(0)
+}
+Enable-PSRemoting @enableArgs
+Enable-WSManCredSSP -Force -Role Server
+# NOTE - This is insecure but can be shored up in later customisation.  Required for Vagrant and other provisioning tools
+winrm set winrm/config/client/auth '@{Basic="true"}'
+winrm set winrm/config/service/auth '@{Basic="true"}'
+winrm set winrm/config/service '@{AllowUnencrypted="true"}'
+winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="2048"}'
+Write-BoxstarterMessage "WinRM setup complete"
+
+# End

--- a/templates/windows-2016/x86_64.vmware.slipstream.json
+++ b/templates/windows-2016/x86_64.vmware.slipstream.json
@@ -1,18 +1,19 @@
 {
   "variables": {
     "template_name": "windows-2016-x86_64",
+    "os_name" : "Win-2016",
     "template_config": "base",
 
     "provisioner": "vmware",
-    "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2016_x64_dvd_9718492_Slip_02.iso",
+    "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2016_x64_dvd_9718492.iso",
     "iso_checksum_type": "md5",
-    "iso_checksum": "47993d89a256960eed2e58c9b394aa97",
-    "headless": "true",
+    "iso_checksum": "e02d2e482b0f3dab915435e9040c13b4",
+    "headless": "false",
     "tools_iso": "{{env `VMWARE_TOOLS_ISO`}}/windows.iso",
     "packer_output_dir": "{{env `PACKER_VM_OUT_DIR`}}"
   },
 
-  "description": "Builds a Windows Server 2016 Technical Preview template VM for use in VMware",
+  "description": "Builds a Windows Server 2016 Enterprise template VM for use in VMware",
 
   "_comment": [
       "The boot_command is hacky because the UEFI boot file used requires the 'Press any key' to be done"
@@ -32,7 +33,7 @@
       "communicator": "winrm",
       "winrm_username": "Administrator",
       "winrm_password": "PackerAdmin",
-      "winrm_timeout": "4h",
+      "winrm_timeout": "8h",
 
       "shutdown_command": "shutdown /s /t 1 /c \"Packer Shutdown\" /f /d p:4:1",
       "shutdown_timeout": "1h",
@@ -41,18 +42,18 @@
       "disk_type_id": "0",
       "floppy_files": [
         "files/x86_64/vmware/autounattend.xml",
-        "files/x86_64/vmware/generalize-packer.autounattend.xml",
-        "files/x86_64/vmware/{{build_name}}.package.ps1",
         "../../scripts/windows/bootstrap-base.bat",
         "../../scripts/windows/start-boxstarter.ps1",
         "../../scripts/windows/windows-env.ps1",
         "../../scripts/windows/shutdown-packer.bat",
         "../../scripts/windows/generalize-packer.bat",
-        "../../scripts/windows/clean-disk-dism.ps1",
-        "../../scripts/windows/clean-disk-sdelete.ps1"
+        "../../scripts/windows/generate-slipstream.ps1",
+        "files/slipstream-filter",
+        "files/x86_64/vmware/generalize-packer.autounattend.xml",
+        "files/x86_64/windows-2016-slipstream.package.ps1"
       ],
 
-      "boot_command": [ "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter>"],
+      "boot_command": [ "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait>"],
       "boot_wait": "1s",
 
       "vmx_data": {
@@ -94,17 +95,9 @@
     {
       "type": "powershell",
       "inline": [
-        "A:\\clean-disk-dism.ps1"
-      ]
-    },
-    {
-      "type": "windows-restart"
-    },
-    {
-      "type": "powershell",
-      "inline": [
-        "A:\\clean-disk-sdelete.ps1"
-      ]
+        "C:\\Packer\\Dism\\generate-slipstream.ps1 -OSName {{user `os_name`}} -ImageIndex 2 -PatchSearch *.msu"
+      ],
+      "valid_exit_codes": [0,1]
     }
   ]
 }

--- a/templates/windows-7/files/x86_64/vmware/windows-7-x86_64-vmware-base.package.ps1
+++ b/templates/windows-7/files/x86_64/vmware/windows-7-x86_64-vmware-base.package.ps1
@@ -17,8 +17,7 @@ if (-not (Test-Path "A:\NET45.installed"))
 {
   # Install .Net Framework 4.5.2
   Write-BoxstarterMessage "Installing .Net 4.5"
-  Download-File "http://buildsources.delivery.puppetlabs.net/windows/dotnet45/dotnetfx45_full_x86_x64.exe" "$Env:TEMP/dotnetfx45_full_x86_x64.exe"
-  Start-Process -Wait "$Env:TEMP/dotnetfx45_full_x86_x64.exe" -NoNewWindow -PassThru -ArgumentList "/quiet /norestart"
+  choco install dotnet4.5.2 -y
   Touch-File "A:\NET45.installed"
   if (Test-PendingReboot) { Invoke-Reboot }
 }

--- a/templates/windows-7/files/x86_64/windows-7-slipstream.package.ps1
+++ b/templates/windows-7/files/x86_64/windows-7-slipstream.package.ps1
@@ -21,8 +21,7 @@ if (-not (Test-Path "A:\NET45.installed"))
 {
   # Install .Net Framework 4.5.2
   Write-BoxstarterMessage "Installing .Net 4.5"
-  Download-File "http://buildsources.delivery.puppetlabs.net/windows/dotnet45/dotnetfx45_full_x86_x64.exe" "$Env:TEMP/dotnetfx45_full_x86_x64.exe"
-  Start-Process -Wait "$Env:TEMP/dotnetfx45_full_x86_x64.exe" -NoNewWindow -PassThru -ArgumentList "/quiet /norestart"
+  choco install dotnet4.5.2 -y
   Touch-File "A:\NET45.installed"
   if (Test-PendingReboot) { Invoke-Reboot }
 }

--- a/templates/windows-8.1/files/x86_64/vmware/windows-8.1-x86_64-vmware-base.package.ps1
+++ b/templates/windows-8.1/files/x86_64/vmware/windows-8.1-x86_64-vmware-base.package.ps1
@@ -17,7 +17,7 @@ if (-not (Test-Path "A:\NET45.installed"))
 {
   # Install .Net Framework 4.5.2
   Write-BoxstarterMessage "Installing .Net 4.5"
-  choco install dotnet4.5 -y
+  choco install dotnet4.5.2 -y
   Touch-File "A:\NET45.installed"
   if (Test-PendingReboot) { Invoke-Reboot }
 }


### PR DESCRIPTION
Add in the automation files for Win-2016 slipstream generation.
The CU for Win-2016 updates has become a bit flaky, so regen the
slipstream to help this.

Also change all .Net 4.5.2 installs to use a more up to date chocolatey package.