### PR TITLE
(IMAGES-108) Remove Sound from Systray

### DIFF
--- a/manifests/windows/windows_template/manifests/policies/local_group_policies.pp
+++ b/manifests/windows/windows_template/manifests/policies/local_group_policies.pp
@@ -1,3 +1,5 @@
+# Class to setup local_group_policies for the packer/windows builds
+#
 class windows_template::policies::local_group_policies ()
 {
     # Search Group Policies and find their registry information
@@ -14,125 +16,148 @@ class windows_template::policies::local_group_policies ()
     }
 
     windows_group_policy::local::machine { 'PowerShellExecutionPolicyUnrestricted':
-        key   => 'Software\Policies\Microsoft\Windows\PowerShell',
-        value => 'ExecutionPolicy',
-        data  => 'Unrestricted',
-        type  => 'REG_SZ',
+        key    => 'Software\Policies\Microsoft\Windows\PowerShell',
+        value  => 'ExecutionPolicy',
+        data   => 'Unrestricted',
+        type   => 'REG_SZ',
         notify => Windows_group_policy::Gpupdate['GPUpdate'],
     }
     windows_group_policy::local::machine { 'PowerShellExecutionPolicyEnableScripts':
-        key   => 'Software\Policies\Microsoft\Windows\PowerShell',
-        value => 'EnableScripts',
-        data  => 1,
-        type  => 'REG_DWORD',
+        key    => 'Software\Policies\Microsoft\Windows\PowerShell',
+        value  => 'EnableScripts',
+        data   => 1,
+        type   => 'REG_DWORD',
         notify => Windows_group_policy::Gpupdate['GPUpdate'],
     }
 
     windows_group_policy::local::machine { 'DisableServerManagerAtLogon2012':
-        key   => 'Software\Policies\Microsoft\Windows\Server\ServerManager',
-        value => 'DoNotOpenAtLogon',
-        data  => 1,
-        type  => 'REG_DWORD',
+        key    => 'Software\Policies\Microsoft\Windows\Server\ServerManager',
+        value  => 'DoNotOpenAtLogon',
+        data   => 1,
+        type   => 'REG_DWORD',
         notify => Windows_group_policy::Gpupdate['GPUpdate'],
     }
     windows_group_policy::local::machine { 'DisableServerManagerAtLogon2008':
-        key   => 'Software\Policies\Microsoft\Windows\Server\InitialConfigurationTasks',
-        value => 'DoNotOpenAtLogon',
-        data  => 1,
-        type  => 'REG_DWORD',
+        key    => 'Software\Policies\Microsoft\Windows\Server\InitialConfigurationTasks',
+        value  => 'DoNotOpenAtLogon',
+        data   => 1,
+        type   => 'REG_DWORD',
         notify => Windows_group_policy::Gpupdate['GPUpdate'],
     }
 
     windows_group_policy::local::machine { 'DisableShutdownTracker1':
-        key   => 'Software\Policies\Microsoft\Windows NT\Reliability',
-        value => 'ShutdownReasonOn',
-        data  => 0,
-        type  => 'REG_DWORD',
+        key    => 'Software\Policies\Microsoft\Windows NT\Reliability',
+        value  => 'ShutdownReasonOn',
+        data   => 0,
+        type   => 'REG_DWORD',
         notify => Windows_group_policy::Gpupdate['GPUpdate'],
     }
     windows_group_policy::local::machine { 'DisableShutdownTracker2':
-        key   => 'Software\Policies\Microsoft\Windows NT\Reliability',
-        value => 'ShutdownReasonUI',
-        data  => 0,
-        type  => 'REG_DWORD',
+        key    => 'Software\Policies\Microsoft\Windows NT\Reliability',
+        value  => 'ShutdownReasonUI',
+        data   => 0,
+        type   => 'REG_DWORD',
         notify => Windows_group_policy::Gpupdate['GPUpdate'],
     }
 
     windows_group_policy::local::machine { 'DisableWER':
-        key   => 'Software\Policies\Microsoft\Windows\Windows Error Reporting',
-        value => 'Disabled',
-        data  => 1,
-        type  => 'REG_DWORD',
+        key    => 'Software\Policies\Microsoft\Windows\Windows Error Reporting',
+        value  => 'Disabled',
+        data   => 1,
+        type   => 'REG_DWORD',
         notify => Windows_group_policy::Gpupdate['GPUpdate'],
     }
 
     windows_group_policy::local::machine { 'DisableSystemRestore':
-        key   => 'SOFTWARE\Policies\Microsoft\Windows NT\SystemRestore',
-        value => 'DisableSR',
-        data  => 1,
-        type  => 'REG_DWORD',
+        key    => 'SOFTWARE\Policies\Microsoft\Windows NT\SystemRestore',
+        value  => 'DisableSR',
+        data   => 1,
+        type   => 'REG_DWORD',
         notify => Windows_group_policy::Gpupdate['GPUpdate'],
     }
 
     windows_group_policy::local::user { 'DisableScreenSaver':
-        key   => 'SOFTWARE\Policies\Microsoft\Windows\Control Panel\Desktop',
-        value => 'ScreenSaveActive',
-        data  => 0,
-        type  => 'REG_SZ',
+        key    => 'SOFTWARE\Policies\Microsoft\Windows\Control Panel\Desktop',
+        value  => 'ScreenSaveActive',
+        data   => 0,
+        type   => 'REG_SZ',
         notify => Windows_group_policy::Gpupdate['GPUpdate'],
     }
 
     windows_group_policy::local::user { 'SetClassicDesktop':
-        key   => 'SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System',
-        value => 'SetVisualStyle',
-        data  => '',
-        type  => 'REG_SZ',
+        key    => 'SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System',
+        value  => 'SetVisualStyle',
+        data   => '',
+        type   => 'REG_SZ',
         notify => Windows_group_policy::Gpupdate['GPUpdate'],
     }
     windows_group_policy::local::user { 'SetRunOnStartMenu':
-        key   => 'Software\Microsoft\Windows\CurrentVersion\Policies\Explore',
-        value => 'ForceRunOnStartMenu',
-        data  => 1,
-        type  => 'REG_DWORD',
+        key    => 'Software\Microsoft\Windows\CurrentVersion\Policies\Explore',
+        value  => 'ForceRunOnStartMenu',
+        data   => 1,
+        type   => 'REG_DWORD',
         notify => Windows_group_policy::Gpupdate['GPUpdate'],
     }
     windows_group_policy::local::user { 'SetNoMusic':
-        key   => 'Software\Microsoft\Windows\CurrentVersion\Policies\Explorer',
-        value => 'NoStartMenuMyMusic',
-        data  => 1,
-        type  => 'REG_DWORD',
+        key    => 'Software\Microsoft\Windows\CurrentVersion\Policies\Explorer',
+        value  => 'NoStartMenuMyMusic',
+        data   => 1,
+        type   => 'REG_DWORD',
         notify => Windows_group_policy::Gpupdate['GPUpdate'],
     }
     windows_group_policy::local::user { 'SetNoPictures':
-        key   => 'Software\Microsoft\Windows\CurrentVersion\Policies\Explorer',
-        value => 'NoSMMyPictures',
-        data  => 1,
-        type  => 'REG_DWORD',
-        notify => Windows_group_policy::Gpupdate['GPUpdate'],
-    }
-    windows_group_policy::local::user { 'SetNoWindowsStore':
-        key   => 'Software\Policies\Microsoft\Windows\Explorer',
-        value => 'ShowWindowsStoreAppsOnTaskbar',
-        data  => 2,
-        type  => 'REG_DWORD',
+        key    => 'Software\Microsoft\Windows\CurrentVersion\Policies\Explorer',
+        value  => 'NoSMMyPictures',
+        data   => 1,
+        type   => 'REG_DWORD',
         notify => Windows_group_policy::Gpupdate['GPUpdate'],
     }
     windows_group_policy::local::user { 'ControlPanelAllItems':
-        key   => 'Software\Microsoft\Windows\CurrentVersion\Policies\Explorer',
-        value => 'ForceClassicControlPanel',
-        data  => 1,
-        type  => 'REG_DWORD',
+        key    => 'Software\Microsoft\Windows\CurrentVersion\Policies\Explorer',
+        value  => 'ForceClassicControlPanel',
+        data   => 1,
+        type   => 'REG_DWORD',
         notify => Windows_group_policy::Gpupdate['GPUpdate'],
     }
-
+    # Settings to control notification area - some of these were attempted in the HKCU settings
+    # but are better defined as policy settings (e.g. show all systray notifications)
+    windows_group_policy::local::user { 'VolumeControlIcon':
+        key    => 'Software\Microsoft\Windows\CurrentVersion\Policies\Explorer',
+        value  => 'NoAutoTrayNotify',
+        data   => 1,
+        type   => 'REG_DWORD',
+        notify => Windows_group_policy::Gpupdate['GPUpdate'],
+    }
+    windows_group_policy::local::user { 'ValueHideSCAVolume':
+        key    => 'Software\Microsoft\Windows\CurrentVersion\Policies\Explorer',
+        value  => 'HideSCAVolume',
+        data   => 1,
+        type   => 'REG_DWORD',
+        notify => Windows_group_policy::Gpupdate['GPUpdate'],
+    }
+    windows_group_policy::local::user { 'NoPinningStoreToTaskbar':
+        key    => 'Software\Policies\Microsoft\Windows\Explorer',
+        value  => 'NoPinningStoreToTaskbar',
+        data   => 1,
+        type   => 'REG_DWORD',
+        notify => Windows_group_policy::Gpupdate['GPUpdate'],
+    }
+    windows_group_policy::local::user { 'NoShowWindowsStoreAppsOnTaskbar':
+        key    => 'Software\Policies\Microsoft\Windows\Explorer',
+        value  => 'ShowWindowsStoreAppsOnTaskbar',
+        data   => 2,
+        type   => 'REG_DWORD',
+        notify => Windows_group_policy::Gpupdate['GPUpdate'],
+    }
+ 
     # TODO Update Start Menu 2008 only
 
     # Disable Windows Update
     windows_group_policy::local::machine { 'DisableWindowsUpdate':
-        key   => 'Software\Policies\Microsoft\Windows\WindowsUpdate\AU',
-        value => 'NoAutoUpdate',
-        data  => 1,
-        type  => 'REG_DWORD',
+        key    => 'Software\Policies\Microsoft\Windows\WindowsUpdate\AU',
+        value  => 'NoAutoUpdate',
+        data   => 1,
+        type   => 'REG_DWORD',
         notify => Windows_group_policy::Gpupdate['GPUpdate'],
     }
 

--- a/manifests/windows/windows_template/manifests/registry/machine.pp
+++ b/manifests/windows/windows_template/manifests/registry/machine.pp
@@ -54,7 +54,6 @@ class windows_template::registry::machine ()
         ensure => present,
     }
 
-
     # Disable UAC (Moved from boxstarter script)
     registry::value { 'DisableUAC':
         key   => 'HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System',
@@ -62,6 +61,14 @@ class windows_template::registry::machine ()
         data  => 0,
         type  => 'dword',
     }
+    # Ensure Install MSI As Admin is NOT Disabled.
+    registry::value { 'AdminInstallMSI':
+        key   => 'HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows\\Installer',
+        value => 'DisableMSI',
+        data  => 0,
+        type  => 'dword',
+    }
+    
 
     # Set the following BGInfo Variables using facter provided variables from env
     #VMPOOLER_Build_Date=Build-Date

--- a/manifests/windows/windows_template/manifests/registry/machine.pp
+++ b/manifests/windows/windows_template/manifests/registry/machine.pp
@@ -2,7 +2,7 @@ class windows_template::registry::machine ()
 {
 
     registry::value { 'DebugPolicies':
-        key   => 'HKLM\Software\Microsoft\Windows NT\CurrentVersion\Winlogon',
+        key   => 'HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon',
         value => 'UserEnvDebugLevel',
         data  => 196610,
         type  => 'dword'
@@ -10,19 +10,19 @@ class windows_template::registry::machine ()
 
     # Windows Error Reporting
     registry::value { 'UserModeCrashDumpFolder':
-        key   => 'HKLM\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps',
+        key   => 'HKLM\\SOFTWARE\\Microsoft\\Windows\\Windows Error Reporting\\LocalDumps',
         value => 'DumpFolder',
-        data  => 'C:\crash_dumps',
+        data  => 'C:\\crash_dumps',
         type  => 'expand'
     }
     registry::value { 'UserModeCrashDumpCount':
-        key   => 'HKLM\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps',
+        key   => 'HKLM\\SOFTWARE\\Microsoft\\Windows\\Windows Error Reporting\\LocalDumps',
         value => 'DumpCount',
         data  => 10,
         type  => 'dword'
     }
     registry::value { 'UserModeCrashDumpType':
-        key   => 'HKLM\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps',
+        key   => 'HKLM\\SOFTWARE\\Microsoft\\Windows\\Windows Error Reporting\\LocalDumps',
         value => 'DumpType',
         data  => 2,
         type  => 'dword'
@@ -36,14 +36,14 @@ class windows_template::registry::machine ()
 
     # Disable IE ESC for admins
     registry::value { 'DisableIEESCForAdmins':
-        key   => 'HKLM\SOFTWARE\Microsoft\Active Setup\Installed Components\{A509B1A7-37EF-4b3f-8CFC-4F3A74704073}',
+        key   => 'HKLM\\SOFTWARE\\Microsoft\\Active Setup\\Installed Components\\{A509B1A7-37EF-4b3f-8CFC-4F3A74704073}',
         value => 'IsInstalled',
         data  => 0,
         type  => 'dword'
     }
     # Disable IE ESC for non-admins
     registry::value { 'DisableIEESCForNonAdmins':
-        key   => 'HKLM\SOFTWARE\Microsoft\Active Setup\Installed Components\{A509B1A8-37EF-4b3f-8CFC-4F3A74704073}',
+        key   => 'HKLM\\SOFTWARE\\Microsoft\\Active Setup\\Installed Components\\{A509B1A8-37EF-4b3f-8CFC-4F3A74704073}',
         value => 'IsInstalled',
         data  => 0,
         type  => 'dword',
@@ -57,7 +57,7 @@ class windows_template::registry::machine ()
 
     # Disable UAC (Moved from boxstarter script)
     registry::value { 'DisableUAC':
-        key   => 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System',
+        key   => 'HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System',
         value => 'EnableLUA',
         data  => 0,
         type  => 'dword',
@@ -68,25 +68,25 @@ class windows_template::registry::machine ()
     #VMPOOLER_Packer_SHA=124214215215215235
     #VMPOOLER_Packer_Template=Packer_Template_Name & type
     registry::value { 'VMPOOLER_Build_Date':
-        key   => 'HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment',
+        key   => 'HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment',
         value => 'VMPOOLER_Build_Date',
         data  => "${build_date}",
         type  => 'string'
     }
     registry::value { 'VMPOOLER_Packer_SHA':
-        key   => 'HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment',
+        key   => 'HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment',
         value => 'VMPOOLER_Packer_SHA',
         data  => "${packer_sha}",
         type  => 'string'
     }
     registry::value { 'VMPOOLER_Packer_Template':
-        key   => 'HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment',
+        key   => 'HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment',
         value => 'VMPOOLER_Packer_Template',
         data  => "${packer_template_name}",
         type  => 'string'
     }
     registry::value { 'VMPOOLER_Packer_Template_Type':
-        key   => 'HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment',
+        key   => 'HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment',
         value => 'VMPOOLER_Packer_Template_Type',
         data  => "${packer_template_type}",
         type  => 'string'
@@ -102,17 +102,19 @@ class windows_template::registry::machine ()
     #
     if ( "${windows_install_option}" == 'Core' ) {
         registry::value { 'WinCoreLogon':
-          key   => 'HKLM\Software\Microsoft\Windows NT\CurrentVersion\Winlogon',
+          key   => 'HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon',
           value => 'Shell',
           data  => 'explorer.exe',
-          type  => 'string'
+          type  => 'string',
+
         }
     }
+
     if ("$::operatingsystemrelease" == '2008R2') {
       # WMF5 on 2008R2 causes an issue with sysprep, so set this registry key
       # https://social.technet.microsoft.com/Forums/en-US/a37d2158-1b8b-412e-ad49-02fe0ba573c2/sysprep-fails-on-windows-2008-r2-after-installing-windows-management-framework-50?forum=mdt
       registry::value { 'WMFStreamProvider':
-          key   => 'HKLM\SOFTWARE\Microsoft\Windows\StreamProvider',
+          key   => 'HKLM\\SOFTWARE\\Microsoft\\Windows\\StreamProvider',
           value => 'LastFullPayloadTime',
           data  => 0,
           type  => 'dword'

--- a/manifests/windows/windows_template/manifests/registry/user.pp
+++ b/manifests/windows/windows_template/manifests/registry/user.pp
@@ -53,12 +53,12 @@ class windows_template::registry::user ()
     type  => 'dword',
   }
 
-  # Icon Notification Tray - enable all notifications for the moment.
-  # Setting as per spec is tricky (see RE-7692)
-  registry::value { 'Explorer_':
-    key   => 'HKLM\\DEFUSER\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer',
-    value => 'EnableAutoTray',
-    data  => 0,
+  # Switch off Remove all Devices on Taskbar
+  # reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\Applets\SysTray" /v "Services" /t reg_dword /d 29 /f
+  registry::value { 'Notifications_RemoveDevices':
+    key   => 'HKLM\\DEFUSER\\Software\\Microsoft\\Windows\\CurrentVersion\\Applets\\SysTray',
+    value => 'Services',
+    data  => 29,
     type  => 'dword',
   }
 

--- a/scripts/windows/core-shutdown.ps1
+++ b/scripts/windows/core-shutdown.ps1
@@ -9,10 +9,6 @@ Param(
 
 if ($UseStartupWorkaround) {
     Write-Warning "Cleaning up PowerShell profile workaround for startup items"
-
-    Remove-ItemProperty `
-            -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" `
-            -Name Shell
     Remove-Item -Force $PROFILE
 }
 

--- a/templates/win-common/vmware.vsphere.cygwin.json
+++ b/templates/win-common/vmware.vsphere.cygwin.json
@@ -193,8 +193,10 @@
       "overwrite" : "true",
       "options": [
         "--X:logLevel=verbose",
-        "--X:logFile={{user `packer_output_dir`}}/ovftool-{{build_name}}.log"
-      ]
+        "--X:logFile={{user `packer_output_dir`}}/ovftool-{{build_name}}.log",
+        "--allowAllExtraConfig",
+        "--allowExtraConfig",
+        "--extraConfig:devices.hotplug=false"      ]
     }
   ]
 }


### PR DESCRIPTION
Remove the Sound/Volume control from the System tray and generally tidy up the Taskbar and System Tray area with a few other small maintenance fixes:
1. Ensure devices.hotplug is set to false for exported VM so that Device Removal Icon is not displayed.
2. Fix an issue with win-2012r2-core and win-2016-core that blocked RunOnce running at post-clone
3. Ensure that Adminstrator can install MSI (IMAGES-599)