### PR TITLE
(IMAGES-665) Tidy Vagrantfile parameters

### DIFF
--- a/templates/win-common/files/virtualbox/vagrantfile-windows.template.erb
+++ b/templates/win-common/files/virtualbox/vagrantfile-windows.template.erb
@@ -4,8 +4,6 @@
 Vagrant.require_version ">= 1.6.2"
 
 Vagrant.configure("2") do |config|
-  config.vm.define "<%= vm_define %>"
-
   config.vm.box               = "<%= vm_box %>"
   config.vm.communicator      = "winrm"
   config.vm.guest             = :windows
@@ -14,7 +12,6 @@ Vagrant.configure("2") do |config|
   config.winrm.password       = "vagrant"
   config.vm.hostname          = "<%= vm_hostname %>"
   config.windows.halt_timeout = 15
-  config.vbguest.auto_update  = <%= vb_autoupdate %>
   config.vm.boot_timeout      = 600
 
   config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct: true

--- a/templates/win-common/gen-xslt.sh
+++ b/templates/win-common/gen-xslt.sh
@@ -66,17 +66,9 @@ if [ "${IMAGE_TYPE}" = "virtualbox" ] ;then
     echo "Generating vagrantfile template"
     # Beware - Names must not contain Underyscores.
     export PACKER_VB_HOSTNAME=`jq -r .template_name ${TEMPLATE_DIR}/${IMAGE_ARCH}.vars.json | tr '_' '-'`
-    export PACKER_BEAKER_NAME=`jq -r .beakerhost ${TEMPLATE_DIR}/${IMAGE_ARCH}.vars.json`
     export PACKER_BEAKER_NAME_TR=`jq -r .beakerhost ${TEMPLATE_DIR}/${IMAGE_ARCH}.vars.json | tr '_' '-'`
-    if [[ ${PACKER_VB_HOSTNAME} == *core* ]] ;then
-       PACKER_VB_AUTOUPDATE=false
-    else
-       PACKER_VB_AUTOUPDATE=true
-    fi
 
-    erb vm_define=vagrant-${PACKER_BEAKER_NAME} \
-        vm_box=winpacker/${PACKER_BEAKER_NAME_TR} \
-        vm_hostname=vagrant-${PACKER_VB_HOSTNAME} \
-        vb_autoupdate=${PACKER_VB_AUTOUPDATE} \
+    erb vm_box=winpacker/${PACKER_BEAKER_NAME_TR} \
+        vm_hostname=${PACKER_VB_HOSTNAME} \
             ../win-common/files/virtualbox/vagrantfile-windows.template.erb > tmp/vagrantfile-windows.template
 fi


### PR DESCRIPTION
The win-2012r2-core vagrant/facter acceptance tests are more due to
incorrect hostname format from the beakerhostgenerator file, but this
opportunity is taken to tidy up the Vagrantfile and its generation, i.e.
the removal of parameters that are not needed etc.