### PR TITLE
(maint) Update redhat-fips 7.2 image to use new mirror repos

### DIFF
--- a/templates/redhat/7.2-fips/x86_64/vars.json
+++ b/templates/redhat/7.2-fips/x86_64/vars.json
@@ -2,7 +2,7 @@
     "template_name"                         : "redhat-fips-7.2-x86_64",
     "template_os"                           : "rhel7-64",
     "beakerhost"                            : "",
-    "version"                               : "0.0.1",
+    "version"                               : "0.0.2",
     "iso_url"                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/rhel-server-7.2-x86_64-dvd.iso",
     "iso_checksum"                          : "03f3a0291634335f6995534d829bd21ffaa0d000004dfeb1b2fb81052d64a4d5",
     "iso_checksum_type"                     : "sha256",


### PR DESCRIPTION
This just amounts to a version bump, as a rebuild will pick up the new
repo scheme as defined in repos.pp.