### PR TITLE
(MAINT) Don't start sshd during post-clone

### DIFF
--- a/scripts/windows/init/vmpooler-post-clone-configuration.ps1
+++ b/scripts/windows/init/vmpooler-post-clone-configuration.ps1
@@ -85,8 +85,8 @@ Write-Output "Register the Cygwin LSA authentication package "
 # Add github.com as a known host (needed for git@gihub:<repo> clone ops)
 & $CygWinShell --login -c `'ssh-keyscan -t rsa github.com `>`> /home/$AdministratorName/.ssh/known_hosts`'
 
-Write-Output "Add SSHD Process with Manual Startup"
-& $CygWinShell --login -c `'cygrunsrv -S sshd`'
+# Set sshd process to manual startup - the vmpooler-clone-startup script does the actual start.
+Write-Output "Set SSHD Process with Manual Startup"
 Set-Service "sshd" -StartupType Manual
 
 Write-Output "Re-enable NETBios and WinRM Services"


### PR DESCRIPTION
Small maint change to improve the acceptance reliability.
Starting sshd before we reboot to rename the host causes failures in the
vcloud/beaker hypervisor - suspect this is because it uses IP addresses
rather than the given hostname to detect when the host is alive, thus
breaking the test initialisation sequence. The vmpooler initialisation
is more tolerant of this as it the ssh test uses the given hostname
which isn't active until after the reboot.

Suspect we can further rationalise and tidy the overal ssh startup
sequence (i.e. use Automatic start), but lets just do this for now.