### PR TITLE
(maint) Update vsphere setup script to work with official RedHat images

### DIFF
--- a/manifests/modules/packer/templates/vsphere/redhat.rb.erb
+++ b/manifests/modules/packer/templates/vsphere/redhat.rb.erb
@@ -19,7 +19,7 @@ Kernel.system('hostname -F /etc/hostname')
 
 puts '- Re-obtaining DHCP lease...'
 
-<% if (@operatingsystem == 'CentOS') or (@operatingsystem == 'Scientific') or (@operatingsystem == 'OracleLinux') -%>
+<% if (@operatingsystem == 'RedHat') or (@operatingsystem == 'CentOS') or (@operatingsystem == 'Scientific') or (@operatingsystem == 'OracleLinux') -%>
   <% if @operatingsystemmajrelease == '7' -%>
     File.open('/var/lib/NetworkManager/dhclient-ens160.conf', 'a') do |f|
       f << "send host-name #{hostname}"


### PR DESCRIPTION
This was a tweak I had to make to get the redhat fips image to build. Previously we haven't had any official RedHat templates in this repo, only CentOS/Scientific/Oracle.