### PR TITLE
(IMAGES-569) Update debian 9 image to released version, add hack

### DIFF
--- a/templates/debian-9.0/i386.vmware.base.json
+++ b/templates/debian-9.0/i386.vmware.base.json
@@ -6,8 +6,8 @@
       "template_os": "debian7",
       "template_config": "base",
 
-      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/debian-stretch-DI-rc3-i386-xfce-CD-1.iso",
-      "iso_checksum": "a249b14f295491525ed4a4c9ab6403723ad30b88cf6a7dfe89a2aa165d043938",
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/debian-9.0.0-i386-netinst.iso",
+      "iso_checksum": "3bf78f7b003203a6b771b05fa1790e74ee3ea15d6245a01683f90c02b95c0315",
       "iso_checksum_type": "sha256",
 
       "memory_size": "512",
@@ -15,7 +15,7 @@
 
       "provisioner": "vmware",
       "required_modules": "puppetlabs-stdlib saz-ssh",
-      "puppet_aio": "http://apt.puppetlabs.com/pool/jessie/PC1/p/puppet-agent/puppet-agent_1.8.2-1jessie_i386.deb",
+      "puppet_aio": "http://apt.puppetlabs.com/pool/jessie/PC1/p/puppet-agent/puppet-agent_1.10.5-1jessie_i386.deb",
       "headless": "true",
 
       "packer_output_dir": "{{env `PACKER_VM_OUT_DIR`}}"
@@ -69,6 +69,7 @@
         "PUPPET_AIO={{user `puppet_aio`}}"
       ],
       "scripts": [
+        "./new_os_hacks/add_libreadline6.sh",
         "../../scripts/bootstrap-aio.sh"
       ]
     },
@@ -92,7 +93,8 @@
       ],
       "scripts": [
         "../../scripts/cleanup-aio.sh",
-        "../../scripts/cleanup-packer.sh"
+        "../../scripts/cleanup-packer.sh",
+        "./new_os_hacks/remove_libreadline6.sh"
       ]
     }
   ]

--- a/templates/debian-9.0/i386.vmware.vsphere.nocm.json
+++ b/templates/debian-9.0/i386.vmware.vsphere.nocm.json
@@ -10,7 +10,7 @@
 
       "provisioner": "vmware",
       "required_modules": "puppetlabs-stdlib example42-network puppetlabs-apt",
-      "puppet_aio": "http://apt.puppetlabs.com/pool/jessie/PC1/p/puppet-agent/puppet-agent_1.8.2-1jessie_i386.deb",
+      "puppet_aio": "http://apt.puppetlabs.com/pool/jessie/PC1/p/puppet-agent/puppet-agent_1.10.5-1jessie_i386.deb",
       "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
       "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",
       "packer_vcenter_username": "{{env `PACKER_VCENTER_USERNAME`}}",
@@ -65,6 +65,7 @@
         "PUPPET_AIO={{user `puppet_aio`}}"
       ],
       "scripts": [
+        "./new_os_hacks/add_libreadline6.sh",
         "../../scripts/bootstrap-aio.sh"
       ]
     },
@@ -96,7 +97,8 @@
       "scripts": [
         "../../scripts/cleanup-aio.sh",
         "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-scrub.sh",
+        "./new_os_hacks/remove_libreadline6.sh"
       ]
     }
   ],

--- a/templates/debian-9.0/new_os_hacks/add_libreadline6.sh
+++ b/templates/debian-9.0/new_os_hacks/add_libreadline6.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Install libreadline6 so jessie agents can work on stretch
+cd /tmp
+curl -O http://http.us.debian.org/debian/pool/main/r/readline6/libreadline6_6.3-8+b3_$(dpkg --print-architecture).deb
+dpkg -i libreadline6_6.3-8+b3_$(dpkg --print-architecture).deb
+rm libreadline6_6.3-8+b3_$(dpkg --print-architecture).deb

--- a/templates/debian-9.0/new_os_hacks/remove_libreadline6.sh
+++ b/templates/debian-9.0/new_os_hacks/remove_libreadline6.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# remove libreadline6
+dpkg -P libreadline6

--- a/templates/debian-9.0/x86_64.vmware.base.json
+++ b/templates/debian-9.0/x86_64.vmware.base.json
@@ -6,8 +6,8 @@
       "template_os": "debian7-64",
       "template_config": "base",
 
-      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/debian-stretch-DI-rc3-amd64-xfce-CD-1.iso",
-      "iso_checksum": "156134299f3303ca505501127f7d5d169cbf868525b1e2eede59d7f4a40a2e3e",
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/debian-9.0.0-amd64-netinst.iso",
+      "iso_checksum": "9d98f339016dc2a3998881949a8f0678baede26b5106f18ef1168d7e13606773",
       "iso_checksum_type": "sha256",
 
       "memory_size": "512",
@@ -15,7 +15,7 @@
 
       "provisioner": "vmware",
       "required_modules": "puppetlabs-stdlib saz-ssh",
-      "puppet_aio": "http://apt.puppetlabs.com/pool/jessie/PC1/p/puppet-agent/puppet-agent_1.8.2-1jessie_amd64.deb",
+      "puppet_aio": "http://apt.puppetlabs.com/pool/jessie/PC1/p/puppet-agent/puppet-agent_1.10.5-1jessie_amd64.deb",
       "headless": "true",
 
       "packer_output_dir": "{{env `PACKER_VM_OUT_DIR`}}"
@@ -70,6 +70,7 @@
         "PUPPET_AIO={{user `puppet_aio`}}"
       ],
       "scripts": [
+        "./new_os_hacks/add_libreadline6.sh",
         "../../scripts/bootstrap-aio.sh"
       ]
     },
@@ -93,7 +94,8 @@
       ],
       "scripts": [
         "../../scripts/cleanup-aio.sh",
-        "../../scripts/cleanup-packer.sh"
+        "../../scripts/cleanup-packer.sh",
+        "./new_os_hacks/remove_libreadline6.sh"
       ]
     }
   ]

--- a/templates/debian-9.0/x86_64.vmware.vsphere.nocm.json
+++ b/templates/debian-9.0/x86_64.vmware.vsphere.nocm.json
@@ -9,7 +9,7 @@
       "beakerhost": "debian9-64",
       "provisioner": "vmware",
       "required_modules": "puppetlabs-stdlib example42-network puppetlabs-apt",
-      "puppet_aio": "http://apt.puppetlabs.com/pool/jessie/PC1/p/puppet-agent/puppet-agent_1.8.2-1jessie_amd64.deb",
+      "puppet_aio": "http://apt.puppetlabs.com/pool/jessie/PC1/p/puppet-agent/puppet-agent_1.10.5-1jessie_amd64.deb",
       "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
       "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",
       "packer_vcenter_username": "{{env `PACKER_VCENTER_USERNAME`}}",
@@ -21,7 +21,7 @@
       "packer_vcenter_net": "{{env `PACKER_VCENTER_NET`}}",
       "packer_vcenter_insecure": "{{env `PACKER_VCENTER_INSECURE`}}",
       "packer_sha": "{{env `PACKER_SHA`}}",
-    
+
       "headless": "true",
 
       "memory_size": "2048",
@@ -64,6 +64,7 @@
         "PUPPET_AIO={{user `puppet_aio`}}"
       ],
       "scripts": [
+        "./new_os_hacks/add_libreadline6.sh",
         "../../scripts/bootstrap-aio.sh"
       ]
     },
@@ -95,7 +96,8 @@
       "scripts": [
         "../../scripts/cleanup-aio.sh",
         "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh"
+        "../../scripts/cleanup-scrub.sh",
+        "./new_os_hacks/remove_libreadline6.sh"
       ]
     }
   ],


### PR DESCRIPTION
This commit adds the released stable debian 9 images, and adds a hack to
install jessie libreadline6 packages so the debian jessie agent works on
9 (and we can subsequently use it to provision the VM).

When we release the official version of the debian 9 agent, this hack should
be removed