### PR TITLE
(IMAGES-596) Fix Sysprep/Winapp issue

### DIFF
--- a/templates/windows-10/files/i386/vmware/post-clone.autounattend.xml
+++ b/templates/windows-10/files/i386/vmware/post-clone.autounattend.xml
@@ -44,6 +44,11 @@
             <SkipAutoActivation>true</SkipAutoActivation>
         </component>
     </settings>
+    <settings pass="generalize">
+        <component name="Microsoft-Windows-PnpSysprep" processorArchitecture="x86" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <PersistAllDeviceInstalls>true</PersistAllDeviceInstalls>
+        </component>
+    </settings>
     <settings pass="oobeSystem">
         <component name="Microsoft-Windows-International-Core" processorArchitecture="x86" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <InputLocale>en-US</InputLocale>

--- a/templates/windows-10/files/i386/vmware/windows-10-i386-vmware-base.package.ps1
+++ b/templates/windows-10/files/i386/vmware/windows-10-i386-vmware-base.package.ps1
@@ -17,10 +17,13 @@ Disable-PC-Sleep
 Write-BoxstarterMessage "Set all network adapters private"
 $net = get-netconnectionprofile;Set-NetConnectionProfile -Name $net.Name -NetworkCategory Private
 
+# Remove Win-10 packages that break sysprep
+Remove-Win10Packages
+
 # Run the Packer Update Sequence
 Install-PackerWindowsUpdates
 
-# Remove Win-10 packages that break sysprep
+# Remove Win-10 packages that break sysprep a second time in case WU installed more.
 Remove-Win10Packages
 
 # Enable Remote Desktop (with reduce authentication resetting here again)

--- a/templates/windows-10/files/x86_64/vmware/post-clone.autounattend.xml
+++ b/templates/windows-10/files/x86_64/vmware/post-clone.autounattend.xml
@@ -44,6 +44,11 @@
             <SkipAutoActivation>true</SkipAutoActivation>
         </component>
     </settings>
+    <settings pass="generalize">
+        <component name="Microsoft-Windows-PnpSysprep" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <PersistAllDeviceInstalls>true</PersistAllDeviceInstalls>
+        </component>
+    </settings>    
     <settings pass="oobeSystem">
         <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <InputLocale>en-US</InputLocale>

--- a/templates/windows-10/files/x86_64/vmware/windows-10-x86_64-vmware-base.package.ps1
+++ b/templates/windows-10/files/x86_64/vmware/windows-10-x86_64-vmware-base.package.ps1
@@ -17,10 +17,13 @@ Disable-PC-Sleep
 Write-BoxstarterMessage "Set all network adapters private"
 $net = get-netconnectionprofile;Set-NetConnectionProfile -Name $net.Name -NetworkCategory Private
 
+# Remove Win-10 packages that break sysprep
+Remove-Win10Packages
+
 # Run the Packer Update Sequence
 Install-PackerWindowsUpdates
 
-# Remove Win-10 packages that break sysprep
+# Remove Win-10 packages that break sysprep a second time in case WU installed more.
 Remove-Win10Packages
 
 # Enable Remote Desktop (with reduce authentication resetting here again)

--- a/templates/windows-10/i386.vmware.base.json
+++ b/templates/windows-10/i386.vmware.base.json
@@ -93,6 +93,7 @@
   "provisioners": [
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-clean-disk-dism.ps1",
       "inline": [
         "A:\\clean-disk-dism.ps1"
       ]
@@ -102,6 +103,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-clean-disk-sdelete.ps1",
       "inline": [
         "A:\\clean-disk-sdelete.ps1"
       ]

--- a/templates/windows-10/i386.vmware.slipstream.json
+++ b/templates/windows-10/i386.vmware.slipstream.json
@@ -94,6 +94,7 @@
   "provisioners": [
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/script.ps1",
       "inline": [
         "C:\\Packer\\Dism\\generate-slipstream.ps1 -OSName {{user `os_name`}} -ImageIndex 1 -PatchSearch *.msu"
       ],

--- a/templates/windows-10/i386.vmware.vsphere.cygwin.json
+++ b/templates/windows-10/i386.vmware.vsphere.cygwin.json
@@ -87,6 +87,7 @@
   "provisioners": [
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/mkdir-packer-paths.ps1",
       "inline": [
         "md -Path C:\\Packer\\puppet\\modules",
         "md -Path C:\\Packer\\Downloads",
@@ -101,12 +102,14 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-install-win-packages.ps1",
       "inline": [
         "A:\\install-win-packages.ps1"
       ]
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-install-cygwin.ps1",
       "inline": [
         "A:\\install-cygwin.ps1"
       ],
@@ -129,6 +132,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-puppet-configure.ps1",
       "inline": [
         "A:\\puppet-configure.ps1 -PackerTemplateName {{user `template_name`}}-{{user `version`}} -PackerSHA '{{user `packer_sha`}}' -PackerTemplateType 'vmpooler'"
       ]
@@ -138,6 +142,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-config-winsettings.ps1",
       "inline": [
         "A:\\config-winsettings.ps1"
       ]
@@ -147,6 +152,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-cleanup-host.ps1",
       "inline": [
         "A:\\cleanup-host.ps1"
       ]
@@ -166,6 +172,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-vmpooler-arm-host.ps1",
       "inline": [
         "C:\\Packer\\Init\\vmpooler-arm-host.ps1"
       ]

--- a/templates/windows-10/x86_64.vmware.base.json
+++ b/templates/windows-10/x86_64.vmware.base.json
@@ -93,6 +93,7 @@
   "provisioners": [
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-clean-disk-dism.ps1",
       "inline": [
         "A:\\clean-disk-dism.ps1"
       ]
@@ -102,6 +103,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-clean-disk-sdelete.ps1",
       "inline": [
         "A:\\clean-disk-sdelete.ps1"
       ]

--- a/templates/windows-10/x86_64.vmware.slipstream.json
+++ b/templates/windows-10/x86_64.vmware.slipstream.json
@@ -94,6 +94,7 @@
   "provisioners": [
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/script.ps1",
       "inline": [
         "C:\\Packer\\Dism\\generate-slipstream.ps1 -OSName {{user `os_name`}} -ImageIndex 1 -PatchSearch *.msu"
       ],

--- a/templates/windows-10/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-10/x86_64.vmware.vsphere.cygwin.json
@@ -87,6 +87,7 @@
   "provisioners": [
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/mkdir-packer-paths.ps1",
       "inline": [
         "md -Path C:\\Packer\\puppet\\modules",
         "md -Path C:\\Packer\\Downloads",
@@ -98,6 +99,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-install-win-packages.ps1",
       "inline": [
         "A:\\install-win-packages.ps1"
       ]
@@ -107,6 +109,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-install-cygwin.ps1",
       "inline": [
         "A:\\install-cygwin.ps1"
       ],
@@ -129,6 +132,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-puppet-configure.ps1",
       "inline": [
         "A:\\puppet-configure.ps1 -PackerTemplateName {{user `template_name`}}-{{user `version`}} -PackerSHA '{{user `packer_sha`}}' -PackerTemplateType 'vmpooler'"
       ]
@@ -138,6 +142,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-config-winsettings.ps1",
       "inline": [
         "A:\\config-winsettings.ps1"
       ]
@@ -147,6 +152,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-cleanup-host.ps1",
       "inline": [
         "A:\\cleanup-host.ps1"
       ]
@@ -166,6 +172,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-vmpooler-arm-host.ps1",
       "inline": [
         "C:\\Packer\\Init\\vmpooler-arm-host.ps1"
       ]

--- a/templates/windows-2008/files/x86_64/vmware/post-clone.autounattend.xml
+++ b/templates/windows-2008/files/x86_64/vmware/post-clone.autounattend.xml
@@ -44,6 +44,11 @@
             </RunSynchronous>
         </component>
     </settings>
+    <settings pass="generalize">
+        <component name="Microsoft-Windows-PnpSysprep" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <PersistAllDeviceInstalls>true</PersistAllDeviceInstalls>
+        </component>
+    </settings>
     <settings pass="oobeSystem">
         <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <InputLocale>en-US</InputLocale>

--- a/templates/windows-2008/x86_64.vmware.base.json
+++ b/templates/windows-2008/x86_64.vmware.base.json
@@ -92,6 +92,7 @@
   "provisioners": [
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-clean-disk-dism.ps1",
       "inline": [
         "A:\\clean-disk-dism.ps1"
       ]
@@ -101,6 +102,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-clean-disk-sdelete.ps1",
       "inline": [
         "A:\\clean-disk-sdelete.ps1"
       ]

--- a/templates/windows-2008/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-2008/x86_64.vmware.vsphere.cygwin.json
@@ -90,6 +90,7 @@
   "provisioners": [
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/mkdir-packer-paths.ps1",
       "elevated_user": "{{user `winrm_username`}}",
       "elevated_password": "{{user `winrm_password`}}",
       "inline": [
@@ -103,6 +104,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-install-win-packages.ps1",
       "elevated_user": "{{user `winrm_username`}}",
       "elevated_password": "{{user `winrm_password`}}",
       "inline": [
@@ -114,6 +116,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-install-cygwin.ps1",
       "elevated_user": "{{user `winrm_username`}}",
       "elevated_password": "{{user `winrm_password`}}",
       "inline": [
@@ -138,6 +141,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-puppet-configure.ps1",
       "elevated_user": "{{user `winrm_username`}}",
       "elevated_password": "{{user `winrm_password`}}",
       "inline": [
@@ -149,6 +153,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-config-winsettings.ps1",
       "elevated_user": "{{user `winrm_username`}}",
       "elevated_password": "{{user `winrm_password`}}",
       "inline": [
@@ -160,6 +165,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-cleanup-host.ps1",
       "elevated_user": "{{user `winrm_username`}}",
       "elevated_password": "{{user `winrm_password`}}",
       "inline": [
@@ -181,6 +187,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-vmpooler-arm-host.ps1",
       "elevated_user": "{{user `winrm_username`}}",
       "elevated_password": "{{user `winrm_password`}}",
       "inline": [
@@ -189,6 +196,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-shutdown-packer.ps1",
       "elevated_user": "{{user `winrm_username`}}",
       "elevated_password": "{{user `winrm_password`}}",
       "inline": [

--- a/templates/windows-2008r2-wmf5/files/x86_64/vmware/post-clone.autounattend.xml
+++ b/templates/windows-2008r2-wmf5/files/x86_64/vmware/post-clone.autounattend.xml
@@ -47,6 +47,11 @@
             <SkipAutoActivation>true</SkipAutoActivation>
         </component>
     </settings>
+    <settings pass="generalize">
+        <component name="Microsoft-Windows-PnpSysprep" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <PersistAllDeviceInstalls>true</PersistAllDeviceInstalls>
+        </component>
+    </settings>
     <settings pass="oobeSystem">
         <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <InputLocale>en-US</InputLocale>

--- a/templates/windows-2008r2-wmf5/x86_64.vmware.base.json
+++ b/templates/windows-2008r2-wmf5/x86_64.vmware.base.json
@@ -93,6 +93,7 @@
   "provisioners": [
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-clean-disk-dism.ps1",
       "inline": [
         "A:\\clean-disk-dism.ps1"
       ]
@@ -102,6 +103,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-clean-disk-sdelete.ps1",
       "inline": [
         "A:\\clean-disk-sdelete.ps1"
       ]

--- a/templates/windows-2008r2-wmf5/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-2008r2-wmf5/x86_64.vmware.vsphere.cygwin.json
@@ -87,6 +87,7 @@
   "provisioners": [
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/mkdir-packer-paths.ps1",
       "inline": [
         "md -Path C:\\Packer\\puppet\\modules",
         "md -Path C:\\Packer\\Downloads",
@@ -98,6 +99,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-install-win-packages.ps1",
       "inline": [
         "A:\\install-win-packages.ps1"
       ]
@@ -107,6 +109,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-install-cygwin.ps1",
       "inline": [
         "A:\\install-cygwin.ps1"
       ],
@@ -129,6 +132,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-puppet-configure.ps1",
       "inline": [
         "A:\\puppet-configure.ps1 -PackerTemplateName {{user `template_name`}}-{{user `version`}} -PackerSHA '{{user `packer_sha`}}'"
       ]
@@ -138,6 +142,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-config-winsettings.ps1",
       "inline": [
         "A:\\config-winsettings.ps1"
       ]
@@ -147,6 +152,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-cleanup-host.ps1",
       "inline": [
         "A:\\cleanup-host.ps1"
       ]
@@ -166,6 +172,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-vmpooler-arm-host.ps1",
       "inline": [
         "C:\\Packer\\Init\\vmpooler-arm-host.ps1"
       ]

--- a/templates/windows-2008r2/files/x86_64/vmware/post-clone.autounattend.xml
+++ b/templates/windows-2008r2/files/x86_64/vmware/post-clone.autounattend.xml
@@ -47,6 +47,11 @@
             <SkipAutoActivation>true</SkipAutoActivation>
         </component>
     </settings>
+    <settings pass="generalize">
+        <component name="Microsoft-Windows-PnpSysprep" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <PersistAllDeviceInstalls>true</PersistAllDeviceInstalls>
+        </component>
+    </settings>
     <settings pass="oobeSystem">
         <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <InputLocale>en-US</InputLocale>

--- a/templates/windows-2008r2/x86_64.vmware.base.json
+++ b/templates/windows-2008r2/x86_64.vmware.base.json
@@ -93,6 +93,7 @@
   "provisioners": [
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-clean-disk-dism.ps1",
       "inline": [
         "A:\\clean-disk-dism.ps1"
       ]
@@ -102,6 +103,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-clean-disk-sdelete.ps1",
       "inline": [
         "A:\\clean-disk-sdelete.ps1"
       ]

--- a/templates/windows-2008r2/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-2008r2/x86_64.vmware.vsphere.cygwin.json
@@ -87,6 +87,7 @@
   "provisioners": [
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/mkdir-packer-paths.ps1",
       "inline": [
         "md -Path C:\\Packer\\puppet\\modules",
         "md -Path C:\\Packer\\Downloads",
@@ -98,6 +99,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-install-win-packages.ps1",
       "inline": [
         "A:\\install-win-packages.ps1"
       ]
@@ -107,6 +109,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-install-cygwin.ps1",
       "inline": [
         "A:\\install-cygwin.ps1"
       ],
@@ -129,6 +132,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-puppet-configure.ps1",
       "inline": [
         "A:\\puppet-configure.ps1 -PackerTemplateName {{user `template_name`}}-{{user `version`}} -PackerSHA '{{user `packer_sha`}}'"
       ]
@@ -138,6 +142,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-config-winsettings.ps1",
       "inline": [
         "A:\\config-winsettings.ps1"
       ]
@@ -147,6 +152,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-cleanup-host.ps1",
       "inline": [
         "A:\\cleanup-host.ps1"
       ]
@@ -166,6 +172,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-vmpooler-arm-host.ps1",
       "inline": [
         "C:\\Packer\\Init\\vmpooler-arm-host.ps1"
       ]

--- a/templates/windows-2012/files/x86_64/vmware/post-clone.autounattend.xml
+++ b/templates/windows-2012/files/x86_64/vmware/post-clone.autounattend.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
+    <settings pass="generalize">
+        <component name="Microsoft-Windows-PnpSysprep" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <PersistAllDeviceInstalls>true</PersistAllDeviceInstalls>
+        </component>
+    </settings>
     <settings pass="oobeSystem">
         <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <InputLocale>en-US</InputLocale>

--- a/templates/windows-2012/x86_64.vmware.base.json
+++ b/templates/windows-2012/x86_64.vmware.base.json
@@ -93,6 +93,7 @@
   "provisioners": [
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-clean-disk-dism.ps1",
       "inline": [
         "A:\\clean-disk-dism.ps1"
       ]
@@ -102,6 +103,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-clean-disk-sdelete.ps1",
       "inline": [
         "A:\\clean-disk-sdelete.ps1"
       ]

--- a/templates/windows-2012/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-2012/x86_64.vmware.vsphere.cygwin.json
@@ -87,6 +87,7 @@
   "provisioners": [
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/mkdir-packer-paths.ps1",
       "inline": [
         "md -Path C:\\Packer\\puppet\\modules",
         "md -Path C:\\Packer\\Downloads",
@@ -98,6 +99,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-install-win-packages.ps1",
       "inline": [
         "A:\\install-win-packages.ps1"
       ]
@@ -107,6 +109,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-install-cygwin.ps1",
       "inline": [
         "A:\\install-cygwin.ps1"
       ],
@@ -129,6 +132,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-puppet-configure.ps1",
       "inline": [
         "A:\\puppet-configure.ps1 -PackerTemplateName {{user `template_name`}}-{{user `version`}} -PackerSHA '{{user `packer_sha`}}'"
       ]
@@ -138,6 +142,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-config-winsettings.ps1",
       "inline": [
         "A:\\config-winsettings.ps1"
       ]
@@ -147,6 +152,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-cleanup-host.ps1",
       "inline": [
         "A:\\cleanup-host.ps1"
       ]
@@ -166,6 +172,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-vmpooler-arm-host.ps1",
       "inline": [
         "C:\\Packer\\Init\\vmpooler-arm-host.ps1"
       ]

--- a/templates/windows-2012r2-core/files/x86_64/virtualbox/post-clone.autounattend.xml
+++ b/templates/windows-2012r2-core/files/x86_64/virtualbox/post-clone.autounattend.xml
@@ -46,6 +46,11 @@
             <SkipAutoActivation>true</SkipAutoActivation>
         </component>
     </settings>
+    <settings pass="generalize">
+        <component name="Microsoft-Windows-PnpSysprep" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <PersistAllDeviceInstalls>true</PersistAllDeviceInstalls>
+        </component>
+    </settings>
     <settings pass="oobeSystem">
         <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <InputLocale>en-US</InputLocale>

--- a/templates/windows-2012r2-core/files/x86_64/vmware/post-clone.autounattend.xml
+++ b/templates/windows-2012r2-core/files/x86_64/vmware/post-clone.autounattend.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
+    <settings pass="generalize">
+        <component name="Microsoft-Windows-PnpSysprep" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <PersistAllDeviceInstalls>true</PersistAllDeviceInstalls>
+        </component>
+    </settings>
     <settings pass="oobeSystem">
         <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <InputLocale>en-US</InputLocale>

--- a/templates/windows-2012r2-core/x86_64.virtualbox.base.json
+++ b/templates/windows-2012r2-core/x86_64.virtualbox.base.json
@@ -53,7 +53,8 @@
   ],
   "provisioners": [
     {
-      "type"  : "powershell",
+      "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-clean-disk-dism.ps1",
       "inline": [
         "A:\\clean-disk-dism.ps1"
       ]
@@ -63,6 +64,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-clean-disk-sdelete.ps1",
       "inline": [
         "A:\\clean-disk-sdelete.ps1"
       ]

--- a/templates/windows-2012r2-core/x86_64.virtualbox.vagrant.cygwin.json
+++ b/templates/windows-2012r2-core/x86_64.virtualbox.vagrant.cygwin.json
@@ -48,6 +48,7 @@
   "provisioners": [
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/mkdir-packer-paths.ps1",
       "inline": [
         "md -Path C:\\Packer\\puppet\\modules",
         "md -Path C:\\Packer\\Downloads",
@@ -59,6 +60,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-install-win-packages.ps1",
       "inline": [
         "A:\\install-win-packages.ps1"
       ]
@@ -68,6 +70,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-install-cygwin.ps1",
       "inline": [
         "A:\\install-cygwin.ps1"
       ],
@@ -90,6 +93,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-puppet-configure.ps1",
       "inline": [
         "A:\\puppet-configure.ps1 -PackerTemplateName {{user `template_name`}}-{{user `version`}} -PackerSHA '{{user `packer_sha`}}' -PackerTemplateType 'vagrant'"
       ]
@@ -99,6 +103,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-config-winsettings.ps1",
       "inline": [
         "A:\\config-winsettings.ps1"
       ]
@@ -108,6 +113,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-cleanup-host.ps1",
       "inline": [
         "A:\\cleanup-host.ps1"
       ]
@@ -124,6 +130,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-queue-sysprep.ps1",
       "inline": [
         "Write-Host 'Initiate Sysprep'",
         "C:\\Windows\\System32\\sysprep\\sysprep /oobe /quit /unattend:C:\\Packer\\Init\\post-clone.autounattend.xml",
@@ -136,6 +143,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-vagrant-arm-host.ps1",
       "inline": [
         "C:\\Packer\\Init\\vagrant-arm-host.ps1"
       ]

--- a/templates/windows-2012r2-core/x86_64.vmware.base.json
+++ b/templates/windows-2012r2-core/x86_64.vmware.base.json
@@ -95,6 +95,7 @@
   "provisioners": [
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-clean-disk-dism.ps1",
       "inline": [
         "A:\\clean-disk-dism.ps1"
       ]
@@ -104,6 +105,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-clean-disk-sdelete.ps1",
       "inline": [
         "A:\\clean-disk-sdelete.ps1"
       ]

--- a/templates/windows-2012r2-core/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-2012r2-core/x86_64.vmware.vsphere.cygwin.json
@@ -91,6 +91,7 @@
   "provisioners": [
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/mkdir-packer-paths.ps1",
       "inline": [
         "md -Path C:\\Packer\\puppet\\modules",
         "md -Path C:\\Packer\\Downloads",
@@ -102,6 +103,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-install-win-packages.ps1",
       "inline": [
         "A:\\install-win-packages.ps1"
       ]
@@ -111,6 +113,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-install-cygwin.ps1",
       "inline": [
         "A:\\install-cygwin.ps1"
       ],
@@ -133,6 +136,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-puppet-configure.ps1",
       "inline": [
         "A:\\puppet-configure.ps1 -PackerTemplateName {{user `template_name`}}-{{user `version`}} -PackerSHA '{{user `packer_sha`}}'"
       ]
@@ -142,6 +146,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-config-winsettings.ps1",
       "inline": [
         "A:\\config-winsettings.ps1"
       ]
@@ -151,6 +156,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-cleanup-host.ps1",
       "inline": [
         "A:\\cleanup-host.ps1"
       ]
@@ -170,6 +176,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-vmpooler-arm-host.ps1",
       "inline": [
         "C:\\Packer\\Init\\vmpooler-arm-host.ps1"
       ]

--- a/templates/windows-2012r2-ja/files/x86_64/virtualbox/post-clone.autounattend.xml
+++ b/templates/windows-2012r2-ja/files/x86_64/virtualbox/post-clone.autounattend.xml
@@ -46,6 +46,11 @@
             <SkipAutoActivation>true</SkipAutoActivation>
         </component>
     </settings>
+    <settings pass="generalize">
+        <component name="Microsoft-Windows-PnpSysprep" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <PersistAllDeviceInstalls>true</PersistAllDeviceInstalls>
+        </component>
+    </settings>
     <settings pass="oobeSystem">
         <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <InputLocale>en-US</InputLocale>

--- a/templates/windows-2012r2-ja/files/x86_64/vmware/post-clone.autounattend.xml
+++ b/templates/windows-2012r2-ja/files/x86_64/vmware/post-clone.autounattend.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
+    <settings pass="generalize">
+        <component name="Microsoft-Windows-PnpSysprep" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <PersistAllDeviceInstalls>true</PersistAllDeviceInstalls>
+        </component>
+    </settings>
     <settings pass="oobeSystem">
         <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <InputLocale>ja-JP</InputLocale>

--- a/templates/windows-2012r2-ja/x86_64.virtualbox.base.json
+++ b/templates/windows-2012r2-ja/x86_64.virtualbox.base.json
@@ -53,7 +53,8 @@
   ],
   "provisioners": [
     {
-      "type"  : "powershell",
+      "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-clean-disk-dism.ps1",
       "inline": [
         "A:\\clean-disk-dism.ps1"
       ]
@@ -63,6 +64,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-clean-disk-sdelete.ps1",
       "inline": [
         "A:\\clean-disk-sdelete.ps1"
       ]

--- a/templates/windows-2012r2-ja/x86_64.virtualbox.vagrant.cygwin.json
+++ b/templates/windows-2012r2-ja/x86_64.virtualbox.vagrant.cygwin.json
@@ -48,6 +48,7 @@
   "provisioners": [
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/mkdir-packer-paths.ps1",
       "inline": [
         "md -Path C:\\Packer\\puppet\\modules",
         "md -Path C:\\Packer\\Downloads",
@@ -59,6 +60,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-install-win-packages.ps1",
       "inline": [
         "A:\\install-win-packages.ps1"
       ]
@@ -68,6 +70,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-install-cygwin.ps1",
       "inline": [
         "A:\\install-cygwin.ps1"
       ],
@@ -90,6 +93,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-puppet-configure.ps1",
       "inline": [
         "A:\\puppet-configure.ps1 -PackerTemplateName {{user `template_name`}}-{{user `version`}} -PackerSHA '{{user `packer_sha`}}' -PackerTemplateType 'vagrant'"
       ]
@@ -99,6 +103,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-config-winsettings.ps1",
       "inline": [
         "A:\\config-winsettings.ps1"
       ]
@@ -108,6 +113,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-cleanup-host.ps1",
       "inline": [
         "A:\\cleanup-host.ps1"
       ]
@@ -124,6 +130,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-queue-sysprep.ps1",
       "inline": [
         "Write-Host 'Initiate Sysprep'",
         "C:\\Windows\\System32\\sysprep\\sysprep /oobe /quit /unattend:C:\\Packer\\Init\\post-clone.autounattend.xml",
@@ -136,6 +143,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-vagrant-arm-host.ps1",
       "inline": [
         "C:\\Packer\\Init\\vagrant-arm-host.ps1"
       ]

--- a/templates/windows-2012r2-ja/x86_64.vmware.base.json
+++ b/templates/windows-2012r2-ja/x86_64.vmware.base.json
@@ -93,6 +93,7 @@
   "provisioners": [
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-clean-disk-dism.ps1",
       "inline": [
         "A:\\clean-disk-dism.ps1"
       ]
@@ -101,6 +102,7 @@
       "type": "windows-restart"
     },
     {
+      "remote_path": "c:/Windows/Temp/run-clean-disk-sdelete.ps1",
       "type": "powershell",
       "inline": [
         "A:\\clean-disk-sdelete.ps1"

--- a/templates/windows-2012r2-ja/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-2012r2-ja/x86_64.vmware.vsphere.cygwin.json
@@ -87,6 +87,7 @@
   "provisioners": [
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/mkdir-packer-paths.ps1",
       "inline": [
         "md -Path C:\\Packer\\puppet\\modules",
         "md -Path C:\\Packer\\Downloads",
@@ -98,6 +99,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-install-win-packages.ps1",
       "inline": [
         "A:\\install-win-packages.ps1"
       ]
@@ -107,6 +109,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-install-cygwin.ps1",
       "inline": [
         "A:\\install-cygwin.ps1"
       ],
@@ -129,6 +132,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-puppet-configure.ps1",
       "inline": [
         "A:\\puppet-configure.ps1 -PackerTemplateName {{user `template_name`}}-{{user `version`}} -PackerSHA '{{user `packer_sha`}}'"
       ]
@@ -138,6 +142,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-config-winsettings.ps1",
       "inline": [
         "A:\\config-winsettings.ps1"
       ]
@@ -147,6 +152,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-cleanup-host.ps1",
       "inline": [
         "A:\\cleanup-host.ps1"
       ]
@@ -166,6 +172,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-vmpooler-arm-host.ps1",
       "inline": [
         "C:\\Packer\\Init\\vmpooler-arm-host.ps1"
       ]

--- a/templates/windows-2012r2-wmf5/files/x86_64/vmware/post-clone.autounattend.xml
+++ b/templates/windows-2012r2-wmf5/files/x86_64/vmware/post-clone.autounattend.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
+    <settings pass="generalize">
+        <component name="Microsoft-Windows-PnpSysprep" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <PersistAllDeviceInstalls>true</PersistAllDeviceInstalls>
+        </component>
+    </settings>
     <settings pass="oobeSystem">
         <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <InputLocale>en-US</InputLocale>

--- a/templates/windows-2012r2-wmf5/x86_64.vmware.base.json
+++ b/templates/windows-2012r2-wmf5/x86_64.vmware.base.json
@@ -93,6 +93,7 @@
   "provisioners": [
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-clean-disk-dism.ps1",
       "inline": [
         "A:\\clean-disk-dism.ps1"
       ]
@@ -102,6 +103,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-clean-disk-sdelete.ps1",
       "inline": [
         "A:\\clean-disk-sdelete.ps1"
       ]

--- a/templates/windows-2012r2-wmf5/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-2012r2-wmf5/x86_64.vmware.vsphere.cygwin.json
@@ -91,6 +91,7 @@
   "provisioners": [
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/mkdir-packer-paths.ps1",
       "inline": [
         "md -Path C:\\Packer\\puppet\\modules",
         "md -Path C:\\Packer\\Downloads",
@@ -102,6 +103,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-install-win-packages.ps1",
       "inline": [
         "A:\\install-win-packages.ps1"
       ]
@@ -111,6 +113,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-install-cygwin.ps1",
       "inline": [
         "A:\\install-cygwin.ps1"
       ],
@@ -133,6 +136,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-puppet-configure.ps1",
       "inline": [
         "A:\\puppet-configure.ps1 -PackerTemplateName {{user `template_name`}}-{{user `version`}} -PackerSHA '{{user `packer_sha`}}'"
       ]
@@ -142,6 +146,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-config-winsettings.ps1",
       "inline": [
         "A:\\config-winsettings.ps1"
       ]
@@ -151,6 +156,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-cleanup-host.ps1",
       "inline": [
         "A:\\cleanup-host.ps1"
       ]
@@ -170,6 +176,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-vmpooler-arm-host.ps1",
       "inline": [
         "C:\\Packer\\Init\\vmpooler-arm-host.ps1"
       ]

--- a/templates/windows-2012r2/files/x86_64/virtualbox/post-clone.autounattend.xml
+++ b/templates/windows-2012r2/files/x86_64/virtualbox/post-clone.autounattend.xml
@@ -46,6 +46,11 @@
             <SkipAutoActivation>true</SkipAutoActivation>
         </component>
     </settings>
+    <settings pass="generalize">
+        <component name="Microsoft-Windows-PnpSysprep" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <PersistAllDeviceInstalls>true</PersistAllDeviceInstalls>
+        </component>
+    </settings>
     <settings pass="oobeSystem">
         <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <InputLocale>en-US</InputLocale>

--- a/templates/windows-2012r2/files/x86_64/vmware/post-clone.autounattend.xml
+++ b/templates/windows-2012r2/files/x86_64/vmware/post-clone.autounattend.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
+    <settings pass="generalize">
+        <component name="Microsoft-Windows-PnpSysprep" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <PersistAllDeviceInstalls>true</PersistAllDeviceInstalls>
+        </component>
+    </settings>
     <settings pass="oobeSystem">
         <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <InputLocale>en-US</InputLocale>

--- a/templates/windows-2012r2/x86_64.virtualbox.base.json
+++ b/templates/windows-2012r2/x86_64.virtualbox.base.json
@@ -53,7 +53,8 @@
   ],
   "provisioners": [
     {
-      "type"  : "powershell",
+      "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-clean-disk-dism.ps1",
       "inline": [
         "A:\\clean-disk-dism.ps1"
       ]
@@ -63,6 +64,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-clean-disk-sdelete.ps1",
       "inline": [
         "A:\\clean-disk-sdelete.ps1"
       ]

--- a/templates/windows-2012r2/x86_64.virtualbox.vagrant.cygwin.json
+++ b/templates/windows-2012r2/x86_64.virtualbox.vagrant.cygwin.json
@@ -48,6 +48,7 @@
   "provisioners": [
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/mkdir-packer-paths.ps1",
       "inline": [
         "md -Path C:\\Packer\\puppet\\modules",
         "md -Path C:\\Packer\\Downloads",
@@ -59,6 +60,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-install-win-packages.ps1",
       "inline": [
         "A:\\install-win-packages.ps1"
       ]
@@ -68,6 +70,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-install-cygwin.ps1",
       "inline": [
         "A:\\install-cygwin.ps1"
       ],
@@ -90,6 +93,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-puppet-configure.ps1",
       "inline": [
         "A:\\puppet-configure.ps1 -PackerTemplateName {{user `template_name`}}-{{user `version`}} -PackerSHA '{{user `packer_sha`}}' -PackerTemplateType 'vagrant'"
       ]
@@ -99,6 +103,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-config-winsettings.ps1",
       "inline": [
         "A:\\config-winsettings.ps1"
       ]
@@ -108,6 +113,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-cleanup-host.ps1",
       "inline": [
         "A:\\cleanup-host.ps1"
       ]
@@ -124,6 +130,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-queue-sysprep.ps1",
       "inline": [
         "Write-Host 'Initiate Sysprep'",
         "C:\\Windows\\System32\\sysprep\\sysprep /oobe /quit /unattend:C:\\Packer\\Init\\post-clone.autounattend.xml",
@@ -136,6 +143,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-vagrant-arm-host.ps1",
       "inline": [
         "C:\\Packer\\Init\\vagrant-arm-host.ps1"
       ]

--- a/templates/windows-2012r2/x86_64.vmware.base.json
+++ b/templates/windows-2012r2/x86_64.vmware.base.json
@@ -93,6 +93,7 @@
   "provisioners": [
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-clean-disk-dism.ps1",
       "inline": [
         "A:\\clean-disk-dism.ps1"
       ]
@@ -102,6 +103,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-clean-disk-sdelete.ps1",
       "inline": [
         "A:\\clean-disk-sdelete.ps1"
       ]

--- a/templates/windows-2012r2/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-2012r2/x86_64.vmware.vsphere.cygwin.json
@@ -91,6 +91,7 @@
   "provisioners": [
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/mkdir-packer-paths.ps1",
       "inline": [
         "md -Path C:\\Packer\\puppet\\modules",
         "md -Path C:\\Packer\\Downloads",
@@ -102,6 +103,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-install-win-packages.ps1",
       "inline": [
         "A:\\install-win-packages.ps1"
       ]
@@ -111,6 +113,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-install-cygwin.ps1",
       "inline": [
         "A:\\install-cygwin.ps1"
       ],
@@ -133,6 +136,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-puppet-configure.ps1",
       "inline": [
         "A:\\puppet-configure.ps1 -PackerTemplateName {{user `template_name`}}-{{user `version`}} -PackerSHA '{{user `packer_sha`}}'"
       ]
@@ -142,6 +146,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-config-winsettings.ps1",
       "inline": [
         "A:\\config-winsettings.ps1"
       ]
@@ -151,6 +156,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-cleanup-host.ps1",
       "inline": [
         "A:\\cleanup-host.ps1"
       ]
@@ -170,6 +176,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-vmpooler-arm-host.ps1",
       "inline": [
         "C:\\Packer\\Init\\vmpooler-arm-host.ps1"
       ]

--- a/templates/windows-2016-core/files/x86_64/virtualbox/post-clone.autounattend.xml
+++ b/templates/windows-2016-core/files/x86_64/virtualbox/post-clone.autounattend.xml
@@ -46,6 +46,11 @@
             <SkipAutoActivation>true</SkipAutoActivation>
         </component>
     </settings>
+    <settings pass="generalize">
+        <component name="Microsoft-Windows-PnpSysprep" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <PersistAllDeviceInstalls>true</PersistAllDeviceInstalls>
+        </component>
+    </settings>
     <settings pass="oobeSystem">
         <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <InputLocale>en-US</InputLocale>

--- a/templates/windows-2016-core/files/x86_64/vmware/post-clone.autounattend.xml
+++ b/templates/windows-2016-core/files/x86_64/vmware/post-clone.autounattend.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
+    <settings pass="generalize">
+        <component name="Microsoft-Windows-PnpSysprep" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <PersistAllDeviceInstalls>true</PersistAllDeviceInstalls>
+        </component>
+    </settings>
     <settings pass="oobeSystem">
         <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <InputLocale>en-US</InputLocale>

--- a/templates/windows-2016-core/x86_64.virtualbox.base.json
+++ b/templates/windows-2016-core/x86_64.virtualbox.base.json
@@ -53,7 +53,8 @@
   ],
   "provisioners": [
     {
-      "type"  : "powershell",
+      "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-clean-disk-dism.ps1",
       "inline": [
         "A:\\clean-disk-dism.ps1"
       ]
@@ -63,6 +64,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-clean-disk-sdelete.ps1",
       "inline": [
         "A:\\clean-disk-sdelete.ps1"
       ]

--- a/templates/windows-2016-core/x86_64.virtualbox.vagrant.cygwin.json
+++ b/templates/windows-2016-core/x86_64.virtualbox.vagrant.cygwin.json
@@ -48,6 +48,7 @@
   "provisioners": [
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/mkdir-packer-paths.ps1",
       "inline": [
         "md -Path C:\\Packer\\puppet\\modules",
         "md -Path C:\\Packer\\Downloads",
@@ -59,12 +60,14 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-install-win-packages.ps1",
       "inline": [
         "A:\\install-win-packages.ps1"
       ]
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-install-cygwin.ps1",
       "inline": [
         "A:\\install-cygwin.ps1"
       ],
@@ -87,6 +90,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-puppet-configure.ps1",
       "inline": [
         "A:\\puppet-configure.ps1 -PackerTemplateName {{user `template_name`}}-{{user `version`}} -PackerSHA '{{user `packer_sha`}}' -PackerTemplateType 'vagrant'"
       ]
@@ -96,6 +100,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-config-winsettings.ps1",
       "inline": [
         "A:\\config-winsettings.ps1"
       ]
@@ -105,6 +110,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-cleanup-host.ps1",
       "inline": [
         "A:\\cleanup-host.ps1"
       ]
@@ -121,6 +127,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-queue-sysprep.ps1",
       "inline": [
         "Write-Host 'Initiate Sysprep'",
         "C:\\Windows\\System32\\sysprep\\sysprep /oobe /quit /unattend:C:\\Packer\\Init\\post-clone.autounattend.xml",
@@ -133,6 +140,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-vagrant-arm-host.ps1",
       "inline": [
         "C:\\Packer\\Init\\vagrant-arm-host.ps1"
       ]

--- a/templates/windows-2016-core/x86_64.vmware.base.json
+++ b/templates/windows-2016-core/x86_64.vmware.base.json
@@ -95,6 +95,7 @@
   "provisioners": [
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-clean-disk-dism.ps1",
       "inline": [
         "A:\\clean-disk-dism.ps1"
       ]
@@ -104,6 +105,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-clean-disk-sdelete.ps1",
       "inline": [
         "A:\\clean-disk-sdelete.ps1"
       ]

--- a/templates/windows-2016-core/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-2016-core/x86_64.vmware.vsphere.cygwin.json
@@ -91,6 +91,7 @@
   "provisioners": [
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/mkdir-packer-paths.ps1",
       "inline": [
         "md -Path C:\\Packer\\puppet\\modules",
         "md -Path C:\\Packer\\Downloads",
@@ -102,12 +103,14 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-install-win-packages.ps1",
       "inline": [
         "A:\\install-win-packages.ps1"
       ]
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-install-cygwin.ps1",
       "inline": [
         "A:\\install-cygwin.ps1"
       ],
@@ -130,6 +133,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-puppet-configure.ps1",
       "inline": [
         "A:\\puppet-configure.ps1 -PackerTemplateName {{user `template_name`}}-{{user `version`}} -PackerSHA '{{user `packer_sha`}}'"
       ]
@@ -139,6 +143,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-config-winsettings.ps1",
       "inline": [
         "A:\\config-winsettings.ps1"
       ]
@@ -148,6 +153,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-cleanup-host.ps1",
       "inline": [
         "A:\\cleanup-host.ps1"
       ]
@@ -167,6 +173,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-vmpooler-arm-host.ps1",
       "inline": [
         "C:\\Packer\\Init\\vmpooler-arm-host.ps1"
       ]

--- a/templates/windows-2016/files/x86_64/vmware/post-clone.autounattend.xml
+++ b/templates/windows-2016/files/x86_64/vmware/post-clone.autounattend.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
+    <settings pass="generalize">
+        <component name="Microsoft-Windows-PnpSysprep" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <PersistAllDeviceInstalls>true</PersistAllDeviceInstalls>
+        </component>
+    </settings>
     <settings pass="oobeSystem">
         <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <InputLocale>en-US</InputLocale>

--- a/templates/windows-2016/x86_64.vmware.base.json
+++ b/templates/windows-2016/x86_64.vmware.base.json
@@ -93,6 +93,7 @@
   "provisioners": [
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-clean-disk-dism.ps1",
       "inline": [
         "A:\\clean-disk-dism.ps1"
       ]
@@ -102,6 +103,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-clean-disk-sdelete.ps1",
       "inline": [
         "A:\\clean-disk-sdelete.ps1"
       ]

--- a/templates/windows-2016/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-2016/x86_64.vmware.vsphere.cygwin.json
@@ -87,6 +87,7 @@
   "provisioners": [
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/mkdir-packer-paths.ps1",
       "inline": [
         "md -Path C:\\Packer\\puppet\\modules",
         "md -Path C:\\Packer\\Downloads",
@@ -98,6 +99,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-install-win-packages.ps1",
       "inline": [
         "A:\\install-win-packages.ps1"
       ]
@@ -107,6 +109,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-install-cygwin.ps1",
       "inline": [
         "A:\\install-cygwin.ps1"
       ],
@@ -129,6 +132,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-puppet-configure.ps1",
       "inline": [
         "A:\\puppet-configure.ps1 -PackerTemplateName {{user `template_name`}}-{{user `version`}} -PackerSHA '{{user `packer_sha`}}'"
       ]
@@ -138,6 +142,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-config-winsettings.ps1",
       "inline": [
         "A:\\config-winsettings.ps1"
       ]
@@ -147,6 +152,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-cleanup-host.ps1",
       "inline": [
         "A:\\cleanup-host.ps1"
       ]
@@ -166,6 +172,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-vmpooler-arm-host.ps1",
       "inline": [
         "C:\\Packer\\Init\\vmpooler-arm-host.ps1"
       ]

--- a/templates/windows-7/x86_64.vmware.base.json
+++ b/templates/windows-7/x86_64.vmware.base.json
@@ -93,6 +93,7 @@
   "provisioners": [
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-clean-disk-dism.ps1",
       "inline": [
         "A:\\clean-disk-dism.ps1"
       ]
@@ -102,6 +103,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-clean-disk-sdelete.ps1",
       "inline": [
         "A:\\clean-disk-sdelete.ps1"
       ]

--- a/templates/windows-7/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-7/x86_64.vmware.vsphere.cygwin.json
@@ -87,6 +87,7 @@
   "provisioners": [
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/mkdir-packer-paths.ps1",
       "inline": [
         "md -Path C:\\Packer\\puppet\\modules",
         "md -Path C:\\Packer\\Downloads",
@@ -98,6 +99,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-install-win-packages.ps1",
       "inline": [
         "A:\\install-win-packages.ps1"
       ]
@@ -107,6 +109,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-install-cygwin.ps1",
       "inline": [
         "A:\\install-cygwin.ps1"
       ],
@@ -129,6 +132,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-puppet-configure.ps1",
       "inline": [
         "A:\\puppet-configure.ps1 -PackerTemplateName {{user `template_name`}}-{{user `version`}} -PackerSHA '{{user `packer_sha`}}'"
       ]
@@ -138,6 +142,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-config-winsettings.ps1",
       "inline": [
         "A:\\config-winsettings.ps1"
       ]
@@ -147,6 +152,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-cleanup-host.ps1",
       "inline": [
         "A:\\cleanup-host.ps1"
       ]
@@ -166,6 +172,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-vmpooler-arm-host.ps1",
       "inline": [
         "C:\\Packer\\Init\\vmpooler-arm-host.ps1"
       ]

--- a/templates/windows-8.1/x86_64.vmware.base.json
+++ b/templates/windows-8.1/x86_64.vmware.base.json
@@ -93,6 +93,7 @@
   "provisioners": [
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-clean-disk-dism.ps1",
       "inline": [
         "A:\\clean-disk-dism.ps1"
       ]
@@ -102,6 +103,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-clean-disk-sdelete.ps1",
       "inline": [
         "A:\\clean-disk-sdelete.ps1"
       ]

--- a/templates/windows-8.1/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-8.1/x86_64.vmware.vsphere.cygwin.json
@@ -88,6 +88,7 @@
   "provisioners": [
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/mkdir-packer-paths.ps1",
       "inline": [
         "md -Path C:\\Packer\\puppet\\modules",
         "md -Path C:\\Packer\\Downloads",
@@ -99,6 +100,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-install-win-packages.ps1",
       "inline": [
         "A:\\install-win-packages.ps1"
       ]
@@ -108,6 +110,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-install-cygwin.ps1",
       "inline": [
         "A:\\install-cygwin.ps1"
       ],
@@ -130,6 +133,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-puppet-configure.ps1",
       "inline": [
         "A:\\puppet-configure.ps1 -PackerTemplateName {{user `template_name`}}-{{user `version`}} -PackerSHA '{{user `packer_sha`}}'"
       ]
@@ -139,6 +143,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-config-winsettings.ps1",
       "inline": [
         "A:\\config-winsettings.ps1"
       ]
@@ -148,6 +153,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-cleanup-host.ps1",
       "inline": [
         "A:\\cleanup-host.ps1"
       ]
@@ -167,6 +173,7 @@
     },
     {
       "type": "powershell",
+      "remote_path": "c:/Windows/Temp/run-vmpooler-arm-host.ps1",
       "inline": [
         "C:\\Packer\\Init\\vmpooler-arm-host.ps1"
       ]


### PR DESCRIPTION
The latest cumulative update to Windows-10 seems to add or re-enable a number of the Metro apps which are causing a sysprep failure. Revise the App cleanup to remove all Metro Apps and to repeat the exercise after the Windows Update cycle is complete.

Also fix the following two issues which were impacting this Patch Tuesday general refresh of images:
1. Add sleep to Powershell to overcome a Packer/Powershell intermittent issue
2. Persist drivers in the Post-Clone Sysprep - should reduce pooler instance startup time.