### PR TITLE
(IMAGES-639) Remove Store/App packages for win-8.1

### DIFF
--- a/scripts/windows/windows-env.ps1
+++ b/scripts/windows/windows-env.ps1
@@ -295,9 +295,9 @@ Function Install-DotNetLatest
 }
 
 
-# Helper function to remove Windows-10 packages that break sysprep (packages are not needed in our test env)
+# Helper function to remove Store/Apps packages that break sysprep (packages are not needed in our test env)
 
-Function Remove-Win10Packages
+Function Remove-AppsPackages
 {
   Write-Output "Remove All Win-10 App/Packages to prevent Sysprep Issues"
 

--- a/templates/win-common/files/PostCloneTemplate.xml
+++ b/templates/win-common/files/PostCloneTemplate.xml
@@ -41,13 +41,13 @@
                     <Path>net user administrator /active:yes</Path>
                     <Order>1</Order>
                 </RunSynchronousCommand>
+                <!-- NB - only really needed for Win-8.1 but shouldn't harm rest of boots - needs regression -->
+                <RunSynchronousCommand wcm:action="add">
+                    <Path>reg add HKLM\Software\Microsoft\Windows\CurrentVersion\Policies\System /v EnableFirstLogonAnimation /t REG_DWORD /d 0 /f</Path>
+                    <Order>2</Order>
+                    <Description>Do not Show First Logon Animation</Description>
+                </RunSynchronousCommand>
             </RunSynchronous>
-            <!-- NB - only really needed for Win-8.1 but shouldn't harm rest of boots - needs regression -->
-            <RunSynchronousCommand wcm:action="add">
-                <Path>reg add HKLM\Software\Microsoft\Windows\CurrentVersion\Policies\System /v EnableFirstLogonAnimation /t REG_DWORD /d 0 /f</Path>
-                <Order>2</Order>
-                <Description>Do not Show First Logon Animation</Description>
-            </RunSynchronousCommand>
         </component>
         <component name="Microsoft-Windows-Security-SPP-UX" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <SkipAutoActivation>true</SkipAutoActivation>

--- a/templates/windows-10/files/i386/platform-packages.ps1
+++ b/templates/windows-10/files/i386/platform-packages.ps1
@@ -4,5 +4,5 @@ $ErrorActionPreference = "Stop"
 
 Write-Host "Running Win-10 Package Customisation"
 
-# Remove Win-10 packages that break sysprep
-Remove-Win10Packages
+# Remove Store/Apps packages that break sysprep
+Remove-AppsPackages

--- a/templates/windows-10/files/x86_64/platform-packages.ps1
+++ b/templates/windows-10/files/x86_64/platform-packages.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = "Stop"
 
 . A:\windows-env.ps1
 
-Write-Host "Running Win-10 Package Customisation"
+Write-Host "Running Win-10 Package Customisationtemplates/windows-10/files/i386/platform-packages.ps1"
 
-# Remove Win-10 packages that break sysprep
-Remove-Win10Packages
+# Remove Store/Apps packages that break sysprep
+Remove-AppsPackages

--- a/templates/windows-8.1/files/x86_64/platform-packages.ps1
+++ b/templates/windows-8.1/files/x86_64/platform-packages.ps1
@@ -4,3 +4,5 @@ $ErrorActionPreference = "Stop"
 
 Write-Host "Running Win-8.1 Package Customisation"
 
+# Remove Store/Apps packages that break sysprep
+Remove-AppsPackages


### PR DESCRIPTION
Applies the same method that was used for Windows-10 to resolve Sysprep
issues with the store/apps packages by completely removing them as they
are not needed for vmpooler etc.

Rename method for Win10 to more generic name.