### PR TITLE
(IMAGES-640) Custom vsphere spec for Win-2008 and other fixes

### DIFF
--- a/scripts/windows/windows-env.ps1
+++ b/scripts/windows/windows-env.ps1
@@ -295,9 +295,9 @@ Function Install-DotNetLatest
 }
 
 
-# Helper function to remove Windows-10 packages that break sysprep (packages are not needed in our test env)
+# Helper function to remove Store/Apps packages that break sysprep (packages are not needed in our test env)
 
-Function Remove-Win10Packages
+Function Remove-AppsPackages
 {
   Write-Output "Remove All Win-10 App/Packages to prevent Sysprep Issues"
 

--- a/templates/win-common/files/PostCloneTemplate.xml
+++ b/templates/win-common/files/PostCloneTemplate.xml
@@ -41,13 +41,13 @@
                     <Path>net user administrator /active:yes</Path>
                     <Order>1</Order>
                 </RunSynchronousCommand>
+                <!-- NB - only really needed for Win-8.1 but shouldn't harm rest of boots - needs regression -->
+                <RunSynchronousCommand wcm:action="add">
+                    <Path>reg add HKLM\Software\Microsoft\Windows\CurrentVersion\Policies\System /v EnableFirstLogonAnimation /t REG_DWORD /d 0 /f</Path>
+                    <Order>2</Order>
+                    <Description>Do not Show First Logon Animation</Description>
+                </RunSynchronousCommand>
             </RunSynchronous>
-            <!-- NB - only really needed for Win-8.1 but shouldn't harm rest of boots - needs regression -->
-            <RunSynchronousCommand wcm:action="add">
-                <Path>reg add HKLM\Software\Microsoft\Windows\CurrentVersion\Policies\System /v EnableFirstLogonAnimation /t REG_DWORD /d 0 /f</Path>
-                <Order>2</Order>
-                <Description>Do not Show First Logon Animation</Description>
-            </RunSynchronousCommand>
         </component>
         <component name="Microsoft-Windows-Security-SPP-UX" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <SkipAutoActivation>true</SkipAutoActivation>

--- a/templates/win-common/vmware.base.json
+++ b/templates/win-common/vmware.base.json
@@ -93,7 +93,7 @@
   "provisioners": [
     {
       "type": "powershell",
-      "remote_path": "{{user `packer_downloads_dir`}}/print-pswindowslog.ps1",
+      "remote_path": "{{user `packer_download_dir`}}/print-pswindowslog.ps1",
       "inline": [
         "Write-Output 'Executing Powershell Script: print-pswindowslog.ps1'",
         "Get-Content C:\\Packer\\Logs\\start-pswindowsupdate.log | foreach {Write-Output $_}",
@@ -103,7 +103,7 @@
     
     {
       "type": "powershell",
-      "remote_path": "{{user `packer_downloads_dir`}}/run-clean-disk-dism.ps1",
+      "remote_path": "{{user `packer_download_dir`}}/run-clean-disk-dism.ps1",
       "inline": [
         "Write-Output 'Executing Powershell Script: run-clean-disk-dism.ps1'",
         "A:\\clean-disk-dism.ps1"
@@ -114,7 +114,7 @@
     },
     {
       "type": "powershell",
-      "remote_path": "{{user `packer_downloads_dir`}}/run-clean-disk-sdelete.ps1",
+      "remote_path": "{{user `packer_download_dir`}}/run-clean-disk-sdelete.ps1",
       "inline": [
         "Write-Output 'Executing Powershell Script: run-clean-disk-sdelete.ps1'",
         "A:\\clean-disk-sdelete.ps1"

--- a/templates/win-common/vmware.vsphere.cygwin.json
+++ b/templates/win-common/vmware.vsphere.cygwin.json
@@ -112,7 +112,7 @@
       },
       {
         "type": "powershell",
-        "remote_path": "{{user `packer_downloads_dir`}}/run-install-win-packages.ps1",
+        "remote_path": "{{user `packer_download_dir`}}/run-install-win-packages.ps1",
         "inline": [
           "Write-Output 'Executing Powershell Script: run-install-win-packages.ps1'",
           "A:\\install-win-packages.ps1"
@@ -123,7 +123,7 @@
       },
       {
         "type": "powershell",
-        "remote_path": "{{user `packer_downloads_dir`}}/run-install-cygwin.ps1",
+        "remote_path": "{{user `packer_download_dir`}}/run-install-cygwin.ps1",
         "inline": [
           "Write-Output 'Executing Powershell Script: run-install-cygwin.ps1'",
           "A:\\install-cygwin.ps1"
@@ -137,7 +137,7 @@
       },
       {
         "type": "powershell",
-        "remote_path": "{{user `packer_downloads_dir`}}/run-puppet-configure.ps1",
+        "remote_path": "{{user `packer_download_dir`}}/run-puppet-configure.ps1",
         "inline": [
           "Write-Output 'Executing Powershell Script: run-puppet-configure.ps1'",
           "A:\\puppet-configure.ps1 -PackerTemplateName {{user `template_name`}}-{{user `version`}} -PackerSHA '{{user `packer_sha`}}' -PackerTemplateType 'vmpooler'"
@@ -148,7 +148,7 @@
       },
       {
         "type": "powershell",
-        "remote_path": "{{user `packer_downloads_dir`}}/run-config-winsettings.ps1",
+        "remote_path": "{{user `packer_download_dir`}}/run-config-winsettings.ps1",
         "inline": [
           "Write-Output 'Executing Powershell Script: run-config-winsettings.ps1'",
           "A:\\config-winsettings.ps1"
@@ -159,7 +159,7 @@
       },
       {
         "type": "powershell",
-        "remote_path": "{{user `packer_downloads_dir`}}/run-cleanup-host.ps1",
+        "remote_path": "{{user `packer_download_dir`}}/run-cleanup-host.ps1",
         "inline": [
           "Write-Output 'Executing Powershell Script: run-cleanup-host.ps1'",
           "A:\\cleanup-host.ps1"
@@ -170,7 +170,7 @@
       },
       {
         "type": "powershell",
-        "remote_path": "{{user `packer_downloads_dir`}}/run-vmpooler-arm-host.ps1",
+        "remote_path": "{{user `packer_download_dir`}}/run-vmpooler-arm-host.ps1",
         "inline": [
           "Write-Output 'Executing Powershell Script: run-vmpooler-arm-host.ps1'",
           "C:\\Packer\\Init\\vmpooler-arm-host.ps1"

--- a/templates/windows-10/files/i386/platform-packages.ps1
+++ b/templates/windows-10/files/i386/platform-packages.ps1
@@ -4,5 +4,5 @@ $ErrorActionPreference = "Stop"
 
 Write-Host "Running Win-10 Package Customisation"
 
-# Remove Win-10 packages that break sysprep
-Remove-Win10Packages
+# Remove Store/Apps packages that break sysprep
+Remove-AppsPackages

--- a/templates/windows-10/files/x86_64/platform-packages.ps1
+++ b/templates/windows-10/files/x86_64/platform-packages.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = "Stop"
 
 . A:\windows-env.ps1
 
-Write-Host "Running Win-10 Package Customisation"
+Write-Host "Running Win-10 Package Customisationtemplates/windows-10/files/i386/platform-packages.ps1"
 
-# Remove Win-10 packages that break sysprep
-Remove-Win10Packages
+# Remove Store/Apps packages that break sysprep
+Remove-AppsPackages

--- a/templates/windows-2008/x86_64.vmware.vsphere.cygwin.json
+++ b/templates/windows-2008/x86_64.vmware.vsphere.cygwin.json
@@ -1,0 +1,213 @@
+{
+  "variables": {
+     "template_config": "vsphere.cygwin",
+
+    "headless"                 : "true",
+    "provisioner"              : "{{env `IMAGE_TYPE`}}",
+    "firmware"                 : "efi",
+    "winrm_username"           : "Administrator",
+    "winrm_password"           : "PackerAdmin",
+    "winrm_timeout"            : "8h",
+    "memsize"                  : "4096",
+    "numvcpus"                 : "2",
+    "post_memsize"             : "4096",
+    "shutdown_timeout"         : "1h",
+
+    "qa_root_passwd"           : "{{env `QA_ROOT_PASSWD_PLAIN`}}",
+    "packer_vcenter_host"      : "{{env `PACKER_VCENTER_HOST`}}",
+    "packer_vcenter_username"  : "{{env `PACKER_VCENTER_USERNAME`}}",
+    "packer_vcenter_password"  : "{{env `PACKER_VCENTER_PASSWORD`}}",
+    "packer_vcenter_dc"        : "{{env `PACKER_VCENTER_DC`}}",
+    "packer_vcenter_cluster"   : "{{env `PACKER_VCENTER_CLUSTER`}}",
+    "packer_vcenter_datastore" : "{{env `PACKER_VCENTER_DATASTORE`}}",
+    "packer_vcenter_folder"    : "{{env `PACKER_VCENTER_FOLDER`}}",
+    "packer_vcenter_net"       : "{{env `PACKER_VCENTER_NET`}}",
+    "packer_vcenter_insecure"  : "{{env `PACKER_VCENTER_INSECURE`}}",
+    "packer_sha"               : "{{env `PACKER_SHA`}}",
+    "packer_source_dir"        : "{{env `PACKER_VM_SRC_DIR`}}",
+    "packer_output_dir"        : "{{env `PACKER_VM_OUT_DIR`}}",
+    "packer_download_dir"      : "C:/Packer/Downloads"
+  },
+
+  "description": "Builds a Windows Server 2008 SP2 template VM for use in VMware. Custom spec needed for this platform",
+
+  "builders": [
+    {
+      "name"              : "{{user `template_name`}}-{{user `provisioner`}}-{{user `template_config`}}",
+      "vm_name"           : "packer-{{build_name}}",
+      "type"              : "vmware-vmx",
+      "source_path"       : "{{user `packer_source_dir`}}/output-{{user `template_name`}}-{{user `provisioner`}}-base/packer-{{user `template_name`}}-{{user `provisioner`}}-base.vmx",
+      "output_directory"  : "{{user `packer_output_dir`}}/output-{{build_name}}",
+
+      "headless"          : "{{user `headless`}}",
+
+      "communicator"      : "winrm",
+      "winrm_username"    : "{{user `winrm_username`}}",
+      "winrm_password"    : "{{user `winrm_password`}}",
+      "winrm_timeout"     : "{{user `winrm_timeout`}}",
+
+      "shutdown_command"  : "{{user `shutdown_command`}}",
+      "shutdown_timeout"  : "{{user `shutdown_timeout`}}",
+
+      "floppy_files": [
+        "../../scripts/windows/bootstrap-base.bat",
+        "../../scripts/windows/cleanup-host.ps1",
+        "../../scripts/windows/install-win-packages.ps1",
+        "../../scripts/windows/install-cygwin.ps1",
+        "../../scripts/windows/cygwin-packages",
+        "../../scripts/windows/gitforwin.inf",
+        "../../scripts/windows/puppet-configure.ps1",
+        "../../scripts/windows/shutdown-packer.bat",
+        "../../scripts/windows/windows-env.ps1",
+        "../../scripts/windows/Low-SecurityPasswordPolicy.inf",
+        "../../scripts/windows/config-winsettings.ps1",
+        "files/shutdown-packer-2008.ps1",
+        "../../scripts/windows/win-site.pp"
+      ],
+
+      "vmx_data": {
+        "gui.fitguestusingnativedisplayresolution" : "FALSE",
+        "annotation"                               : "Packer build: {{user `template_name`}}-{{user `version`}} built {{isotime}} SHA: {{user `packer_sha`}}",
+        "firmware"                                 : "{{user `firmware`}}",
+
+        "guest_os_type"                            : "longhorn-64",
+        "memsize"                                  : "{{user `memsize`}}",
+        "numvcpus"                                 : "{{user `numvcpus`}}",
+        "ethernet0.virtualdev"                     : "vmxnet3",
+        "scsi0.virtualdev"                         : "lsisas1068",
+        "virtualHW.version"                        : "10",
+        "devices.hotplug"                          : "false",
+        "vcpu.hotadd"                              : "TRUE",
+        "mem.hotadd"                               : "TRUE",
+
+
+        "tools.syncTime"                           : "FALSE",
+        "time.synchronize.continue"                : "FALSE",
+        "time.synchronize.restore"                 : "FALSE",
+        "time.synchronize.resume.disk"             : "FALSE",
+        "time.synchronize.shrink"                  : "FALSE",
+        "time.synchronize.tools.startup"           : "FALSE",
+        "time.synchronize.tools.enable"            : "FALSE",
+        "time.synchronize.resume.host"             : "FALSE"
+      }
+    }
+  ],
+  "provisioners": [
+      {
+        "type": "file",
+        "source": "../../manifests/windows/",
+        "destination": "C:\\Packer\\puppet\\modules"
+      },
+      {
+        "type": "file",
+        "source": "../../scripts/windows/init/",
+        "destination": "C:\\Packer\\Init"
+      },
+      {
+        "type": "file",
+        "source": "./tmp/post-clone.autounattend.xml",
+        "destination": "C:\\Packer\\Init\\post-clone.autounattend.xml"
+      },
+    {
+      "type": "powershell",
+      "elevated_user": "{{user `winrm_username`}}",
+      "elevated_password": "{{user `winrm_password`}}",
+      "remote_path": "{{user `packer_download_dir`}}/run-install-win-packages.ps1",
+      "inline": [
+        "A:\\install-win-packages.ps1"
+      ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "powershell",
+      "elevated_user": "{{user `winrm_username`}}",
+      "elevated_password": "{{user `winrm_password`}}",
+      "remote_path": "{{user `packer_download_dir`}}/run-install-cygwin.ps1",
+      "inline": [
+        "A:\\install-cygwin.ps1"
+      ],
+      "environment_vars": [
+        "QA_ROOT_PASSWD={{user `qa_root_passwd`}}"
+      ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "powershell",
+      "elevated_user": "{{user `winrm_username`}}",
+      "elevated_password": "{{user `winrm_password`}}",
+      "remote_path": "{{user `packer_download_dir`}}/run-puppet-configure.ps1",
+      "inline": [
+        "A:\\puppet-configure.ps1 -PackerTemplateName {{user `template_name`}}-{{user `version`}} -PackerSHA '{{user `packer_sha`}}'"
+      ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "powershell",
+      "elevated_user": "{{user `winrm_username`}}",
+      "elevated_password": "{{user `winrm_password`}}",
+      "remote_path": "{{user `packer_download_dir`}}/run-config-winsettings.ps1",
+      "inline": [
+        "A:\\config-winsettings.ps1"
+      ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "powershell",
+      "elevated_user": "{{user `winrm_username`}}",
+      "elevated_password": "{{user `winrm_password`}}",
+      "remote_path": "{{user `packer_download_dir`}}/run-cleanup-host.ps1",
+      "inline": [
+        "A:\\cleanup-host.ps1"
+      ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "powershell",
+      "elevated_user": "{{user `winrm_username`}}",
+      "elevated_password": "{{user `winrm_password`}}",
+      "remote_path": "{{user `packer_download_dir`}}/run-vmpooler-arm-host.ps1",
+      "inline": [
+        "C:\\Packer\\Init\\vmpooler-arm-host.ps1"
+      ]
+    },
+    {
+      "type": "powershell",
+      "elevated_user": "{{user `winrm_username`}}",
+      "elevated_password": "{{user `winrm_password`}}",
+      "remote_path": "{{user `packer_download_dir`}}/run-shutdown-packer.ps1",
+      "inline": [
+        "A:\\shutdown-packer-2008.ps1"
+      ]
+    }
+  ],
+  "post-processors": [
+    {
+      "type": "vsphere",
+      "host": "{{user `packer_vcenter_host`}}",
+      "username": "{{user `packer_vcenter_username`}}",
+      "password": "{{user `packer_vcenter_password`}}",
+      "datacenter": "{{user `packer_vcenter_dc`}}",
+      "cluster": "{{user `packer_vcenter_cluster`}}",
+      "datastore": "{{user `packer_vcenter_datastore`}}",
+      "vm_folder": "{{user `packer_vcenter_folder`}}",
+      "vm_name": "{{user `template_name`}}-{{user `version`}}",
+      "vm_network": "{{user `packer_vcenter_net`}}",
+      "insecure" : "{{user `packer_vcenter_insecure`}}",
+      "overwrite" : "true",
+      "options": [
+        "--X:logLevel=verbose",
+        "--X:logFile={{user `packer_output_dir`}}/ovftool-{{build_name}}.log"
+      ]
+    }
+  ]
+}

--- a/templates/windows-8.1/files/x86_64/platform-packages.ps1
+++ b/templates/windows-8.1/files/x86_64/platform-packages.ps1
@@ -4,3 +4,5 @@ $ErrorActionPreference = "Stop"
 
 Write-Host "Running Win-8.1 Package Customisation"
 
+# Remove Store/Apps packages that break sysprep
+Remove-AppsPackages


### PR DESCRIPTION
The Win-2008 .json file for vsphere.cygwin diverges too much from the
rest of the Windows platforms, so an exception is being made for the
stage 2 build. The base build appears to work ok with the generic .json spec.

Also add the following fixes:
1. IMAGES-647 - Fix winrm issue for Powershell 2 based platforms.
2. Remove Store/App packages for Win-8.1 to resolve Sysprep issue