### PR TITLE
(IMAGES-595) Remove debian 9 libreadline hack

### DIFF
--- a/templates/debian-9.0/i386.vmware.base.json
+++ b/templates/debian-9.0/i386.vmware.base.json
@@ -15,7 +15,7 @@
 
       "provisioner": "vmware",
       "required_modules": "puppetlabs-stdlib saz-ssh",
-      "puppet_aio": "http://apt.puppetlabs.com/pool/jessie/PC1/p/puppet-agent/puppet-agent_1.10.5-1jessie_i386.deb",
+      "puppet_aio": "http://apt.puppetlabs.com/pool/stretch/PC1/p/puppet-agent/puppet-agent_1.10.6-1stretch_i386.deb",
       "headless": "true",
 
       "packer_output_dir": "{{env `PACKER_VM_OUT_DIR`}}"
@@ -70,7 +70,6 @@
         "PUPPET_AIO={{user `puppet_aio`}}"
       ],
       "scripts": [
-        "./new_os_hacks/add_libreadline6.sh",
         "../../scripts/bootstrap-aio.sh"
       ]
     },
@@ -94,8 +93,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-aio.sh",
-        "../../scripts/cleanup-packer.sh",
-        "./new_os_hacks/remove_libreadline6.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/debian-9.0/i386.vmware.vsphere.nocm.json
+++ b/templates/debian-9.0/i386.vmware.vsphere.nocm.json
@@ -10,7 +10,7 @@
 
       "provisioner": "vmware",
       "required_modules": "puppetlabs-stdlib example42-network puppetlabs-apt",
-      "puppet_aio": "http://apt.puppetlabs.com/pool/jessie/PC1/p/puppet-agent/puppet-agent_1.10.5-1jessie_i386.deb",
+      "puppet_aio": "http://apt.puppetlabs.com/pool/stretch/PC1/p/puppet-agent/puppet-agent_1.10.6-1stretch_i386.deb",
       "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
       "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",
       "packer_vcenter_username": "{{env `PACKER_VCENTER_USERNAME`}}",
@@ -66,7 +66,6 @@
         "PUPPET_AIO={{user `puppet_aio`}}"
       ],
       "scripts": [
-        "./new_os_hacks/add_libreadline6.sh",
         "../../scripts/bootstrap-aio.sh"
       ]
     },
@@ -98,8 +97,7 @@
       "scripts": [
         "../../scripts/cleanup-aio.sh",
         "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh",
-        "./new_os_hacks/remove_libreadline6.sh"
+        "../../scripts/cleanup-scrub.sh"
       ]
     }
   ],

--- a/templates/debian-9.0/new_os_hacks/add_libreadline6.sh
+++ b/templates/debian-9.0/new_os_hacks/add_libreadline6.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Install libreadline6 so jessie agents can work on stretch
-cd /tmp
-curl -O http://http.us.debian.org/debian/pool/main/r/readline6/libreadline6_6.3-8+b3_$(dpkg --print-architecture).deb
-dpkg -i libreadline6_6.3-8+b3_$(dpkg --print-architecture).deb
-rm libreadline6_6.3-8+b3_$(dpkg --print-architecture).deb

--- a/templates/debian-9.0/new_os_hacks/remove_libreadline6.sh
+++ b/templates/debian-9.0/new_os_hacks/remove_libreadline6.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# remove libreadline6
-dpkg -P libreadline6

--- a/templates/debian-9.0/x86_64.vmware.base.json
+++ b/templates/debian-9.0/x86_64.vmware.base.json
@@ -15,7 +15,7 @@
 
       "provisioner": "vmware",
       "required_modules": "puppetlabs-stdlib saz-ssh",
-      "puppet_aio": "http://apt.puppetlabs.com/pool/jessie/PC1/p/puppet-agent/puppet-agent_1.10.5-1jessie_amd64.deb",
+      "puppet_aio": "http://apt.puppetlabs.com/pool/stretch/PC1/p/puppet-agent/puppet-agent_1.10.6-1stretch_amd64.deb",
       "headless": "true",
 
       "packer_output_dir": "{{env `PACKER_VM_OUT_DIR`}}"
@@ -71,7 +71,6 @@
         "PUPPET_AIO={{user `puppet_aio`}}"
       ],
       "scripts": [
-        "./new_os_hacks/add_libreadline6.sh",
         "../../scripts/bootstrap-aio.sh"
       ]
     },
@@ -95,8 +94,7 @@
       ],
       "scripts": [
         "../../scripts/cleanup-aio.sh",
-        "../../scripts/cleanup-packer.sh",
-        "./new_os_hacks/remove_libreadline6.sh"
+        "../../scripts/cleanup-packer.sh"
       ]
     }
   ]

--- a/templates/debian-9.0/x86_64.vmware.vsphere.nocm.json
+++ b/templates/debian-9.0/x86_64.vmware.vsphere.nocm.json
@@ -9,7 +9,7 @@
       "beakerhost": "debian9-64",
       "provisioner": "vmware",
       "required_modules": "puppetlabs-stdlib example42-network puppetlabs-apt",
-      "puppet_aio": "http://apt.puppetlabs.com/pool/jessie/PC1/p/puppet-agent/puppet-agent_1.10.5-1jessie_amd64.deb",
+      "puppet_aio": "http://apt.puppetlabs.com/pool/stretch/PC1/p/puppet-agent/puppet-agent_1.10.6-1stretch_amd64.deb",
       "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
       "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",
       "packer_vcenter_username": "{{env `PACKER_VCENTER_USERNAME`}}",
@@ -65,7 +65,6 @@
         "PUPPET_AIO={{user `puppet_aio`}}"
       ],
       "scripts": [
-        "./new_os_hacks/add_libreadline6.sh",
         "../../scripts/bootstrap-aio.sh"
       ]
     },
@@ -97,8 +96,7 @@
       "scripts": [
         "../../scripts/cleanup-aio.sh",
         "../../scripts/cleanup-packer.sh",
-        "../../scripts/cleanup-scrub.sh",
-        "./new_os_hacks/remove_libreadline6.sh"
+        "../../scripts/cleanup-scrub.sh"
       ]
     }
   ],


### PR DESCRIPTION
This commit removes the hack we used to get debian 9 to work by using the
newly released agent 1.10.6 for debian 9