### PR TITLE
(RE-9766) Update puppetlabs-packer to use artifactory

### DIFF
--- a/scripts/windows/generate-slipstream.ps1
+++ b/scripts/windows/generate-slipstream.ps1
@@ -20,7 +20,7 @@ $WinImageFile = "$WinDistPath\sources\install.wim"
 
 # Install ADK
 Write-Output "Install Win ADK"
-Download-File http://buildsources.delivery.puppetlabs.net/windows/winadk/adksetup_win2012r2.exe  $PackerDownloads\adksetup_win2012r2.exe
+Download-File https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/winadk/adksetup_win2012r2.exe  $PackerDownloads\adksetup_win2012r2.exe
 Start-Process -Wait "$PackerDownloads\adksetup_win2012r2.exe" -ArgumentList "/quiet /norestart /features OptionId.DeploymentTools"
 Write-Output "Win ADK Installed"
 

--- a/scripts/windows/install-cygwin.ps1
+++ b/scripts/windows/install-cygwin.ps1
@@ -60,14 +60,14 @@ if ($ENV:QA_ROOT_PASSWD.length -le 0 ) {throw "QA_ROOT_PASSWD is not defined"}
 $ENV:QA_ROOT_PASSWD | Out-File "$CygwinDownloads\qapasswd"
 
 Write-Output "Downloading Cygwin Packages"
-Download-File "http://buildsources.delivery.puppetlabs.net/windows/cygwin/packages-$ARCH.zip" "$CygwinDownloads\packages_$ARCH.zip"
+Download-File "https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/cygwin/packages-$ARCH.zip" "$CygwinDownloads\packages_$ARCH.zip"
 Write-Output "Extracting $CygwinDownloads\packages_$ARCH.zip"
 $zproc = Start-Process "$7zip" -PassThru -NoNewWindow -ArgumentList "x $CygwinDownloads\packages_$ARCH.zip -y -o$CygwinDownloads"
 $zproc.WaitForExit()
 
 Write-Output "Downloading Cygwin Setup"
 $CygWinSetup = "$CygwinDownloads\setup-$ARCH.exe"
-Download-File "http://buildsources.delivery.puppetlabs.net/windows/cygwin/setup-$ARCH.exe" $CygWinSetup
+Download-File "https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/cygwin/setup-$ARCH.exe" $CygWinSetup
 # Install Cygwin from the download location.
 # Start-Process -wait needed to address Win-2008 where the setup appears to run async and script exits before install has completed
 Write-Output "Installing Cygwin"

--- a/scripts/windows/install-win-packages.ps1
+++ b/scripts/windows/install-win-packages.ps1
@@ -12,20 +12,20 @@ If ( $WindowsServerCore ) {
 else {
 
   Write-Output "Installing Google Chrome Browser"
-  Download-File "http://buildsources.delivery.puppetlabs.net/windows/googlechrome/ChromeSetup-$ARCH.exe" "$PackerDownloads\ChromeSetup-$ARCH.exe"
+  Download-File "https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/googlechrome/ChromeSetup-$ARCH.exe" "$PackerDownloads\ChromeSetup-$ARCH.exe"
   Start-Process -Wait "$PackerDownloads\ChromeSetup-$ARCH.exe" @SprocParms -ArgumentList "/silent /install"
   Write-Output "Google Chrome Browser Installed"
 
   $NotePadInstaller = "npp.7.5.1.Installer-$ARCH.exe"
   Write-Output "Installing Notepad++ $NotePadInstaller"
-  Download-File "http://buildsources.delivery.puppetlabs.net/windows/notepadplusplus/$NotePadInstaller" "$PackerDownloads\$NotePadInstaller"
+  Download-File "https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/notepadplusplus/$NotePadInstaller" "$PackerDownloads\$NotePadInstaller"
   Start-Process -Wait "$PackerDownloads\$NotePadInstaller" @SprocParms -ArgumentList "/S"
   Write-Output "Notepad++ Installed"
 }
 
 $GitForWinInstaller = "Git-2.15.0-$ARCH.exe"
 Write-Output "Installing Git For Windows $GitForWinInstaller"
-Download-File "http://buildsources.delivery.puppetlabs.net/windows/gitforwin/$GitForWinInstaller"  "$PackerDownloads\$GitForWinInstaller"
+Download-File "https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/gitforwin/$GitForWinInstaller"  "$PackerDownloads\$GitForWinInstaller"
 Start-Process -Wait "$PackerDownloads\$GitForWinInstaller" @SprocParms -ArgumentList "/VERYSILENT /LOADINF=A:\gitforwin.inf"
 Write-Output "Git For Windows Installed"
 
@@ -39,7 +39,7 @@ $SysInternalsTools = @(
   'autologon'
 )
 $SysInternalsTools | ForEach-Object {
-  Download-File http://buildsources.delivery.puppetlabs.net/windows/sysinternals/$_.zip $PackerDownloads\$_.zip
+  Download-File https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/sysinternals/$_.zip $PackerDownloads\$_.zip
   # PS2 has a bug with "Start-Process -Wait" which can cause it to fail if the command finishes "too quickly", so using this
   # workaround to address random failures (especially with Win-2012)
   $zproc = Start-Process "$7zip" @SprocParms -ArgumentList "x $PackerDownloads\$_.zip -y -o$SysInternals"

--- a/scripts/windows/start-pswindowsupdate.ps1
+++ b/scripts/windows/start-pswindowsupdate.ps1
@@ -104,7 +104,7 @@ if (-not (Test-Path "$PackerLogs\7zip.installed")) {
   # Download and install 7za now as its needed here and is useful going forward.
   $SevenZipInstaller = "7z1604-$ARCH.exe"
   Write-Host "Installing 7zip $SevenZipInstaller"
-  Download-File "http://buildsources.delivery.puppetlabs.net/windows/7zip/$SevenZipInstaller"  "$Env:TEMP\$SevenZipInstaller"
+  Download-File "https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/7zip/$SevenZipInstaller"  "$Env:TEMP\$SevenZipInstaller"
   Start-Process -Wait "$Env:TEMP\$SevenZipInstaller" @SprocParms -ArgumentList "/S"
   Touch-File "$PackerLogs\7zip.installed"
   Write-Host "7zip Installed"
@@ -112,7 +112,7 @@ if (-not (Test-Path "$PackerLogs\7zip.installed")) {
 
 if (-not (Test-Path "$PackerLogs\PSWindowsUpdate.installed")) {
   # Download and install PSWindows Update Modules.
-  Download-File "http://buildsources.delivery.puppetlabs.net/windows/pswindowsupdate/PSWindowsUpdate.zip" "$Env:TEMP/pswindowsupdate.zip"
+  Download-File "https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/pswindowsupdate/PSWindowsUpdate.zip" "$Env:TEMP/pswindowsupdate.zip"
   mkdir -Path "$Env:TEMP\PSWindowsUpdate"
   $zproc = Start-Process "$7zip" @SprocParms -ArgumentList "x $Env:TEMP/pswindowsupdate.zip -y -o$PackerStaging"
   $zproc.WaitForExit()

--- a/scripts/windows/windows-env.ps1
+++ b/scripts/windows/windows-env.ps1
@@ -297,10 +297,10 @@ Function Install-DotNetLatest
           else {
             $PreReqPatch = "Windows6.1-KB4019990-x64.msu"
           }
-          Install_Win_Patch -PatchUrl "http://buildsources.delivery.puppetlabs.net/windows/dotnet/$PreReqPatch"
+          Install_Win_Patch -PatchUrl "https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/dotnet/$PreReqPatch"
         }
       }
-      Download-File "http://buildsources.delivery.puppetlabs.net/windows/dotnet/$DotNetInstaller" "$Env:TEMP/$DotNetInstaller"
+      Download-File "https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/dotnet/$DotNetInstaller" "$Env:TEMP/$DotNetInstaller"
       Start-Process -Wait "$Env:TEMP/$DotNetInstaller" -NoNewWindow -PassThru -ArgumentList "/passive /norestart"
   }
   Touch-File "$PackerLogs\InstallDotNetLatest.installed"

--- a/templates/win-2008/files/x86_64/platform-packages.ps1
+++ b/templates/win-2008/files/x86_64/platform-packages.ps1
@@ -11,7 +11,7 @@ if (-not (Test-Path "$PackerLogs\NET35.Installed"))
 {
   # Install .Net 3.5.1
   Write-Output ".Net 3.5.1"
-  Download-File "http://buildsources.delivery.puppetlabs.net/windows/win-2008-ps2/dotnetfx35setup.exe"  "$ENV:TEMP\dotnetfx35setup.exe"
+  Download-File "https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/win-2008-ps2/dotnetfx35setup.exe"  "$ENV:TEMP\dotnetfx35setup.exe"
   Start-Process -Wait "$ENV:TEMP\dotnetfx35setup.exe" -ArgumentList "/q"
   Write-Output ".Net 3.5.1 Installed"
   Touch-File "$PackerLogs\NET35.Installed"
@@ -22,7 +22,7 @@ if (-not (Test-Path "$PackerLogs\WinUpdate.Installed"))
 {
   # Install .Net 3.5.1
   Write-Output "Updating Windows Update agent"
-  Download-File "http://buildsources.delivery.puppetlabs.net/windows/win-2008-ps2/windowsupdateagent30-x64.exe"  "$ENV:TEMP\windowsupdateagent30-x64.exe"
+  Download-File "https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/win-2008-ps2/windowsupdateagent30-x64.exe"  "$ENV:TEMP\windowsupdateagent30-x64.exe"
   Start-Process -Wait "$ENV:TEMP\windowsupdateagent30-x64.exe" -ArgumentList "/q"
   Write-Output "Updating Windows Update agent"
   Touch-File "$PackerLogs\WinUpdate.Installed"

--- a/templates/win-2008r2-wmf5/files/x86_64/platform-packages.ps1
+++ b/templates/win-2008r2-wmf5/files/x86_64/platform-packages.ps1
@@ -29,7 +29,7 @@ if (-not (Test-Path "$PackerLogs\WMF5.installed"))
 {
   # Install WMF 5 (Powershell)
   Write-Host "Installing WFM 5.1"
-  Install_Win_Patch -PatchUrl "http://buildsources.delivery.puppetlabs.net/windows/wmf5/Win7AndW2K8R2-KB3191566-x64.msu"
+  Install_Win_Patch -PatchUrl "https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/wmf5/Win7AndW2K8R2-KB3191566-x64.msu"
   Touch-File "$PackerLogs\WMF5.installed"
   Invoke-Reboot
 }

--- a/templates/win-2012r2-wmf5/files/x86_64/platform-packages.ps1
+++ b/templates/win-2012r2-wmf5/files/x86_64/platform-packages.ps1
@@ -18,7 +18,7 @@ if (-not (Test-Path "$PackerLogs\WMF5.installed"))
 {
   # Enable Desktop experience to get cleanmgr
   Write-Host "Install WMF5 Patch"
-  Install_Win_Patch -PatchUrl "http://buildsources.delivery.puppetlabs.net/windows/wmf5/Win8.1AndW2K12R2-KB3191564-x64.msu"
+  Install_Win_Patch -PatchUrl "https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/wmf5/Win8.1AndW2K12R2-KB3191564-x64.msu"
   Touch-File "$PackerLogs\WMF5.installed"
   Invoke-Reboot
 }


### PR DESCRIPTION
This change updates references from using http://buildsources.delivery.puppetlabs.net/ to https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/.