### PR TITLE
(WIP) (IMAGES-576) Move to latest Powershell module

### DIFF
--- a/manifests/windows/forge-modules.txt
+++ b/manifests/windows/forge-modules.txt
@@ -4,6 +4,6 @@
 # Specific versions are supported now (e.g. we need to stick to Powershell 1.0.6)
 # TODO Support custom forge URLs
 
-puppetlabs-powershell 1.0.6
+puppetlabs-powershell
 puppetlabs-registry
 puppetlabs-stdlib


### PR DESCRIPTION
There were issues with the Powershell module not working under WMF 5.1
(Anniversary Edition of Windows 10) which forced pinning to Powershell
Moduel Version 1.0.6. These have since been resolved, so remove pinning
to allow the latest powershell module.