### PR TITLE
RHEL 6.8 and 7.2 Templates and Improvements

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -1,3 +1,4 @@
+include packer::repos
 include packer::updates
 include packer::sshd
 include packer::networking

--- a/manifests/modules/packer/manifests/repos.pp
+++ b/manifests/modules/packer/manifests/repos.pp
@@ -1,0 +1,37 @@
+# For platforms that come up without any configured software repos
+# (e.g, RHEL), this class is used to configure repos pointing to
+# our internal mirrors so that packages can be installed by other
+# puppet classes (mainly vmtools.pp).
+#
+# TODO: Consolidate this and the vsphere repos manifest into a single
+# module, which can be conditionally included in base.pp for targeted
+# platforms and for all cases in vsphere.pp.
+class packer::repos {
+
+  if $::operatingsystem == 'RedHat' {
+
+    $repo_mirror = 'https://artifactory.delivery.puppetlabs.net/artifactory'
+    $os_mirror   = 'http://osmirror.delivery.puppetlabs.net'
+    $gpgkey      = 'RPM-GPG-KEY-redhat-release'
+
+    resources { 'yumrepo':
+      purge => true,
+    }
+
+    # We don't have consistent mirror urls between RedHat versions:
+    $base_url = $::operatingsystemmajrelease ? {
+      '7' => "${repo_mirror}/rpm-rhel/7.2/${::architecture}",
+      '6' => "${repo_mirror}/rpm-rhel/6.8/${::architecture}",
+      '5' => "${os_mirror}/rhel50server-${::architecture}/RPMS.all"
+    }
+
+    yumrepo { "localmirror-everything":
+      descr    => "localmirror-everything",
+      baseurl  => "${base_url}",
+      gpgcheck => "1",
+      gpgkey   => "file:///etc/pki/rpm-gpg/${gpgkey}"
+    }
+
+  }
+
+}

--- a/manifests/modules/packer/manifests/vsphere/repos.pp
+++ b/manifests/modules/packer/manifests/vsphere/repos.pp
@@ -77,11 +77,19 @@ class packer::vsphere::repos inherits packer::vsphere::params {
         purge => true,
       }
 
-      $base_url = $::operatingsystem ? {
-        'Fedora'      => "${repo_mirror}/rpm__remote_fedora/releases/${::operatingsystemmajrelease}/Everything/${::architecture}/os",
-        'CentOS'      => "${repo_mirror}/rpm__remote_centos/${::operatingsystemmajrelease}/os/${::architecture}",
-        'RedHat'      => "${os_mirror}/rhel${::operatingsystemmajrelease}latestserver-${::architecture}/RPMS.all",
-        'OracleLinux' => "${os_mirror}/${loweros}-${::operatingsystemmajrelease}-${::architecture}/RPMS.all" 
+      if $::operatingsystem == 'RedHat' {
+        # We don't have consistent mirror urls between RedHat versions:
+        $base_url = $::operatingsystemmajrelease ? {
+          '7' => "${repo_mirror}/rpm-rhel/7.2/${::architecture}",
+          '6' => "${repo_mirror}/rpm-rhel/6.8/${::architecture}",
+          '5' => "${os_mirror}/rhel50server-${::architecture}/RPMS.all"
+        }
+      } else {
+        $base_url = $::operatingsystem ? {
+          'Fedora'      => "${repo_mirror}/rpm__remote_fedora/releases/${::operatingsystemmajrelease}/Everything/${::architecture}/os",
+          'CentOS'      => "${repo_mirror}/rpm__remote_centos/${::operatingsystemmajrelease}/os/${::architecture}",
+          'OracleLinux' => "${os_mirror}/${loweros}-${::operatingsystemmajrelease}-${::architecture}/RPMS.all"
+        }
       }
 
       yumrepo { "localmirror-everything":

--- a/templates/common/vmware.vsphere.nocm.json
+++ b/templates/common/vmware.vsphere.nocm.json
@@ -1,13 +1,15 @@
 {
   "variables": {
-    "template_name"                         : null,
-    "beakerhost"                            : null,
-    "version"                               : null,
-    "puppet_aio"                            : null,
+    "template_name"                                        : null,
+    "beakerhost"                                           : null,
+    "version"                                              : null,
+    "puppet_aio"                                           : null,
 
-    "vmware_vsphere_nocm_required_modules"  : null,
-    "vmware_vsphere_nocm_vmx_data_memsize"  : null,
-    "vmware_vsphere_nocm_vmx_data_numvcpus" : null,
+    "vmware_vsphere_nocm_required_modules"                 : null,
+    "vmware_vsphere_nocm_vmx_data_memsize"                 : null,
+    "vmware_vsphere_nocm_vmx_data_numvcpus"                : null,
+    "vmware_vsphere_nocm_vmx_data_ethernet0_virtualDev"    : "vmxnet3",
+    "vmware_vsphere_nocm_vmx_data_ethernet0_pciSlotNumber" : "33",
 
     "project_root"                          : "../../../..",
     "headless"                              : "true",
@@ -62,7 +64,9 @@
       },
       "vmx_data_post"                       : {
         "memsize"                           : "{{user `vmware_vsphere_nocm_vmx_data_memsize`}}",
-        "numvcpus"                          : "{{user `vmware_vsphere_nocm_vmx_data_numvcpus`}}"
+        "numvcpus"                          : "{{user `vmware_vsphere_nocm_vmx_data_numvcpus`}}",
+        "ethernet0.virtualDev"              : "{{user `vmware_vsphere_nocm_vmx_data_ethernet0_virtualDev`}}",
+        "ethernet0.pciSlotNumber"           : "{{user `vmware_vsphere_nocm_vmx_data_ethernet0_pciSlotNumber`}}"
       }
     }
   ],

--- a/templates/redhat/6.8/common/files/ks.cfg
+++ b/templates/redhat/6.8/common/files/ks.cfg
@@ -1,0 +1,40 @@
+install
+cdrom
+lang en_US.UTF-8
+keyboard us
+network --bootproto=dhcp
+rootpw --iscrypted $1$v4K9E8Wj$gZIHJ5JtQL5ZGZXeqSSsd0
+firewall --enabled --service=ssh
+authconfig --enableshadow --passalgo=sha512
+selinux --disabled
+timezone UTC
+bootloader --location=mbr
+
+text
+skipx
+zerombr
+
+clearpart --all --initlabel
+autopart
+
+auth  --useshadow  --enablemd5
+firstboot --disabled
+reboot --eject
+
+%packages --ignoremissing
+@core
+bzip2
+kernel-devel
+kernel-headers
+gcc
+make
+net-tools
+patch
+perl
+curl
+wget
+nfs-utils
+-ipw2100-firmware
+-ipw2200-firmware
+-ivtv-firmware
+%end

--- a/templates/redhat/6.8/i386/vars.json
+++ b/templates/redhat/6.8/i386/vars.json
@@ -1,0 +1,13 @@
+{
+    "template_name"                         : "redhat-6.8-i386",
+    "template_os"                           : "rhel6",
+    "beakerhost"                            : "centos6-32",
+    "version"                               : "0.0.1",
+    "iso_url"                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/rhel-server-6.8-i386-dvd.iso",
+    "iso_checksum"                          : "22d1754f3e642c2b60234c3f97d1d6689b33bef4dd2252e3f52cd9aa823bb5f3",
+    "iso_checksum_type"                     : "sha256",
+    "boot_command"                          : "<tab> <wait>text ks=hd:fd0:/ks.cfg<wait><enter>",
+    "vmware_vsphere_nocm_vmx_data_memsize"  : "4096",
+    "vmware_vsphere_nocm_vmx_data_numvcpus" : "2",
+    "puppet_aio"                            : "http://yum.puppetlabs.com/el/6/PC1/i386/puppet-agent-1.10.9-1.el6.i386.rpm"
+}

--- a/templates/redhat/6.8/x86_64/vars.json
+++ b/templates/redhat/6.8/x86_64/vars.json
@@ -1,0 +1,13 @@
+{
+    "template_name"                         : "redhat-6.8-x86_64",
+    "template_os"                           : "rhel6-64",
+    "beakerhost"                            : "rhel6-64",
+    "version"                               : "0.0.1",
+    "iso_url"                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/rhel-server-6.8-x86_64-dvd.iso",
+    "iso_checksum"                          : "d35fd1af20f6adef9b11b46c2534ae8b6e18de7754889e2b51808b436dff2804",
+    "iso_checksum_type"                     : "sha256",
+    "boot_command"                          : "<tab> <wait>text ks=hd:fd0:/ks.cfg<wait><enter>",
+    "vmware_vsphere_nocm_vmx_data_memsize"  : "4096",
+    "vmware_vsphere_nocm_vmx_data_numvcpus" : "2",
+    "puppet_aio"                            : "http://yum.puppetlabs.com/el/6/PC1/x86_64/puppet-agent-1.10.9-1.el6.x86_64.rpm"
+}

--- a/templates/redhat/7.2/common/files/ks.cfg
+++ b/templates/redhat/7.2/common/files/ks.cfg
@@ -3,6 +3,7 @@ cdrom
 lang en_US.UTF-8
 keyboard us
 network --bootproto=dhcp
+network --device=ens33 --onboot=yes
 rootpw --iscrypted $1$v4K9E8Wj$gZIHJ5JtQL5ZGZXeqSSsd0
 firewall --enabled --service=ssh
 authconfig --enableshadow --passalgo=sha512
@@ -34,7 +35,6 @@ perl
 curl
 wget
 nfs-utils
-yum-autoupdate
 -ipw2100-firmware
 -ipw2200-firmware
 -ivtv-firmware

--- a/templates/redhat/7.2/x86_64/vars.json
+++ b/templates/redhat/7.2/x86_64/vars.json
@@ -8,6 +8,5 @@
     "iso_checksum_type"                     : "sha256",
     "vmware_vsphere_nocm_vmx_data_memsize"  : "4096",
     "vmware_vsphere_nocm_vmx_data_numvcpus" : "2",
-    "puppet_aio"                            : "http://yum.puppetlabs.com/el/7/PC1/x86_64/puppet-agent-1.10.9-1.el7.x86_64.rpm",
-    "vmware_base_provisioning_scripts"      : "../../common/files/enable-rhel-repos.sh,../../../../scripts/bootstrap-aio.sh"
+    "puppet_aio"                            : "http://yum.puppetlabs.com/el/7/PC1/x86_64/puppet-agent-1.10.9-1.el7.x86_64.rpm"
 }


### PR DESCRIPTION
I think somewhere down the line, the ethernet0 default of vmxnet3 disappeared from the vsphere template. This restores it but in a manner that allows for variable overrides if for some reason a platform doesn't want to use that device (we generally want it used everywhere possible for better networking performance).

It also eliminates the need for using the enable-rhel-repos bootstrap script and puppetizes the configuring of a default yum mirror for RHEL vmware base template installs.I'll finally remove that script after updating the RHEL 7.0-fips template.

