### PR TITLE
(IMAGES-592) Update configuration, repos for fedora 26

### DIFF
--- a/manifests/modules/packer/manifests/vsphere/repos.pp
+++ b/manifests/modules/packer/manifests/vsphere/repos.pp
@@ -77,9 +77,16 @@ class packer::vsphere::repos inherits packer::vsphere::params {
         purge => true,
       }
 
+      # Fedora URLs do not use a '-' after the os name (i.e. they use fedora26, not fedora-26)
+      if $::operatingsystem == 'Fedora' {
+        $base_url = "${repo_mirror}/${loweros}${::operatingsystemmajrelease}-${::architecture}"
+      } else {
+        $base_url = "${repo_mirror}/${loweros}-${::operatingsystemmajrelease}-${::architecture}"
+      }
+
       yumrepo { "localmirror-os":
         descr    => "localmirror-os",
-        baseurl  => "${repo_mirror}/${loweros}-${::operatingsystemmajrelease}-${::architecture}/RPMS.os",
+        baseurl  => "${base_url}/RPMS.os",
         gpgcheck => "1",
         gpgkey   => "file:///etc/pki/rpm-gpg/${gpgkey}"
       }
@@ -91,7 +98,7 @@ class packer::vsphere::repos inherits packer::vsphere::params {
       }
       yumrepo { "localmirror-${updates_ext}":
         descr    => "localmirror-${updates_ext}",
-        baseurl  => "${repo_mirror}/${loweros}-${::operatingsystemmajrelease}-${::architecture}/RPMS.${updates_ext}",
+        baseurl  => "${base_url}/RPMS.${updates_ext}",
         gpgcheck => "1",
         gpgkey   => "file:///etc/pki/rpm-gpg/${gpgkey}"
       }
@@ -99,7 +106,7 @@ class packer::vsphere::repos inherits packer::vsphere::params {
       if $::operatingsystem == 'Fedora' {
         yumrepo { "localmirror-everything":
           descr    => "localmirror-everything",
-          baseurl  => "${repo_mirror}/${loweros}-${::operatingsystemmajrelease}-${::architecture}/RPMS.everything",
+          baseurl  => "${base_url}/RPMS.everything",
           gpgcheck => "1",
           gpgkey   => "file:///etc/pki/rpm-gpg/${gpgkey}"
         }

--- a/templates/fedora-26/x86_64.vmware.base.json
+++ b/templates/fedora-26/x86_64.vmware.base.json
@@ -4,6 +4,8 @@
     {
       "template_name": "fedora-26-x86_64",
       "template_os": "fedora-64",
+      "template_config": "base",
+
 
       "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/Fedora-Server-dvd-x86_64-26-1.5.iso",
       "iso_checksum": "fad18a43b9cec152fc8a1fd368950eaf59be66b1a15438149a0c3a509c56cf2f",
@@ -15,17 +17,18 @@
       "provisioner": "vmware",
       "required_modules": "puppetlabs-stdlib saz-ssh",
       "puppet_aio": "https://yum.puppetlabs.com/fedora/f25/PC1/x86_64/puppet-agent-1.10.6-1.fedoraf25.x86_64.rpm",
+      "headless": "true",
 
-      "output_directory": "{{env `OUTPUT_DIRECTORY`}}"
+      "packer_output_dir": "{{env `PACKER_VM_OUT_DIR`}}"
 
     },
 
   "builders": [
     {
-      "name": "{{user `template_name`}}-{{user `provisioner`}}",
-      "output_directory": "{{user `output_directory`}}output-{{build_name}}",
+      "name": "{{user `template_name`}}-{{user `provisioner`}}-{{user `template_config`}}",
+      "output_directory": "{{user `packer_output_dir`}}/output-{{build_name}}",
       "type": "vmware-iso",
-      "headless": true,
+      "headless": "{{user `headless`}}",
       "boot_command": [
         "<tab> <wait>",
         "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
@@ -49,7 +52,7 @@
       "tools_upload_flavor": "linux",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
-	"ethernet0.pciSlotNumber": "32",
+        "ethernet0.pciSlotNumber": "32",
         "memsize": "{{user `memory_size`}}",
         "numvcpus": "{{user `cpu_count`}}"
       }

--- a/templates/fedora-26/x86_64.vmware.vsphere.nocm.json
+++ b/templates/fedora-26/x86_64.vmware.vsphere.nocm.json
@@ -4,7 +4,7 @@
     {
       "template_name": "fedora-26-x86_64",
       "version": "0.0.1",
-
+      "template_config": "vsphere-nocm",
       "provisioner": "vmware",
       "required_modules": "puppetlabs-stdlib example42-network",
       "puppet_aio": "https://yum.puppetlabs.com/fedora/f25/PC1/x86_64/puppet-agent-1.10.6-1.fedoraf25.x86_64.rpm",
@@ -18,28 +18,32 @@
       "packer_vcenter_folder": "{{env `PACKER_VCENTER_FOLDER`}}",
       "packer_vcenter_net": "{{env `PACKER_VCENTER_NET`}}",
       "packer_vcenter_insecure": "{{env `PACKER_VCENTER_INSECURE`}}",
+      "packer_sha": "{{env `PACKER_SHA`}}",
+
+      "headless": "true",
 
       "memory_size": "4096",
       "cpu_count": "2",
 
-      "output_directory": "{{env `OUTPUT_DIRECTORY`}}"
-
+      "packer_source_dir": "{{env `PACKER_VM_SRC_DIR`}}",
+      "packer_output_dir": "{{env `PACKER_VM_OUT_DIR`}}"
     },
 
   "builders": [
     {
-      "name": "{{user `template_name`}}-{{user `provisioner`}}-vsphere-nocm",
-      "vm_name": "packer-{{build_name}}",
       "type": "vmware-vmx",
-      "headless": true,
-      "source_path": "{{user `output_directory`}}output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
+      "headless": "{{user `headless`}}",
+      "name": "{{user `template_name`}}-{{user `provisioner`}}-{{user `template_config`}}",
+      "vm_name": "packer-{{build_name}}",
+      "source_path": "{{user `packer_source_dir`}}/output-{{user `template_name`}}-{{user `provisioner`}}-base/packer-{{user `template_name`}}-{{user `provisioner`}}-base.vmx",
+      "output_directory": "{{user `packer_output_dir`}}/output-{{build_name}}",
       "ssh_username": "root",
       "ssh_password": "puppet",
       "ssh_port": 22,
       "ssh_wait_timeout": "10000s",
       "shutdown_command": "/sbin/halt -h -p",
       "vmx_data": {
-        "annotation": "{{user `template_name`}}-{{user `version`}} built {{isotime}}"
+      "annotation": "Packer build: {{user `template_name`}}-{{user `version`}} built {{isotime}} SHA: {{user `packer_sha`}}"
       },
       "vmx_data_post": {
         "memsize": "{{user `memory_size`}}",
@@ -106,7 +110,8 @@
       "vm_folder": "{{user `packer_vcenter_folder`}}",
       "vm_name": "{{user `template_name`}}-{{user `version`}}",
       "vm_network": "{{user `packer_vcenter_net`}}",
-      "insecure" : "{{user `packer_vcenter_insecure`}}"
+      "insecure" : "{{user `packer_vcenter_insecure`}}",
+      "overwrite" : "true"
     }
   ]
 }


### PR DESCRIPTION
This commit does 2 things:

1) Updates several parts of the packer configuration that were outdated and
causing problems in the imaging pipeline

2) Updates the puppet manifests for fedora packages to correctly use fedora26
instead of fedora-26 in the URL for mirrored repos