### PR TITLE
(WIN-73) Initial Win-2008r2 GCE Template

### DIFF
--- a/templates/win/2008r2/x86_64/vars.json
+++ b/templates/win/2008r2/x86_64/vars.json
@@ -1,14 +1,16 @@
 {
-    "template_name"     : "win-2008r2-x86_64",
-    "beakerhost"        : "windows2008r2-64",
-    "vbox_guest_os"     : "Windows2008_64",
-    "vmware_guest_os"   : "windows7srv-64",
-    "windows_version"   : "Windows-2008r2",
-    "image_name"        : "Windows Server 2008 R2 SERVERSTANDARD",
-    "product_key"       : "YC6KT-GKW9T-YTKYR-T4X34-R7VHC",
-    "version"           : "20180122_1800",
-    "iso_url"           : "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2008_r2_with_sp1_x64_dvd_617601_SlipStream_03.iso",
-    "iso_checksum_type" : "md5",
-    "iso_checksum"      : "f94011cfdc4e0498a01a86a0cafe403e",
-    "boot_command"      : "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter>"
+    "template_name"             : "win-2008r2-x86_64",
+    "beakerhost"                : "windows2008r2-64",
+    "vbox_guest_os"             : "Windows2008_64",
+    "vmware_guest_os"           : "windows7srv-64",
+    "windows_version"           : "Windows-2008r2",
+    "image_name"                : "Windows Server 2008 R2 SERVERSTANDARD",
+    "product_key"               : "YC6KT-GKW9T-YTKYR-T4X34-R7VHC",
+    "gce_source_image"          : "windows-server-2008-r2-dc-v20180109",
+    "gce_source_image_family"   : "windows-2008-r2",
+    "version"                   : "20180122_1800",
+    "iso_url"                   : "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2008_r2_with_sp1_x64_dvd_617601_SlipStream_03.iso",
+    "iso_checksum_type"         : "md5",
+    "iso_checksum"              : "f94011cfdc4e0498a01a86a0cafe403e",
+    "boot_command"              : "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter>"
 }

--- a/templates/win/common/google.base.json
+++ b/templates/win/common/google.base.json
@@ -1,0 +1,56 @@
+{
+  "variables": {
+ 
+    "gce_network"         : "default",
+    "gce_zone"            : "us-central1-a",
+    "gce_project_id"      : "appveyor-images",
+    "gce_account_file"    : "{{env `PACKER_GCE_ACCOUNT_FILE`}}",
+
+    "winrm_username"      : "packer_admin"
+
+  },
+
+  "description": "Builds a Windows base template VM for use in VMware",
+
+  "_comment": [
+      ""
+  ],
+  "builders": [{
+    "type"                : "googlecompute",
+    "image_name"          : "packer-test-image",
+    "network"             : "{{user `gce_network`}}",
+    "zone"                : "{{user `gce_zone`}}",
+    "account_file"        : "{{user `gce_account_file`}}",
+    "project_id"          : "{{user `gce_project_id`}}",
+    "source_image_family" : "{{user `gce_source_image_family`}}",
+    "disk_size"           : "50",
+    "machine_type"        : "{{user `gce_machine_type`}}",
+    "communicator"        : "winrm",
+    "winrm_username"      : "{{user `winrm_username`}}",
+    "winrm_insecure"      : true,
+    "winrm_use_ssl"       : true,
+    "omit_external_ip"    : false,
+    "metadata": {
+      "windows-startup-script-cmd": "winrm quickconfig -quiet & net localgroup administrators {{user `winrm_username`}} /add & winrm set winrm/config/service/auth @{Basic=\"true\"}"
+    }
+  }
+  ],
+  "provisioners": [
+    {
+      "type": "powershell",
+      "environment_vars" : [
+        "foo=Bar",
+        "Mumble=Flame"
+      ],
+      "inline": [
+        "Write-Output 'Hello World'",
+        "Write-Output 'WinRMConfig: {{ .Winrmconfig}}'",
+        "Write-Output 'Vars: {{.Vars}}'",
+        "Write-Output 'Name: {{.Name}}'",
+        "Write-Output 'project: {{user `gce_project_id`}}'",
+        "Write-Output 'Build Name: {{build_name}}'",
+        "Write-Output 'Path: {{.Path}}'"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
First pass at Windows 2008r2 GCE Template.
This is being added as a stub for the moment, as there are some issues
with this method that need to be resolved.

In particular, unable to translate variables in the powershell provider
which has been opened as a packer issue (5878)

There is also the question if we can obtain the winrm_password which is
set using the GCE Api - this will be needed to enable auto-login which
is required for Appveyor

Submitting this in the interim as practice code.