### PR TITLE
(IMAGES-722) Fix windows image timezones

### DIFF
--- a/manifests/windows/windows_template/manifests/policies/local_group_policies.pp
+++ b/manifests/windows/windows_template/manifests/policies/local_group_policies.pp
@@ -173,7 +173,7 @@ class windows_template::policies::local_group_policies ()
     windows_group_policy::local::machine { 'W32timeNTPServerList':
         key    => 'Software\Policies\Microsoft\W32time\Parameters',
         value  => 'NtpServer',
-        data   => 'opdx-net01-prod.ops.puppetlabs.net pdx-net01-prod.ops.puppetlabs.net opdx-net02.service.puppetlabs.net pdx-net02-prod.ops.puppetlabs.net',
+        data   => '10.240.0.10 10.240.1.10',
         type   => 'REG_SZ',
         notify => Windows_group_policy::Gpupdate['GPUpdate'],
     }

--- a/scripts/windows/init/vmpooler-post-clone-configuration.ps1
+++ b/scripts/windows/init/vmpooler-post-clone-configuration.ps1
@@ -30,6 +30,7 @@ If ($WindowsVersion -like $WindowsServer2008) {
 }
 else {
 	Write-Output "Resyncing Time"
+	net start w32time
 	w32tm /resync
 	w32tm /tz
 }

--- a/templates/win-10-1607/x86_64.vars.json
+++ b/templates/win-10-1607/x86_64.vars.json
@@ -6,7 +6,7 @@
     "windows_version"   : "Windows-10",
     "image_name"        : "Windows 10 Enterprise",
     "product_key"       : "NPPR9-FWDCX-D2C8J-H872K-2YT43",
-    "version"           : "20180109_0000",
+    "version"           : "20180119_1200",
     "iso_url"           : "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_10_enterprise_version_1607_updated_jul_2016_x64_dvd_9054264_SlipStream_02.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "14cf73d5070bc2fa8c75c636ea69a47e",

--- a/templates/win-10-ent/i386.vars.json
+++ b/templates/win-10-ent/i386.vars.json
@@ -6,7 +6,7 @@
     "windows_version"   : "Windows-10",
     "image_name"        : "Windows 10 Enterprise",
     "product_key"       : "NPPR9-FWDCX-D2C8J-H872K-2YT43",
-    "version"           : "20180109_0000",
+    "version"           : "20180119_1200",
     "iso_url"           : "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_10_enterprise_version_1703_updated_july_2017_x86_dvd_10926938.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "a5c289c26bbcc9165540960258dcef75",

--- a/templates/win-10-ent/x86_64.vars.json
+++ b/templates/win-10-ent/x86_64.vars.json
@@ -6,7 +6,7 @@
     "windows_version"   : "Windows-10",
     "image_name"        : "Windows 10 Enterprise",
     "product_key"       : "NPPR9-FWDCX-D2C8J-H872K-2YT43",
-    "version"           : "20180109_0000",
+    "version"           : "20180119_1200",
     "iso_url"           : "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_10_enterprise_version_1703_updated_july_2017_x64_dvd_10925376.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "b5319ffad571daecbaa6f6e779122179",

--- a/templates/win-10-pro/x86_64.vars.json
+++ b/templates/win-10-pro/x86_64.vars.json
@@ -6,7 +6,7 @@
     "windows_version"   : "Windows-10",
     "image_name"        : "Windows 10 Pro",
     "product_key"       : "W269N-WFGWX-YVC9B-4J6C9-T83GX",
-    "version"           : "20180109_0000",
+    "version"           : "20180119_1200",
     "iso_url"           : "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_10_multi-edition_version_1709_updated_sept_2017_x64_dvd_100090817.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "5e8bdef20c4b468f868f1f579197f7cf",

--- a/templates/win-2008/x86_64.vars.json
+++ b/templates/win-2008/x86_64.vars.json
@@ -6,7 +6,7 @@
     "windows_version"   : "Windows-2008",
     "image_name"        : "Windows Longhorn SERVERSTANDARD",
     "product_key"       : "TM24T-X9RMF-VWXK6-X8JC9-BFGM2",
-    "version"           : "20180109_0000",
+    "version"           : "20180119_1200",
     "iso_url"           : "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2008_with_sp2_x64_dvd_342336_SlipStream_03.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "ab418a455fea422d2582c660ee8cd8f1",

--- a/templates/win-2008r2-wmf5/x86_64.vars.json
+++ b/templates/win-2008r2-wmf5/x86_64.vars.json
@@ -6,7 +6,7 @@
     "windows_version"   : "Windows-2008r2",
     "image_name"        : "Windows Server 2008 R2 SERVERSTANDARD",
     "product_key"       : "YC6KT-GKW9T-YTKYR-T4X34-R7VHC",
-    "version"           : "20180109_0000",
+    "version"           : "20180119_1200",
     "iso_url"           : "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2008_r2_with_sp1_x64_dvd_617601_SlipStream_03.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "f94011cfdc4e0498a01a86a0cafe403e",

--- a/templates/win-2008r2/x86_64.vars.json
+++ b/templates/win-2008r2/x86_64.vars.json
@@ -6,7 +6,7 @@
     "windows_version"   : "Windows-2008r2",
     "image_name"        : "Windows Server 2008 R2 SERVERSTANDARD",
     "product_key"       : "YC6KT-GKW9T-YTKYR-T4X34-R7VHC",
-    "version"           : "20180109_0000",
+    "version"           : "20180119_1200",
     "iso_url"           : "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2008_r2_with_sp1_x64_dvd_617601_SlipStream_03.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "f94011cfdc4e0498a01a86a0cafe403e",

--- a/templates/win-2012/x86_64.vars.json
+++ b/templates/win-2012/x86_64.vars.json
@@ -6,7 +6,7 @@
     "windows_version"   : "Windows-2012",
     "image_name"        : "Windows Server 2012 SERVERSTANDARD",
     "product_key"       : "XC9B7-NBPP2-83J2H-RHMBY-92BT4",
-    "version"           : "20180109_0000",
+    "version"           : "20180119_1200",
     "iso_url"           : "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2012_x64_dvd_915478_SlipStream_03.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "8cc8b3f54bb56dce7936bb1e97e3fc31",

--- a/templates/win-2012r2-core/x86_64.vars.json
+++ b/templates/win-2012r2-core/x86_64.vars.json
@@ -7,7 +7,7 @@
     "image_index"       : "1",
     "image_name"        : "Windows Server 2012 R2 SERVERSTANDARDCORE",
     "product_key"       : "D2N9P-3P6X9-2R39C-7RTCD-MDVJX",
-    "version"           : "20180109_0000",
+    "version"           : "20180119_1200",
     "iso_url"           : "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2012_r2_with_update_x64_dvd_6052708_SlipStream_03.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "8b30b370cfd32e2b90ab4e1b77a31bd3",

--- a/templates/win-2012r2-fr/x86_64.vars.json
+++ b/templates/win-2012r2-fr/x86_64.vars.json
@@ -8,7 +8,7 @@
     "windows_version"   : "Windows-2012r2",
     "image_name"        : "Windows Server 2012 R2 SERVERSTANDARD",
     "product_key"       : "D2N9P-3P6X9-2R39C-7RTCD-MDVJX",
-    "version"           : "20180109_0000",
+    "version"           : "20180119_1200",
     "iso_url"           : "http://osmirror.delivery.puppetlabs.net/iso/windows/fr_windows_server_2012_r2_with_update_x64_dvd_6052713_SlipStream_01.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "2aaeb548f739f417a33439fd6a614090",

--- a/templates/win-2012r2-ja/x86_64.vars.json
+++ b/templates/win-2012r2-ja/x86_64.vars.json
@@ -7,7 +7,7 @@
     "windows_version"   : "Windows-2012r2",
     "image_name"        : "Windows Server 2012 R2 SERVERSTANDARD",
     "product_key"       : "D2N9P-3P6X9-2R39C-7RTCD-MDVJX",
-    "version"           : "20180109_0000",
+    "version"           : "20180119_1200",
     "iso_url"           : "http://osmirror.delivery.puppetlabs.net/iso/windows/ja_windows_server_2012_r2_with_update_x64_dvd_6052738_SlipStream_01.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "d06430e4ddc79330649b4b16d984a3d5",

--- a/templates/win-2012r2-wmf5/x86_64.vars.json
+++ b/templates/win-2012r2-wmf5/x86_64.vars.json
@@ -6,7 +6,7 @@
     "windows_version"   : "Windows-2012r2",
     "image_name"        : "Windows Server 2012 R2 SERVERSTANDARD",
     "product_key"       : "D2N9P-3P6X9-2R39C-7RTCD-MDVJX",
-    "version"           : "20180109_0000",
+    "version"           : "20180119_1200",
     "iso_url"           : "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2012_r2_with_update_x64_dvd_6052708_SlipStream_02.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "3feae58c235f88126a1c099d58abfb8f",

--- a/templates/win-2012r2/x86_64.vars.json
+++ b/templates/win-2012r2/x86_64.vars.json
@@ -7,7 +7,7 @@
     "post_memsize"      : "6144",
     "image_name"        : "Windows Server 2012 R2 SERVERSTANDARD",
     "product_key"       : "D2N9P-3P6X9-2R39C-7RTCD-MDVJX",
-    "version"           : "20180109_0000",
+    "version"           : "20180119_1200",
     "iso_url"           : "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2012_r2_with_update_x64_dvd_6052708_SlipStream_02.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "3feae58c235f88126a1c099d58abfb8f",

--- a/templates/win-2016-core/x86_64.vars.json
+++ b/templates/win-2016-core/x86_64.vars.json
@@ -6,7 +6,7 @@
     "windows_version"   : "Windows-2016",
     "image_name"        : "Windows Server 2016 SERVERSTANDARDCORE",
     "product_key"       : "WC2BQ-8NRM3-FDDYY-2BFGV-KHKQY",
-    "version"           : "20180109_0000",
+    "version"           : "20180119_1200",
     "iso_url"           : "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2016_x64_dvd_9718492_Slip_02.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "47993d89a256960eed2e58c9b394aa97",

--- a/templates/win-2016/x86_64.vars.json
+++ b/templates/win-2016/x86_64.vars.json
@@ -6,7 +6,7 @@
     "windows_version"   : "Windows-2016",
     "image_name"        : "Windows Server 2016 SERVERSTANDARD",
     "product_key"       : "WC2BQ-8NRM3-FDDYY-2BFGV-KHKQY",
-    "version"           : "20180109_0000",
+    "version"           : "20180119_1200",
     "iso_url"           : "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2016_x64_dvd_9718492_Slip_02.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "47993d89a256960eed2e58c9b394aa97",

--- a/templates/win-7-wmf5/x86_64.vars.json
+++ b/templates/win-7-wmf5/x86_64.vars.json
@@ -7,7 +7,7 @@
     "image_name"        : "Windows 7 Enterprise",
     "product_key"       : "33PXH-7Y6KF-2VJC9-XBBR8-HVTHH",
     "hypervisor"        : "VMWare",
-    "version"           : "20180109_0000",
+    "version"           : "20180119_1200",
     "iso_url"           : "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_7_enterprise_with_sp1_x64_dvd_u_677651_SlipStream_03.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "4246cfa663a9a581d2da4ba784554308",

--- a/templates/win-7/x86_64.vars.json
+++ b/templates/win-7/x86_64.vars.json
@@ -7,7 +7,7 @@
     "image_name"        : "Windows 7 Enterprise",
     "product_key"       : "33PXH-7Y6KF-2VJC9-XBBR8-HVTHH",
     "hypervisor"        : "VMWare",
-    "version"           : "20180109_0000",
+    "version"           : "20180119_1200",
     "iso_url"           : "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_7_enterprise_with_sp1_x64_dvd_u_677651_SlipStream_03.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "4246cfa663a9a581d2da4ba784554308",

--- a/templates/win-81/x86_64.vars.json
+++ b/templates/win-81/x86_64.vars.json
@@ -6,7 +6,7 @@
     "windows_version"   : "Windows-8.1",
     "image_name"        : "Windows 8.1 Enterprise",
     "product_key"       : "MHF9N-XY6XB-WVXMC-BTDCT-MKKG7",
-    "version"           : "20180109_0000",
+    "version"           : "20180119_1200",
     "iso_url"           : "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_8.1_enterprise_with_update_x64_dvd_6054382_SlipStream_01.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "ce996fb7136d55314747c5cef2602b27",

--- a/templates/win-common/files/Autounattend.xslt
+++ b/templates/win-common/files/Autounattend.xslt
@@ -145,7 +145,7 @@
   </xsl:template> 
 
   <!-- Windows 7 Needs Timezone set in the OOBE phase too -->
-  <xsl:template match='u:unattend/u:settings/u:component[@name="Microsoft-Windows-Shell-Setup"]/u:TimeZone'>
+  <xsl:template match='u:unattend/u:settings[@pass="oobeSystem"]/u:component[@name="Microsoft-Windows-Shell-Setup"]/u:TimeZone'>
     <xsl:if test="$WindowsVersion = 'Windows-7'">
       <xsl:copy>
         <xsl:apply-templates select="@*|node()"/>


### PR DESCRIPTION
The Timezone setting for the Windows Images wasn't set to UTC.
This was a side effect of fixing a timezone issue for win-7 that
filtered the setting out completely for all images.

Also add in an IP Anycast address for the NTP server as recommended by
IT.