### PR TITLE
(IMAGES-680) Win-10 Needs private network adapters

### DIFF
--- a/scripts/windows/init/vagrant-arm-host.ps1
+++ b/scripts/windows/init/vagrant-arm-host.ps1
@@ -3,6 +3,13 @@
 
 $ErrorActionPreference = 'Stop'
 
+# If we are Windows-10/2016 need to set network adapters private.
+# Note - need longhand test as windows_env isn't available here.
+if ($WindowsVersion -like "10.*") {
+  # Setting Windows-10 network connections private.
+  Set-NetConnectionProfile  -InterfaceIndex (Get-NetConnectionProfile).InterfaceIndex -NetworkCategory Private
+}
+
 # Pickup Env Variables defined in "install-cygwin.ps1"
 $CygWinShell = "$ENV:CYGWINDIR\bin\sh.exe"
 $CygwinDownloads = $ENV:CYGWINDOWNLOADS


### PR DESCRIPTION
Windows-10/2016 insists on creating public network adaptors after a sysprep which means WinRM fails to come up properly (Earlier versions of windows allow you to set the adaptors private in the unattend.xml).

So detect if this Windows-10/2016 and set the adapters private.