### PR TITLE
RHEL 6.8 Fixes

### DIFF
--- a/manifests/modules/packer/manifests/repos.pp
+++ b/manifests/modules/packer/manifests/repos.pp
@@ -22,7 +22,7 @@ class packer::repos {
     # TODO: RHEL 5 needs further refactoring
     $base_url = $::operatingsystemmajrelease ? {
       '7' => "${repo_mirror}/rpm__remote_rhel-72",
-      '6' => "${repo_mirror}/rpm__remote_rhel-68/${::architecture}",
+      '6' => "${repo_mirror}/rpm__remote_rhel-68-${::architecture}",
       '5' => "${os_mirror}/rhel50server-${::architecture}/RPMS.all"
     }
 

--- a/manifests/modules/packer/manifests/vsphere/repos.pp
+++ b/manifests/modules/packer/manifests/vsphere/repos.pp
@@ -82,7 +82,7 @@ class packer::vsphere::repos inherits packer::vsphere::params {
         # TODO: RHEL 5 needs further refactoring
         $base_url = $::operatingsystemmajrelease ? {
           '7' => "${repo_mirror}/rpm__remote_rhel-72",
-          '6' => "${repo_mirror}/rpm__remote_rhel-68/${::architecture}",
+          '6' => "${repo_mirror}/rpm__remote_rhel-68-${::architecture}",
           '5' => "${os_mirror}/rhel50server-${::architecture}/RPMS.all"
         }
       } else {

--- a/templates/redhat/6.8/i386/vars.json
+++ b/templates/redhat/6.8/i386/vars.json
@@ -1,8 +1,8 @@
 {
     "template_name"                         : "redhat-6.8-i386",
     "template_os"                           : "rhel6",
-    "beakerhost"                            : "centos6-32",
-    "version"                               : "0.0.1",
+    "beakerhost"                            : "redhat6-32",
+    "version"                               : "0.0.2",
     "iso_url"                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/rhel-server-6.8-i386-dvd.iso",
     "iso_checksum"                          : "22d1754f3e642c2b60234c3f97d1d6689b33bef4dd2252e3f52cd9aa823bb5f3",
     "iso_checksum_type"                     : "sha256",

--- a/templates/redhat/6.8/x86_64/vars.json
+++ b/templates/redhat/6.8/x86_64/vars.json
@@ -1,8 +1,8 @@
 {
     "template_name"                         : "redhat-6.8-x86_64",
     "template_os"                           : "rhel6-64",
-    "beakerhost"                            : "rhel6-64",
-    "version"                               : "0.0.1",
+    "beakerhost"                            : "redhat6-64",
+    "version"                               : "0.0.2",
     "iso_url"                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/rhel-server-6.8-x86_64-dvd.iso",
     "iso_checksum"                          : "d35fd1af20f6adef9b11b46c2534ae8b6e18de7754889e2b51808b436dff2804",
     "iso_checksum_type"                     : "sha256",

--- a/templates/redhat/7.2-fips/x86_64/vars.json
+++ b/templates/redhat/7.2-fips/x86_64/vars.json
@@ -1,7 +1,7 @@
 {
     "template_name"                         : "redhat-fips-7.2-x86_64",
     "template_os"                           : "rhel7-64",
-    "beakerhost"                            : "",
+    "beakerhost"                            : "redhatfips7-64",
     "version"                               : "0.0.2",
     "iso_url"                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/rhel-server-7.2-x86_64-dvd.iso",
     "iso_checksum"                          : "03f3a0291634335f6995534d829bd21ffaa0d000004dfeb1b2fb81052d64a4d5",

--- a/templates/redhat/7.2/x86_64/vars.json
+++ b/templates/redhat/7.2/x86_64/vars.json
@@ -1,7 +1,7 @@
 {
     "template_name"                         : "redhat-7.2-x86_64",
     "template_os"                           : "rhel7-64",
-    "beakerhost"                            : "rhel7-64",
+    "beakerhost"                            : "redhat7-64",
     "version"                               : "0.0.2",
     "iso_url"                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/rhel-server-7.2-x86_64-dvd.iso",
     "iso_checksum"                          : "03f3a0291634335f6995534d829bd21ffaa0d000004dfeb1b2fb81052d64a4d5",


### PR DESCRIPTION
Previously I've seen RHEL 6.8 x86_64 kernel panic on boot when imported into vCenter, but the panic isn't reproducible locally. I've built this template locally and uploaded it into vCenter and it actually boots. So I'm wondering if the issue is actually what version of VMWare is used to *build* the template, and if it turns out that building it via the Jenkins imaging pipeline again results in a template that won't boot, I can at least rebuild it locally and upload it from my own host.