### PR TITLE
(IMAGES-594) Add 'beakerhost' to fedora 26 vsphere image

### DIFF
--- a/templates/fedora-26/x86_64.vmware.vsphere.nocm.json
+++ b/templates/fedora-26/x86_64.vmware.vsphere.nocm.json
@@ -19,6 +19,7 @@
       "packer_vcenter_net": "{{env `PACKER_VCENTER_NET`}}",
       "packer_vcenter_insecure": "{{env `PACKER_VCENTER_INSECURE`}}",
       "packer_sha": "{{env `PACKER_SHA`}}",
+      "beakerhost": "fedora26-64",
 
       "headless": "true",
 


### PR DESCRIPTION
the 'beakerhost' variable defines what string to give beaker-hostgenerator to
produce the configuration for this platform. This commit updates the fedora26
config to include that var