### PR TITLE
(maint) Update Travis to not fail with the new naming convention

### DIFF
--- a/tests/test-syntax.sh
+++ b/tests/test-syntax.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
 counter=0
-for file in $(find . -name "*.json" | egrep -v '\.vars\.|MAINTAINERS|metadata')
+for file in $(find . -name "*.json" | egrep -v '^vars\.|MAINTAINERS|metadata')
 do
     if ! ./packer validate -syntax-only  "$file" &> /dev/null ; then
         echo "$file"
+        # we run the validation command again here to get its output 
         ./packer validate -syntax-only  "$file"
         let counter=$counter+1
     fi


### PR DESCRIPTION
With the new directory structure of the templates established,
variable files will be named "vars.json". This would fail Travis
because it expects "vars.json" files to have a prefix, originally
meant for the architecture. This commit fixes Travis to avoid
failure for that case.