### PR TITLE
(IMAGES-656) Create a RHEL7 FIPS mode packer image

### DIFF
--- a/manifests/modules/packer/manifests/networking/params.pp
+++ b/manifests/modules/packer/manifests/networking/params.pp
@@ -7,38 +7,44 @@ class packer::networking::params {
     }
 
     redhat: {
-      case $::operatingsystemrelease {
-        '7.0.1406', '7.1.1503', '7.2.1511', '7.2': {
-          case $::provisioner {
-            'virtualbox','libvirt': { $interface_script = '/etc/sysconfig/network-scripts/ifcfg-enp0s3' }
-            'vmware':     { $interface_script = '/etc/sysconfig/network-scripts/ifcfg-ens33' }
-          }
 
-          $udev_rule     = '/etc/udev/rules.d/70-persistent-net.rules'
-          $udev_rule_gen = '/lib/udev/rules.d/75-persistent-net-generator.rules'
-        }
+       case $::operatingsystemrelease {
+         '7.0.1406', '7.1.1503', '7.2.1511', '7.2': {
+           case $::provisioner {
+             'virtualbox','libvirt': { $interface_script = '/etc/sysconfig/network-scripts/ifcfg-enp0s3' }
+             'vmware':     { $interface_script = '/etc/sysconfig/network-scripts/ifcfg-ens33' }
+           }
+ 
+           $udev_rule     = '/etc/udev/rules.d/70-persistent-net.rules'
+           $udev_rule_gen = '/lib/udev/rules.d/75-persistent-net-generator.rules'
+         }
 
-        '5.11': {
-          $interface_script = '/etc/sysconfig/network-scripts/ifcfg-eth0'
-          $udev_rule        = '/etc/udev/rules.d/70-persistent-net.rules'
-        }
-
-        '23', '24', '25', '26': {
-          case $::provisioner {
-            'virtualbox': { $interface_script = '/etc/sysconfig/network-scripts/ifcfg-enp0s3' }
-            'libvirt': { $interface_script = '/etc/sysconfig/network-scripts/ifcfg-ens4' }
-            'vmware':     { $interface_script = '/etc/sysconfig/network-scripts/ifcfg-ens32' }
-          }
-          $udev_rule     = undef
-          $udev_rule_gen = undef
-        }
-
-        default: {
-          $interface_script = '/etc/sysconfig/network-scripts/ifcfg-eth0'
-          $udev_rule        = '/etc/udev/rules.d/70-persistent-net.rules'
-          $udev_rule_gen    = '/lib/udev/rules.d/75-persistent-net-generator.rules'
-        }
-      }
+         '7.0': {
+           $interface_script = '/etc/sysconfig/network-scripts/ifcfg-ens33'
+           $udev_rule        = '/etc/udev/rules.d/70-persistent-net.rules'
+         }
+ 
+         '5.11': {
+           $interface_script = '/etc/sysconfig/network-scripts/ifcfg-eth0'
+           $udev_rule        = '/etc/udev/rules.d/70-persistent-net.rules'
+         }
+ 
+         '23', '24', '25', '26': {
+           case $::provisioner {
+             'virtualbox': { $interface_script = '/etc/sysconfig/network-scripts/ifcfg-enp0s3' }
+             'libvirt': { $interface_script = '/etc/sysconfig/network-scripts/ifcfg-ens4' }
+             'vmware':     { $interface_script = '/etc/sysconfig/network-scripts/ifcfg-ens32' }
+           }
+           $udev_rule     = undef
+           $udev_rule_gen = undef
+         }
+ 
+         default: {
+           $interface_script = '/etc/sysconfig/network-scripts/ifcfg-eth0'
+           $udev_rule        = '/etc/udev/rules.d/70-persistent-net.rules'
+           $udev_rule_gen    = '/lib/udev/rules.d/75-persistent-net-generator.rules'
+         }
+       }
     }
     suse: {
       $interface_script = '/etc/sysconfig/network/ifcfg-eth0'

--- a/scripts/enable-rhel-repos.sh
+++ b/scripts/enable-rhel-repos.sh
@@ -1,0 +1,35 @@
+
+# Script to provision Red Hat repos 
+
+redhat_repos="/etc/yum.repos.d/redhat.repo"
+
+repo_template=$'[rhel7-template]
+name=Red Hat Enterprise Linux 7 - $basearch OptRepoName
+baseurl=http://osmirror.delivery.puppetlabs.net/rhel7latestserver-x86_64/RPMS.template/
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+
+'
+
+repos=("os" "updates" "optional" "extras")
+repo_names=("" "" "- Optional" "- Extras")
+
+num_repos=${#repos[@]}
+
+# Generate the repo's from the template while adjusting their urls, names and enable state
+for (( i=1; i<${num_repos}+1; i++ ));
+do
+	repo_str=`echo "$repo_template" | sed "s/template/${repos[$i-1]}/g"` 
+	named_repo_str=`echo "$repo_str" | sed "s/OptRepoName/${repo_names[$i-1]}/g"` 
+	if [ "${repos[$i-1]}" == "extras" ]; then
+		final_repo_str=`echo "$named_repo_str" | sed "s/enabled=1/enabled=0/g"` 
+	else
+		final_repo_str=$named_repo_str 
+	fi
+
+	echo "$final_repo_str" >> $redhat_repos
+	echo "" >> $redhat_repos
+done
+
+

--- a/scripts/enable_fips.sh
+++ b/scripts/enable_fips.sh
@@ -1,0 +1,55 @@
+
+# Script to enable FIPS on a centos. This has been tested on a centos7 till.
+
+# Step 1: Disable PRELINKING.
+
+if [ ! -f /etc/sysconfig/prelink ]; then
+    echo "PRELINKING=no" > /etc/sysconfig/prelink
+else
+    echo "PRELINKING=no" >> /etc/sysconfig/prelink
+fi
+
+
+if [ -f /usr/sbin/prelink ]; then
+    prelink -u -a
+fi
+
+# Step 1.5: Experimental 
+# Install updated version of system openssl that is aligned with what gets installed
+# as part of openssl-devel install
+yum -y install openssl-1.0.2k-8.el7.x86_64
+
+# Step 2: Install dracut-fips and dracut-fips-aesni packages
+
+yum -y install dracut-fips
+yum -y install dracut-fips-aesni
+
+# Step 3: Find out the device details (BLOCK ID) of boot partition
+boot_blkid=$(blkid `df /boot | grep "/dev" | awk 'BEGIN{ FS=" "}; {print $1}'` | awk 'BEGIN{ FS=" "}; {print $2}' | sed 's/"//g')
+
+init_ramfs="/boot/initramfs-2.6.32-358.el6.x86_64.img"
+
+# Step 4: Backup initramfs image and run dracut -v -f
+
+#cp $init_ramfs "$init_ramfs".back
+
+dracut -v -f
+
+
+# Step 5: Manipulate /etc/default/grub to enable FIPs 
+grub_file="/etc/default/grub"
+
+fips_bootblk="fips=1 boot="$boot_blkid
+grub_linux_cmdline=`grep -e "^GRUB_CMDLINE_LINUX" $grub_file | sed "s/\"$/ $fips_bootblk\"/"`
+
+
+grep -v GRUB_CMDLINE_LINUX $grub_file > "$grub_file".bak; cp $grub_file.bak $grub_file
+
+# Now bring in the modified line back
+sed -i "/GRUB_DISABLE_RECOVERY/i \
+  $grub_linux_cmdline" $grub_file
+
+# Step 6: Generate /etc/grub2.cfg
+grub2-mkconfig -o /boot/grub2/grub.cfg 
+
+

--- a/templates/rhel-7.2/calc_hash.rb
+++ b/templates/rhel-7.2/calc_hash.rb
@@ -1,0 +1,36 @@
+require 'digest/sha2'
+require 'digest/md5'
+
+
+# Perform an incremental checksum on a file.
+def checksum_file(digest, filename, lite = false)
+  buffer = lite ? 512 : 4096
+  File.open(filename, 'rb') do |file|
+    while content = file.read(buffer)
+      digest << content
+      break if lite
+    end
+  end
+
+  digest.hexdigest
+end
+
+
+file = ARGV[0]
+hash_alg = ARGV[1]
+
+puts "filename: " + file
+puts "hash algorithm: " + hash_alg
+
+if hash_alg == "sha256"
+  digest = Digest::SHA256.new
+elsif hash_alg == "md5"
+  digest = Digest::MD5.new
+else
+  puts "Unsupport hash algorithm"
+  exit
+end
+
+file_hash_result = checksum_file(digest, file)
+
+puts "File digest: " + file_hash_result

--- a/templates/rhel-7.2/files/x86_64.ks
+++ b/templates/rhel-7.2/files/x86_64.ks
@@ -1,0 +1,41 @@
+install
+cdrom
+lang en_US.UTF-8
+keyboard us
+network --bootproto=dhcp
+rootpw --iscrypted $1$v4K9E8Wj$gZIHJ5JtQL5ZGZXeqSSsd0
+firewall --enabled --service=ssh
+authconfig --enableshadow --passalgo=sha512
+selinux --disabled
+timezone UTC
+bootloader --location=mbr
+
+text
+skipx
+zerombr
+
+clearpart --all --initlabel
+autopart
+
+auth  --useshadow  --enablemd5
+firstboot --disabled
+reboot --eject
+
+%packages --ignoremissing
+@core
+bzip2
+kernel-devel
+kernel-headers
+gcc
+make
+net-tools
+patch
+perl
+curl
+wget
+nfs-utils
+-ipw2100-firmware
+-ipw2200-firmware
+-ivtv-firmware
+%end
+

--- a/templates/rhel-7.2/x86_64.vmware.base.json
+++ b/templates/rhel-7.2/x86_64.vmware.base.json
@@ -1,0 +1,96 @@
+{
+
+  "variables":
+    {
+      "template_name": "redhat-7.2-x86_64",
+      "template_os": "rhel7-64",
+
+      "iso_url": "http://osmirror.delivery.puppetlabs.net/iso/rhel-server-7.0-x86_64-dvd.iso",
+      "iso_checksum": "85a9fedc2bf0fc825cc7817056aa00b3ea87d7e111e0cf8de77d3ba643f8646c",
+      "iso_checksum_type": "sha256",
+
+      "memory_size": "512",
+      "cpu_count": "1",
+
+      "provisioner": "vmware",
+      "required_modules": "puppetlabs-stdlib saz-ssh",
+      "puppet_aio": "http://yum.puppetlabs.com/el/7/PC1/x86_64/puppet-agent-1.10.9-1.el7.x86_64.rpm",
+
+      "output_directory": "{{env `OUTPUT_DIRECTORY`}}"
+
+    },
+
+  "builders": [
+    {
+      "name": "{{user `template_name`}}-{{user `provisioner`}}",
+      "output_directory": "{{user `output_directory`}}output-{{build_name}}",
+      "type": "vmware-iso",
+      "headless": true,
+      "boot_command": [
+        "<tab> <wait>",
+        "text <wait>",
+        "ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/x86_64.ks <wait>",
+        "<enter>"
+      ],
+      "boot_wait": "45s",
+      "disk_size": 20480,
+      "guest_os_type": "{{user `template_os`}}",
+      "http_directory": "files",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `iso_url`}}",
+      "ssh_username": "root",
+      "ssh_password": "puppet",
+      "ssh_port": 22,
+      "ssh_pty": true,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "/sbin/halt -h -p",
+      "tools_upload_flavor": "linux",
+      "vmx_data": {
+        "memsize": "{{user `memory_size`}}",
+        "numvcpus": "{{user `cpu_count`}}",
+        "cpuid.coresPerSocket": "1"
+      }
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type": "shell",
+      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_AIO={{user `puppet_aio`}}"
+      ],
+      "scripts": [
+        "../../scripts/enable-rhel-repos.sh",
+        "../../scripts/bootstrap-aio.sh",
+        "../../scripts/enable_fips.sh"
+      ]
+    },
+
+    {
+      "type": "puppet-masterless",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppetlabs/bin /opt/puppetlabs/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "facter": {
+        "provisioner": "{{user `provisioner`}}"
+      },
+      "manifest_dir": "../../manifests",
+      "manifest_file": "../../manifests/base.pp"
+    },
+
+    {
+      "type": "shell",
+      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_AIO={{user `puppet_aio`}}"
+      ],
+      "scripts": [
+        "../../scripts/cleanup-aio.sh",
+        "../../scripts/cleanup-packer.sh"
+      ]
+    }
+  ]
+
+}

--- a/templates/rhel-7.2/x86_64.vmware.vsphere.nocm.json
+++ b/templates/rhel-7.2/x86_64.vmware.vsphere.nocm.json
@@ -1,0 +1,115 @@
+{
+
+  "variables":
+    {
+      "template_name": "redhat-7.2-x86_64",
+      "version": "0.0.3",
+
+      "provisioner": "vmware",
+      "required_modules": "puppetlabs-stdlib example42-network puppetlabs-firewall",
+      "puppet_aio": "http://yum.puppetlabs.com/el/7/PC1/x86_64/puppet-agent-1.10.9-1.el7.x86_64.rpm",
+      "qa_root_passwd": "{{env `QA_ROOT_PASSWD`}}",
+      "packer_vcenter_host": "{{env `PACKER_VCENTER_HOST`}}",
+      "packer_vcenter_username": "{{env `PACKER_VCENTER_USERNAME`}}",
+      "packer_vcenter_password": "{{env `PACKER_VCENTER_PASSWORD`}}",
+      "packer_vcenter_dc": "{{env `PACKER_VCENTER_DC`}}",
+      "packer_vcenter_cluster": "{{env `PACKER_VCENTER_CLUSTER`}}",
+      "packer_vcenter_datastore": "{{env `PACKER_VCENTER_DATASTORE`}}",
+      "packer_vcenter_folder": "{{env `PACKER_VCENTER_FOLDER`}}",
+      "packer_vcenter_net": "{{env `PACKER_VCENTER_NET`}}",
+      "packer_vcenter_insecure": "{{env `PACKER_VCENTER_INSECURE`}}",
+
+      "memory_size": "4096",
+      "cpu_count": "2",
+
+      "output_directory": "{{env `OUTPUT_DIRECTORY`}}"
+
+
+    },
+
+  "builders": [
+    {
+      "name": "{{user `template_name`}}-{{user `provisioner`}}-vsphere-nocm",
+      "vm_name": "packer-{{build_name}}",
+      "type": "vmware-vmx",
+      "headless": true,
+      "source_path": "{{user `output_directory`}}output-{{user `template_name`}}-{{user `provisioner`}}/packer-{{user `template_name`}}-{{user `provisioner`}}.vmx",
+      "ssh_username": "root",
+      "ssh_password": "puppet",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "/sbin/halt -h -p",
+      "vmx_data": {
+        "annotation": "{{user `template_name`}} built {{isotime}}"
+      },
+      "vmx_data_post": {
+        "memsize": "{{user `memory_size`}}",
+        "numvcpus": "{{user `cpu_count`}}",
+        "cpuid.coresPerSocket": "1",
+        "ethernet0.virtualDev": "vmxnet3"
+      }
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type": "shell",
+      "execute_command": "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_AIO={{user `puppet_aio`}}"
+      ],
+      "scripts": [
+        "../../scripts/enable-rhel-repos.sh",
+        "../../scripts/bootstrap-aio.sh",
+        "../../scripts/enable_fips.sh"
+      ]
+    },
+
+    {
+      "type": "file",
+      "source": "../../hiera",
+      "destination": "/tmp/packer-puppet-masterless"
+    },
+
+    {
+      "type": "puppet-masterless",
+      "execute_command": "{{.FacterVars}} PATH=$PATH:/opt/puppetlabs/bin /opt/puppetlabs/bin/puppet apply --verbose --detailed-exitcodes --hiera_config='/tmp/packer-puppet-masterless/hiera/hiera.yaml' --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "facter": {
+        "provisioner": "{{user `provisioner`}}",
+        "qa_root_passwd": "{{user `qa_root_passwd`}}"
+      },
+      "manifest_dir": "../../manifests",
+      "manifest_file": "../../manifests/vsphere/nocm.pp"
+    },
+
+    {
+      "type": "shell",
+      "environment_vars": [
+        "TEMPLATE={{user `template_name`}}",
+        "PUPPET_AIO={{user `puppet_aio`}}"
+      ],
+      "scripts": [
+        "../../scripts/cleanup-aio.sh",
+        "../../scripts/cleanup-packer.sh",
+        "../../scripts/cleanup-scrub.sh"
+      ]
+    }
+  ],
+
+  "post-processors": [
+    {
+      "type": "vsphere",
+      "host": "{{user `packer_vcenter_host`}}",
+      "username": "{{user `packer_vcenter_username`}}",
+      "password": "{{user `packer_vcenter_password`}}",
+      "datacenter": "{{user `packer_vcenter_dc`}}",
+      "cluster": "{{user `packer_vcenter_cluster`}}",
+      "datastore": "{{user `packer_vcenter_datastore`}}",
+      "vm_folder": "{{user `packer_vcenter_folder`}}",
+      "vm_name": "{{user `template_name`}}-{{user `version`}}",
+      "vm_network": "{{user `packer_vcenter_net`}}",
+      "insecure" : "{{user `packer_vcenter_insecure`}}"
+    }
+  ]
+}


### PR DESCRIPTION
Created new rhel7 template with required scripts to configure it to
  - Enable repo's to be able install packages.
  - Boot in FIPS mode and
  - Install openssl package version aligned with that of openssl-devel

This is installing the currently available version 1.9.3 of puppet agent.
Repo enabling is being done using a script which in future could be
reworked to be done via puppet manifest (vsphere/repos.pp)
Note: Step for loading the image in vsphere is still remaining. 