### PR TITLE
(IMAGES-707) Set SSHD as Automatic in post-clone

### DIFF
--- a/scripts/windows/init/vmpooler-clone-startup.ps1
+++ b/scripts/windows/init/vmpooler-clone-startup.ps1
@@ -39,18 +39,14 @@ function ExitScript([int]$ExitCode){
 	exit $ExitCode
 }
 
-#--- SCRIPT ---#
-Write-Output "Updating the Cygwin passwd file!"
-
 #Snooze for a bit
 sleep -s 10
+
+#--- SCRIPT ---#
+Write-Output "Updating the Cygwin passwd file!"
 
 #Update the passwd file.
 Invoke-Expression $CygwinMkpasswd | Out-File $CygwinPasswdFile -Force -Encoding "ASCII"
 Invoke-Expression $CygwinMkgroup | Out-File $CygwinGroupFile -Force -Encoding "ASCII"
-
-#Start the SSH server
-Write-Output "Starting SSH server!"
-Start-Service "sshd"
 
 ExitScript 0


### PR DESCRIPTION
The SSHD startup was still happening in a seperate script to the
post-clone operation. This seems to cause a failure for sshd to come up
in the image accpeptance test env.

Simplify this by setting sshd as Automatic as one of the last commands
before the computer is renamed and take the startup out of the
startup-script.
The mkpasswd and mkgroup commands are also copied to the post-clone
operation to ensure these are in place before the first sshd
initialisation.