### PR TITLE
(IMAGES-88) Vagrant and Other Packer/Windows Build Cleanup

### DIFF
--- a/manifests/windows/windows_template/manifests/apps/chrome.pp
+++ b/manifests/windows/windows_template/manifests/apps/chrome.pp
@@ -3,8 +3,8 @@
 class windows_template::apps::chrome()
 {
   file { "${::chrome_root}\\Application\\master_preferences":
-    owner  => 'Administrator',
-    group  => 'Administrator',
+    owner  => "${::administrator_sid}",
+    group  => "${::administrator_grp_sid}",
     mode   => '0775',
     source => "${::modules_path}\\windows_template\\files\\master_preferences",
   }

--- a/manifests/windows/windows_template/manifests/policies/local_group_policies.pp
+++ b/manifests/windows/windows_template/manifests/policies/local_group_policies.pp
@@ -220,134 +220,139 @@ class windows_template::policies::local_group_policies ()
         notify => Windows_group_policy::Gpupdate['GPUpdate'],
     }
 
-    # Mostly Win-10 policies.
-    #  1. Turn off Tile Notifications
-    windows_group_policy::local::user { 'NotileApplicationNotification':
-        key    => 'Software\Policies\Microsoft\Windows\CurrentVersion\Pushnotifications',
-        value  => 'NotileApplicationNotification',
-        data   => 0,
-        type   => 'REG_DWORD',
-        notify => Windows_group_policy::Gpupdate['GPUpdate'],
+    # Screen out these policies for anything earlier than Win-2012r2
+    #
+    if ("$::kernelmajversion" > '6.1' ) {
+        # Mostly Win-10 policies.
+        #  1. Turn off Tile Notifications
+        windows_group_policy::local::user { 'NotileApplicationNotification':
+            key    => 'Software\Policies\Microsoft\Windows\CurrentVersion\Pushnotifications',
+            value  => 'NotileApplicationNotification',
+            data   => 0,
+            type   => 'REG_DWORD',
+            notify => Windows_group_policy::Gpupdate['GPUpdate'],
+        }
+        #  2. Clear Tile Notifications at login
+        windows_group_policy::local::user { 'CleartilesOnExit':
+            key    => 'Software\Policies\Microsoft\Windows\Explorer',
+            value  => 'CleartilesOnExit',
+            data   => 1,
+            type   => 'REG_DWORD',
+            notify => Windows_group_policy::Gpupdate['GPUpdate'],
+        }
+        #  3. Computer Configuration > Administrative Templates > Windows Components > Cloud Content "Turn off Microsoft consumer Experience"
+        windows_group_policy::local::machine { 'DisableWindowsConsumerFeatures':
+            key    => 'Software\Policies\microsoft\Windows\CloudContent',
+            value  => 'DisableWindowsConsumerFeatures',
+            data   => 0,
+            type   => 'REG_DWORD',
+            notify => Windows_group_policy::Gpupdate['GPUpdate'],
+        }
+        #  4. User - Cloud Content urn off the Windows Welcome Experience - Enabled
+        windows_group_policy::local::user { 'DisableWindowsSpotlightWindowswelcomeexperience':
+            key    => 'Software\Policies\Microsoft\Windows\CloudContent',
+            value  => 'DisableWindowsSpotlightWindowswelcomeexperience',
+            data   => 1,
+            type   => 'REG_DWORD',
+            notify => Windows_group_policy::Gpupdate['GPUpdate'],
+        }
+        #  5. User Cloud content Do not suggest Third-party-content
+        windows_group_policy::local::user { 'DisablethirdpartySuggestions':
+            key    => 'Software\Policies\Microsoft\Windows\CloudContent',
+            value  => 'DisablethirdpartySuggestions',
+            data   => 1,
+            type   => 'REG_DWORD',
+            notify => Windows_group_policy::Gpupdate['GPUpdate'],
+        }
+        #  6. Windows components - Prevent the usage of OneDrive for file storage
+        windows_group_policy::local::machine { 'DisableFileSyncNGSC':
+            key    => 'Software\Policies\Microsoft\Windows\onedrive',
+            value  => 'DisableFileSyncNGSC',
+            data   => 1,
+            type   => 'REG_DWORD',
+            notify => Windows_group_policy::Gpupdate['GPUpdate'],
+        }
+        #  7. Microsoft Edge - Configure Start Page About:blank
+        windows_group_policy::local::user { 'EdgeProvisionedHomePages':
+            key    => 'Software\Policies\microsoft\microsoftedge\Internet Settings',
+            value  => 'ProvisionedHomePages',
+            data   => 'about:blank',
+            type   => 'REG_SZ',
+            notify => Windows_group_policy::Gpupdate['GPUpdate'],
+        }
+        #  8. Turn off Windows Defender Antivirus
+        windows_group_policy::local::machine { 'DisableWindowsDefender':
+            key    => 'Software\Policies\Microsoft\Windows Defender',
+            value  => 'DisableAntiSpyware',
+            data   => 1,
+            type   => 'REG_DWORD',
+            notify => Windows_group_policy::Gpupdate['GPUpdate'],
+        }
+        #  9. Turn off Desktop Gadgets
+        windows_group_policy::local::machine { 'DisableDesktopGadgets':
+            key    => 'Software\Microsoft\Windows\CurrentVersion\Policies\Windows\Sidebar',
+            value  => 'TurnOffSidebar',
+            data   => 1,
+            type   => 'REG_DWORD',
+            notify => Windows_group_policy::Gpupdate['GPUpdate'],
+        }
+        # 10. Use Solid colour for start background
+        windows_group_policy::local::machine { 'UseWindowsSolidColour':
+            key    => 'Software\Policies\Microsoft\Windows\DWM',
+            value  => 'DisableAccentGradient',
+            data   => 1,
+            type   => 'REG_DWORD',
+            notify => Windows_group_policy::Gpupdate['GPUpdate'],
+        }
+        # 11. Do not allow windows animations
+        windows_group_policy::local::machine { 'Disallowanimations':
+            key    => 'Software\Policies\Microsoft\Windows\DWM',
+            value  => 'Disallowanimations',
+            data   => 1,
+            type   => 'REG_DWORD',
+            notify => Windows_group_policy::Gpupdate['GPUpdate'],
+        }
+        # 12. Turn off Sync Updates
+        windows_group_policy::local::machine { 'DontSyncWindows8AppSettings':
+            key    => 'Software\Policies\Microsoft\UEV\Agent\Configuration',
+            value  => 'DontSyncWindows8AppSettings',
+            data   => 1,
+            type   => 'REG_DWORD',
+            notify => Windows_group_policy::Gpupdate['GPUpdate'],
+        }
+        # 13. Turn off location - Leave
+        # 14. Allow Cortana - DISABLE
+        windows_group_policy::local::machine { 'AllowCortana':
+            key    => 'Software\Policies\Microsoft\Windows\Windows Search',
+            value  => 'AllowCortana',
+            data   => 0,
+            type   => 'REG_DWORD',
+            notify => Windows_group_policy::Gpupdate['GPUpdate'],
+        }
+        # 15. Turn off Store Application
+        windows_group_policy::local::machine { 'DisablestoreApps':
+            key    => 'Software\Policies\Microsoft\Windowsstore',
+            value  => 'DisablestoreApps',
+            data   => 1,
+            type   => 'REG_DWORD',
+            notify => Windows_group_policy::Gpupdate['GPUpdate'],
+        }
+        # 16. Turn off offer to update to latest version of windows
+        windows_group_policy::local::machine { 'DisableOSUpgrade':
+            key    => 'Software\Policies\Microsoft\WindowsStore',
+            value  => 'DisableOSUpgrade',
+            data   => 1,
+            type   => 'REG_DWORD',
+            notify => Windows_group_policy::Gpupdate['GPUpdate'],
+        }
+        # 17. Remove Games from Start Menu
+        windows_group_policy::local::user { 'NoStartMenuMyGames':
+            key    => 'Software\Microsoft\Windows\CurrentVersion\Policies\Explorer',
+            value  => 'NoStartMenuMyGames',
+            data   => 1,
+            type   => 'REG_DWORD',
+            notify => Windows_group_policy::Gpupdate['GPUpdate'],
+        }
     }
-    #  2. Clear Tile Notifications at login
-    windows_group_policy::local::user { 'CleartilesOnExit':
-        key    => 'Software\Policies\Microsoft\Windows\Explorer',
-        value  => 'CleartilesOnExit',
-        data   => 1,
-        type   => 'REG_DWORD',
-        notify => Windows_group_policy::Gpupdate['GPUpdate'],
-    }
-    #  3. Computer Configuration > Administrative Templates > Windows Components > Cloud Content "Turn off Microsoft consumer Experience"
-    windows_group_policy::local::machine { 'DisableWindowsConsumerFeatures':
-        key    => 'Software\Policies\microsoft\Windows\CloudContent',
-        value  => 'DisableWindowsConsumerFeatures',
-        data   => 0,
-        type   => 'REG_DWORD',
-        notify => Windows_group_policy::Gpupdate['GPUpdate'],
-    }
-    #  4. User - Cloud Content urn off the Windows Welcome Experience - Enabled
-    windows_group_policy::local::user { 'DisableWindowsSpotlightWindowswelcomeexperience':
-        key    => 'Software\Policies\Microsoft\Windows\CloudContent',
-        value  => 'DisableWindowsSpotlightWindowswelcomeexperience',
-        data   => 1,
-        type   => 'REG_DWORD',
-        notify => Windows_group_policy::Gpupdate['GPUpdate'],
-    }
-    #  5. User Cloud content Do not suggest Third-party-content
-    windows_group_policy::local::user { 'DisablethirdpartySuggestions':
-        key    => 'Software\Policies\Microsoft\Windows\CloudContent',
-        value  => 'DisablethirdpartySuggestions',
-        data   => 1,
-        type   => 'REG_DWORD',
-        notify => Windows_group_policy::Gpupdate['GPUpdate'],
-    }
-    #  6. Windows components - Prevent the usage of OneDrive for file storage
-    windows_group_policy::local::machine { 'DisableFileSyncNGSC':
-        key    => 'Software\Policies\Microsoft\Windows\onedrive',
-        value  => 'DisableFileSyncNGSC',
-        data   => 1,
-        type   => 'REG_DWORD',
-        notify => Windows_group_policy::Gpupdate['GPUpdate'],
-    }
-    #  7. Microsoft Edge - Configure Start Page About:blank
-    windows_group_policy::local::user { 'EdgeProvisionedHomePages':
-        key    => 'Software\Policies\microsoft\microsoftedge\Internet Settings',
-        value  => 'ProvisionedHomePages',
-        data   => 'about:blank',
-        type   => 'REG_SZ',
-        notify => Windows_group_policy::Gpupdate['GPUpdate'],
-    }
-    #  8. Turn off Windows Defender Antivirus
-    windows_group_policy::local::machine { 'DisableWindowsDefender':
-        key    => 'Software\Policies\Microsoft\Windows Defender',
-        value  => 'DisableAntiSpyware',
-        data   => 1,
-        type   => 'REG_DWORD',
-        notify => Windows_group_policy::Gpupdate['GPUpdate'],
-    }
-    #  9. Turn off Desktop Gadgets
-    windows_group_policy::local::machine { 'DisableDesktopGadgets':
-        key    => 'Software\Microsoft\Windows\CurrentVersion\Policies\Windows\Sidebar',
-        value  => 'TurnOffSidebar',
-        data   => 1,
-        type   => 'REG_DWORD',
-        notify => Windows_group_policy::Gpupdate['GPUpdate'],
-    }
-    # 10. Use Solid colour for start background
-    windows_group_policy::local::machine { 'UseWindowsSolidColour':
-        key    => 'Software\Policies\Microsoft\Windows\DWM',
-        value  => 'DisableAccentGradient',
-        data   => 1,
-        type   => 'REG_DWORD',
-        notify => Windows_group_policy::Gpupdate['GPUpdate'],
-    }
-    # 11. Do not allow windows animations
-    windows_group_policy::local::machine { 'Disallowanimations':
-        key    => 'Software\Policies\Microsoft\Windows\DWM',
-        value  => 'Disallowanimations',
-        data   => 1,
-        type   => 'REG_DWORD',
-        notify => Windows_group_policy::Gpupdate['GPUpdate'],
-    }
-    # 12. Turn off Sync Updates
-    windows_group_policy::local::machine { 'DontSyncWindows8AppSettings':
-        key    => 'Software\Policies\Microsoft\UEV\Agent\Configuration',
-        value  => 'DontSyncWindows8AppSettings',
-        data   => 1,
-        type   => 'REG_DWORD',
-        notify => Windows_group_policy::Gpupdate['GPUpdate'],
-    }
-    # 13. Turn off location - Leave
-    # 14. Allow Cortana - DISABLE
-    windows_group_policy::local::machine { 'AllowCortana':
-        key    => 'Software\Policies\Microsoft\Windows\Windows Search',
-        value  => 'AllowCortana',
-        data   => 0,
-        type   => 'REG_DWORD',
-        notify => Windows_group_policy::Gpupdate['GPUpdate'],
-    }
-    # 15. Turn off Store Application
-    windows_group_policy::local::machine { 'DisablestoreApps':
-        key    => 'Software\Policies\Microsoft\Windowsstore',
-        value  => 'DisablestoreApps',
-        data   => 1,
-        type   => 'REG_DWORD',
-        notify => Windows_group_policy::Gpupdate['GPUpdate'],
-    }
-    # 16. Turn off offer to update to latest version of windows
-    windows_group_policy::local::machine { 'DisableOSUpgrade':
-        key    => 'Software\Policies\Microsoft\WindowsStore',
-        value  => 'DisableOSUpgrade',
-        data   => 1,
-        type   => 'REG_DWORD',
-        notify => Windows_group_policy::Gpupdate['GPUpdate'],
-    }
-    # 17. Remove Games from Start Menu
-    windows_group_policy::local::user { 'NoStartMenuMyGames':
-        key    => 'Software\Microsoft\Windows\CurrentVersion\Policies\Explorer',
-        value  => 'NoStartMenuMyGames',
-        data   => 1,
-        type   => 'REG_DWORD',
-        notify => Windows_group_policy::Gpupdate['GPUpdate'],
-    }
+
 }

--- a/manifests/windows/windows_template/manifests/registry/machine.pp
+++ b/manifests/windows/windows_template/manifests/registry/machine.pp
@@ -30,8 +30,8 @@ class windows_template::registry::machine ()
     file { 'c:/crash_dumps':
       ensure => 'directory',
       mode   => '0750',
-      owner  => 'Administrator',
-      group  => 'Administrators'
+      owner  => "${::administrator_sid}",
+      group  => "${::administrator_grp_sid}"
     }
 
     # Disable IE ESC for admins
@@ -68,7 +68,6 @@ class windows_template::registry::machine ()
         data  => 0,
         type  => 'dword',
     }
-    
 
     # Set the following BGInfo Variables using facter provided variables from env
     #VMPOOLER_Build_Date=Build-Date

--- a/scripts/windows/cleanup-host.ps1
+++ b/scripts/windows/cleanup-host.ps1
@@ -43,8 +43,8 @@ Write-Output "Clearing Files"
     "$ENV:ALLUSERSPROFILE\Microsoft\Windows\WER\ReportArchive",
     "$ENV:ALLUSERSPROFILE\Microsoft\Windows\WER\ReportQueue",
     "$ENV:WINDIR\winsxs\manifestcache",
-    "C:\ProgramData\PuppetLabs",
-    "C:\Program Files\Puppet Labs"
+    "$ENV:ProgramData\PuppetLabs",
+    "$ENV:ProgramFiles\Puppet Labs"
 ) | % { ForceFullyDelete-Paths "$_" }
 
 # Clearing Logs

--- a/scripts/windows/core-shutdown.ps1
+++ b/scripts/windows/core-shutdown.ps1
@@ -9,9 +9,9 @@ Param(
 
 if ($UseStartupWorkaround) {
     Write-Warning "Cleaning up PowerShell profile workaround for startup items"
-    Remove-Item -Force $PROFILE
+    Remove-Item -Force $PROFILE -ErrorAction SilentlyContinue
 }
 
-Remove-Item -Force -Recurse "$($env:APPDATA)\SetupFlags"
+Remove-Item -Force -Recurse "$($env:APPDATA)\SetupFlags" -ErrorAction SilentlyContinue
 
 Stop-Computer -Force

--- a/scripts/windows/init/vagrant-arm-host.ps1
+++ b/scripts/windows/init/vagrant-arm-host.ps1
@@ -6,7 +6,8 @@ $ErrorActionPreference = 'Stop'
 # Pickup Env Variables defined in "install-cygwin.ps1"
 $CygWinShell = "$ENV:CYGWINDIR\bin\sh.exe"
 $CygwinDownloads = $ENV:CYGWINDOWNLOADS
-$AdministratorHome = "$ENV:CYGWINDIR\home\Administrator"
+$AdministratorName =  (Get-WmiObject win32_useraccount -Filter "Sid like 'S-1-5-21-%-500'").Name
+$AdministratorHome = "$ENV:CYGWINDIR\home\$AdministratorName"
 
 # Set up cygserv Username
 Write-Output "Setting SSH Host Configuration"
@@ -33,21 +34,20 @@ Write-Output "Add SSHD Process with Manual Startup"
 & $CygWinShell --login -c `'cygrunsrv -S sshd`'
 Set-Service "sshd" -StartupType Manual
 
-# Make sure the C:/Users/Administrator directory is created by running a dummy-command to create the profile.
-Write-Output "Setting Administrator Account Password"
+# Make sure the C:/Users/$AdministratorName directory is created by running a dummy-command to create the profile.
+Write-Output "Setting $AdministratorName Account Password"
 $qa_root_passwd = Get-Content "$ENV:CYGWINDOWNLOADS\qapasswd"
-net user Administrator "$qa_root_passwd"
-$username = "Administrator"
+net user $AdministratorName "$qa_root_passwd"
 $password = "$qa_root_passwd"
 $securePassword = ConvertTo-SecureString $password -AsPlainText -Force
-$credential = New-Object System.Management.Automation.PSCredential $username, $securePassword
-Write-Output "Creating Administrator Profile"
+$credential = New-Object System.Management.Automation.PSCredential $AdministratorName, $securePassword
+Write-Output "Creating $AdministratorName Profile"
 Start-Process Powershell -Wait -Credential $Credential -LoadUserProfile "Exit"
 
-# Create Administrator cygwin as well
-Write-Output "Creating Administrator ssh/cygwin home directory"
-& $CygWinShell --login -c `'mkdir -p /home/Administrator`'
-& $CygWinShell --login -c `'chown Administrator /home/Administrator`'
+# Create $AdministratorName cygwin as well
+Write-Output "Creating $AdministratorName ssh/cygwin home directory"
+& $CygWinShell --login -c `'mkdir -p /home/$AdministratorName`'
+& $CygWinShell --login -c `'chown $AdministratorName /home/$AdministratorName`'
 
 # Set Startup script (starts sshd)
 Write-Output "Setting startup script"

--- a/scripts/windows/init/vagrant-arm-host.ps1
+++ b/scripts/windows/init/vagrant-arm-host.ps1
@@ -9,6 +9,9 @@ $CygwinDownloads = $ENV:CYGWINDOWNLOADS
 $AdministratorName =  (Get-WmiObject win32_useraccount -Filter "Sid like 'S-1-5-21-%-500'").Name
 $AdministratorHome = "$ENV:CYGWINDIR\home\$AdministratorName"
 
+# Make sure Adminstrator (whatever it is called is active)
+net user "$AdministratorName" /active:yes
+
 # Set up cygserv Username
 Write-Output "Setting SSH Host Configuration"
 & $CygWinShell --login -c `'ssh-host-config --yes --privileged --user cyg_server --pwd vagrant`'

--- a/scripts/windows/install-win-packages.ps1
+++ b/scripts/windows/install-win-packages.ps1
@@ -6,18 +6,6 @@ $ErrorActionPreference = 'Stop'
 
 . A:\windows-env.ps1
 
-Write-Output "Installing Puppet Agent..."
-if ("$ARCH" -eq "x86") {
-  $PuppetMSIUrl = "https://downloads.puppetlabs.com/windows/puppet-agent-x86-latest.msi"
-} else {
-  $PuppetMSIUrl = "https://downloads.puppetlabs.com/windows/puppet-agent-x64-latest.msi"
-}
-
-# Install Puppet Agent
-Download-File "$PuppetMSIUrl" $PackerDownloads\puppet-agent.msi
-Start-Process -Wait "msiexec" @SprocParms -ArgumentList "/i $PackerDownloads\puppet-agent.msi /qn /norestart PUPPET_AGENT_STARTUP_MODE=manual"
-Write-Output "Installed Puppet Agent..."
-
 If ( $WindowsServerCore ) {
   Write-Output "Skipping Browser and Notepad++ installs for Windows Core"
 }

--- a/scripts/windows/puppet-configure.ps1
+++ b/scripts/windows/puppet-configure.ps1
@@ -119,7 +119,7 @@ $ENV:FACTER_packer_sha           = $PackerSHA
 $ENV:FACTER_packer_template_name = $PackerTemplateName
 $ENV:FACTER_packer_template_type = $PackerTemplateType
 # Pick Up user attributes as these could be localised.
-$ENV:FACTER_administrator_sid     =  (Get-WmiObject win32_useraccount -Filter "Sid like 'S-1-5-21-%-500'").sid
+$ENV:FACTER_administrator_sid     =  $WindowsAdminSID
 $ENV:FACTER_administrator_grp_sid = "S-1-5-32-544"
 
 # Chrome root needs arch detection as under x86 on 64 bit boxen

--- a/scripts/windows/windows-env.ps1
+++ b/scripts/windows/windows-env.ps1
@@ -12,6 +12,15 @@ Set-Variable -Option Constant -Name WindowsServer2012   -Value "6.2.*"
 Set-Variable -Option Constant -Name WindowsServer2016   -Value "10.*"
 $WindowsVersion = (Get-WmiObject win32_operatingsystem).version
 
+# Get Administrator SID 
+$WindowsAdminSID =  (Get-WmiObject win32_useraccount -Filter "Sid like 'S-1-5-21-%-500'").sid
+# Crude Code to chose appropriate resonse for YesNo
+$PrimaryLanguage = (Get-Culture).TwoLetterISOLanguageName
+Switch ($PrimaryLanguage) {
+  "fr"  {$AnswerPromptYes = "O"; break}
+  default {$AnswerPromptYes = "Y"; break}
+}
+
 # Test to see if we are Core Version or not.
 # Core installation (no GUI). While there is a more exact WMI query to determine this, checking to see
 # if windows explorer installed is an equally valid check for Windows-2012r2 etc.
@@ -218,7 +227,11 @@ Function ForceFullyDelete-Paths
   try {
     if(Test-Path $filetodelete) {
         Write-Output "Removing $filetodelete"
-        Icacls $filetodelete /grant *S-1-5-32-545:(OI)(CI)F /T /c /q  2>&1 | Out-Null
+        # TBD: Localisation Needed here
+        # 1. /D - Y/N for French
+        # 2. Translate Administrators
+        Takeown /d "$AnswerPromptYes" /R /f $filetodelete
+        Icacls $filetodelete /GRANT:r "$WindowsAdminSID:F" /T /c /q  2>&1 | Out-Null
         Remove-Item $filetodelete -Recurse -Force -ErrorAction SilentlyContinue | Out-Null
       }
     }

--- a/scripts/windows/windows-env.ps1
+++ b/scripts/windows/windows-env.ps1
@@ -218,8 +218,7 @@ Function ForceFullyDelete-Paths
   try {
     if(Test-Path $filetodelete) {
         Write-Output "Removing $filetodelete"
-        Takeown /d Y /R /f $filetodelete
-        Icacls $filetodelete /GRANT:r administrators:F /T /c /q  2>&1 | Out-Null
+        Icacls $filetodelete /grant *S-1-5-32-545:(OI)(CI)F /T /c /q  2>&1 | Out-Null
         Remove-Item $filetodelete -Recurse -Force -ErrorAction SilentlyContinue | Out-Null
       }
     }

--- a/templates/win-2012r2/x86_64.vars.json
+++ b/templates/win-2012r2/x86_64.vars.json
@@ -4,6 +4,7 @@
     "vbox_guest_os"     : "Windows2012_64",
     "vmware_guest_os"   : "windows8srv-64",
     "windows_version"   : "Windows-2012r2",
+    "post_memsize"      : "6144",
     "image_name"        : "Windows Server 2012 R2 SERVERSTANDARD",
     "product_key"       : "D2N9P-3P6X9-2R39C-7RTCD-MDVJX",
     "version"           : "0.0.2",

--- a/templates/win-common/files/AutoUnattendTemplate.xml
+++ b/templates/win-common/files/AutoUnattendTemplate.xml
@@ -244,7 +244,7 @@
                         <Order>3</Order>
                     </SynchronousCommand>
                     <SynchronousCommand wcm:action="add">
-                        <CommandLine>cmd.exe /c wmic useraccount where &quot;name=&apos;Administrator&apos;&quot; set PasswordExpires=FALSE</CommandLine>
+                        <CommandLine>cmd.exe /c wmic useraccount where &quot;sid like &apos;S-1-5-21-%-500&apos;&quot; set PasswordExpires=FALSE</CommandLine>
                         <Description>Disable Administrator Password reset</Description>
                         <Order>4</Order>
                     </SynchronousCommand>
@@ -272,7 +272,7 @@
                         <Order>3</Order>
                     </SynchronousCommand>
                     <SynchronousCommand wcm:action="add">
-                        <CommandLine>wmic useraccount where &quot;name=&apos;Administrator&apos;&quot; set PasswordExpires=FALSE</CommandLine>
+                        <CommandLine>wmic useraccount where &quot;sid like &apos;S-1-5-21-%-500&apos;&quot; set PasswordExpires=FALSE</CommandLine>
                         <Order>4</Order>
                     </SynchronousCommand>
                     <SynchronousCommand wcm:action="add">

--- a/templates/win-common/files/AutoUnattendTemplate.xml
+++ b/templates/win-common/files/AutoUnattendTemplate.xml
@@ -184,8 +184,13 @@
         <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
           <RunSynchronous>
             <RunSynchronousCommand wcm:action="add">
-                <Path>reg add HKLM\Software\Microsoft\Windows\CurrentVersion\Policies\System /v EnableFirstLogonAnimation /t REG_DWORD /d 0 /f</Path>
+                <Path>net user administrator /active:yes</Path>
                 <Order>1</Order>
+            </RunSynchronousCommand>
+            <!-- NB - only really needed for Win-8.1 but shouldn't harm rest of boots - needs regression -->
+            <RunSynchronousCommand wcm:action="add">
+                <Path>reg add HKLM\Software\Microsoft\Windows\CurrentVersion\Policies\System /v EnableFirstLogonAnimation /t REG_DWORD /d 0 /f</Path>
+                <Order>2</Order>
                 <Description>Do not Show First Logon Animation</Description>
             </RunSynchronousCommand>
           </RunSynchronous>

--- a/templates/win-common/files/Autounattend.xslt
+++ b/templates/win-common/files/Autounattend.xslt
@@ -127,9 +127,9 @@
     </xsl:choose>
   </xsl:template>
 
-  <!-- Windows-10 and Windows-8.1 Need this component added -->
+  <!-- Windows-10 and Windows-8.1 & 7 Need this component added -->
   <xsl:template match='u:unattend/u:settings/u:component[@name="Microsoft-Windows-Deployment"]'>
-    <xsl:if test="($WindowsVersion='Windows-8.1') or ($WindowsVersion='Windows-10')" >
+    <xsl:if test="($WindowsVersion='Windows-7') or ($WindowsVersion='Windows-8.1') or ($WindowsVersion='Windows-10')" >
       <xsl:copy>
         <xsl:apply-templates select="@*|node()"/>
       </xsl:copy>
@@ -138,6 +138,15 @@
 
   <xsl:template match='u:unattend/u:settings/u:component[@name="Microsoft-Windows-Shell-Setup"]/u:OOBE/u:NetworkLocation'>
     <xsl:if test="not($WindowsVersion = 'Windows-10')">
+      <xsl:copy>
+        <xsl:apply-templates select="@*|node()"/>
+      </xsl:copy>
+    </xsl:if>
+  </xsl:template> 
+
+  <!-- Windows 7 Needs Timezone set in the OOBE phase too -->
+  <xsl:template match='u:unattend/u:settings/u:component[@name="Microsoft-Windows-Shell-Setup"]/u:TimeZone'>
+    <xsl:if test="$WindowsVersion = 'Windows-7'">
       <xsl:copy>
         <xsl:apply-templates select="@*|node()"/>
       </xsl:copy>

--- a/templates/win-common/files/PostCloneTemplate.xml
+++ b/templates/win-common/files/PostCloneTemplate.xml
@@ -123,6 +123,7 @@
                 <NetworkLocation>Work</NetworkLocation>
                 <ProtectYourPC>1</ProtectYourPC>
             </OOBE>
+            <TimeZone>UTC</TimeZone>
             <RegisteredOwner />
             <ProductKey>KKKKK-KKKKK-KKKKK-KKKKK-KKKKK</ProductKey>
             <UserAccounts>

--- a/templates/win-common/files/PostCloneTemplate.xml
+++ b/templates/win-common/files/PostCloneTemplate.xml
@@ -78,7 +78,7 @@
                         <Order>2</Order>
                     </SynchronousCommand>
                     <SynchronousCommand wcm:action="add">
-                        <CommandLine>cmd.exe /c wmic useraccount where &quot;name=&apos;Administrator&apos;&quot; set PasswordExpires=FALSE</CommandLine>
+                        <CommandLine>cmd.exe /c wmic useraccount where &quot;sid like &apos;S-1-5-21-%-500&apos;&quot; set PasswordExpires=FALSE</CommandLine>
                         <Description>Disable Administrator Password reset</Description>
                         <Order>3</Order>
                     </SynchronousCommand>
@@ -101,11 +101,11 @@
                         <Order>2</Order>
                     </SynchronousCommand>
                     <SynchronousCommand wcm:action="add">
-                        <CommandLine>cmd /C start /wait NET User "Administrator" /Active:yes</CommandLine>
+                        <CommandLine>wmic useraccount where &quot;sid like &apos;S-1-5-21-%-500&apos;&quot; set Disabled=FALSE</CommandLine>
                         <Order>3</Order>
                     </SynchronousCommand>
                     <SynchronousCommand wcm:action="add">
-                        <CommandLine>wmic useraccount where &quot;name=&apos;Administrator&apos;&quot; set PasswordExpires=FALSE</CommandLine>
+                        <CommandLine>wmic useraccount where &quot;sid like &apos;S-1-5-21-%-500&apos;&quot; set PasswordExpires=FALSE</CommandLine>
                         <Order>4</Order>
                     </SynchronousCommand>
                     <SynchronousCommand wcm:action="add">

--- a/templates/win-common/files/virtualbox/vagrantfile-windows.template.erb
+++ b/templates/win-common/files/virtualbox/vagrantfile-windows.template.erb
@@ -4,15 +4,17 @@
 Vagrant.require_version ">= 1.6.2"
 
 Vagrant.configure("2") do |config|
-  config.vm.define "vagrant-windows"
+  config.vm.define "<%= vm_define %>"
 
-  config.vm.box               = "windows"
+  config.vm.box               = "<%= vm_box %>"
   config.vm.communicator      = "winrm"
   config.vm.guest             = :windows
   config.vm.communicator      = "winrm" if Vagrant::VERSION >= '1.6.0'
   config.winrm.username       = "vagrant"
   config.winrm.password       = "vagrant"
+  config.vm.hostname          = "<%= vm_hostname %>"
   config.windows.halt_timeout = 15
+  config.vbguest.auto_update  = <%= vb_autoupdate %>
 
   config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct: true
   config.vm.network :forwarded_port, guest: 3389, host: 3389, id: "rdp", auto_correct: true
@@ -25,21 +27,4 @@ Vagrant.configure("2") do |config|
     v.customize ["setextradata", "global", "GUI/SuppressMessages", "all" ]
   end
 
-  config.vm.provider :vmware_fusion do |v, override|
-    v.vmx["memsize"]                   = "2048"
-    v.vmx["numvcpus"]                  = "2"
-    v.vmx["ethernet0.virtualDev"]      = "vmxnet3"
-    v.vmx["RemoteDisplay.vnc.enabled"] = "false"
-    v.vmx["RemoteDisplay.vnc.port"]    = "5900"
-    v.vmx["scsi0.virtualDev"]          = "lsisas1068"
-  end
-
-  config.vm.provider :vmware_workstation do |v, override|
-    v.vmx["memsize"]                   = "2048"
-    v.vmx["numvcpus"]                  = "2"
-    v.vmx["ethernet0.virtualDev"]      = "vmxnet3"
-    v.vmx["RemoteDisplay.vnc.enabled"] = "false"
-    v.vmx["RemoteDisplay.vnc.port"]    = "5900"
-    v.vmx["scsi0.virtualDev"]          = "lsisas1068"
-  end
 end

--- a/templates/win-common/virtualbox.base.json
+++ b/templates/win-common/virtualbox.base.json
@@ -40,7 +40,6 @@
         "shutdown_command"        : "{{user `shutdown_command`}}",
         "shutdown_timeout"        : "1h",
         "vboxmanage": [
-          ["setproperty","machinefolder","{{user `current_pwd`}}/output-vbox-machine"],
           ["modifyvm","{{.Name}}","--memory","{{user `memory_size`}}"],
           ["modifyvm","{{.Name}}","--cpus","{{user `cpu_count`}}"],
           ["modifyvm", "{{.Name}}", "--natpf1", "guestwinrm,tcp,127.0.0.1,5985,,5985"]

--- a/templates/win-common/virtualbox.vagrant.cygwin.json
+++ b/templates/win-common/virtualbox.vagrant.cygwin.json
@@ -141,7 +141,8 @@
             ]
         },
         {
-            "type": "windows-restart"
+            "type": "windows-restart",
+            "restart_timeout": "15m"
         },
         {
             "type": "powershell",

--- a/templates/win-common/virtualbox.vagrant.cygwin.json
+++ b/templates/win-common/virtualbox.vagrant.cygwin.json
@@ -53,7 +53,6 @@
           "../../scripts/windows/win-site.pp"
         ],
         "vboxmanage": [
-          ["setproperty","machinefolder","{{user `current_pwd`}}/output-vbox-machine"],
           ["modifyvm","{{.Name}}","--memory","2048"],
           ["modifyvm","{{.Name}}","--cpus","2"]
         ]

--- a/templates/win-common/virtualbox.vagrant.cygwin.json
+++ b/templates/win-common/virtualbox.vagrant.cygwin.json
@@ -159,7 +159,7 @@
         "post-processors": [{
             "type"                : "vagrant",
             "output"              : "{{user `packer_shared_dir`}}/output-{{build_name}}/{{user `template_name`}}-{{user `provisioner`}}-{{user `template_config`}}.box",
-            "vagrantfile_template": "../win-common/files/virtualbox/vagrantfile-windows.template"
+            "vagrantfile_template": "tmp/vagrantfile-windows.template"
         }
     ]
 }

--- a/templates/win-common/virtualbox.vagrant.cygwin.json
+++ b/templates/win-common/virtualbox.vagrant.cygwin.json
@@ -130,18 +130,8 @@
             ]
         },
         {
-            "type": "powershell",
-            "remote_path": "{{user `packer_downloads_dir`}}/run-queue-sysprep.ps1",
-            "inline": [
-                "Write-Output 'Executing Powershell Script: run-queue-sysprep.ps1'",
-                "Write-Output 'Initiate Sysprep'",
-                "C:\\Windows\\System32\\sysprep\\sysprep /oobe /quit /unattend:C:\\Packer\\Init\\post-clone.autounattend.xml",
-                "Write-Output 'Sysprep queued.'",
-                "Start-Sleep -Seconds 10"
-            ]
-        },
-        {
             "type": "windows-restart",
+            "restart_command": "C:\\Windows\\System32\\sysprep\\sysprep /oobe /reboot /unattend:C:\\Packer\\Init\\post-clone.autounattend.xml",
             "restart_timeout": "15m"
         },
         {


### PR DESCRIPTION
This PR addresses several trailing issues related to the Packer/Windows builds including:
1. Generalising the VagrantFile for vagrant builds (IMAGES-88)
2. Localisation issues for Windows French (IMAGES-335)
3. Windows-7 Post-Clone issues with Vagrant (IMAGES-662)
4. Windows-2012r2 image wasn't setting the image memory size correctly.