### PR TITLE
Centos 7.4

### DIFF
--- a/manifests/modules/packer/manifests/networking/params.pp
+++ b/manifests/modules/packer/manifests/networking/params.pp
@@ -8,7 +8,7 @@ class packer::networking::params {
 
     redhat: {
       case $::operatingsystemrelease {
-        '7.0', '7.0.1406', '7.1.1503', '7.2.1511', '7.2', '7.3.1611': {
+        '7.0', '7.0.1406', '7.1.1503', '7.2.1511', '7.2', '7.3.1611', '7.4.1708': {
           case $::provisioner {
             'virtualbox': { $interface_script = '/etc/sysconfig/network-scripts/ifcfg-enp0s3' }
             'vmware':     { $interface_script = '/etc/sysconfig/network-scripts/ifcfg-ens33' }

--- a/templates/centos/7.4/common/files/ks.cfg
+++ b/templates/centos/7.4/common/files/ks.cfg
@@ -1,0 +1,42 @@
+install
+cdrom
+lang en_US.UTF-8
+keyboard us
+network --bootproto=dhcp
+rootpw --iscrypted $1$v4K9E8Wj$gZIHJ5JtQL5ZGZXeqSSsd0
+firewall --disabled 
+authconfig --enableshadow --passalgo=sha512
+selinux --disabled
+timezone UTC
+bootloader --location=mbr
+
+text
+skipx
+zerombr
+
+clearpart --all --initlabel
+autopart
+
+auth  --useshadow  --enablemd5
+firstboot --disabled
+reboot --eject
+
+%packages --ignoremissing
+@core
+bzip2
+kernel-devel
+kernel-headers
+gcc
+make
+net-tools
+patch
+perl
+curl
+wget
+nfs-utils
+yum-autoupdate
+-ipw2100-firmware
+-ipw2200-firmware
+-ivtv-firmware
+%end
+

--- a/templates/centos/7.4/x86_64/vars.json
+++ b/templates/centos/7.4/x86_64/vars.json
@@ -6,6 +6,7 @@
     "iso_url"                               : "http://centos.mirror.nucleus.be/7.4.1708/isos/x86_64/CentOS-7-x86_64-DVD-1708.iso",
     "iso_checksum"                          : "ec7500d4b006702af6af023b1f8f1b890b6c7ee54400bb98cef968b883cd6546",
     "iso_checksum_type"                     : "sha256",
+    "docker_base_image"                     : "centos:7.4.1708",
     "virtualbox_base_template_os"           : "RedHat_64",
     "vmware_vsphere_nocm_vmx_data_memsize"  : "4096",
     "vmware_vsphere_nocm_vmx_data_numvcpus" : "2",

--- a/templates/centos/7.4/x86_64/vars.json
+++ b/templates/centos/7.4/x86_64/vars.json
@@ -1,0 +1,13 @@
+{
+    "template_name"                         : "centos-7.4-x86_64",
+    "template_os"                           : "rhel7-64",
+    "beakerhost"                            : "centos7-64",
+    "version"                               : "0.0.1",
+    "iso_url"                               : "http://centos.mirror.nucleus.be/7.4.1708/isos/x86_64/CentOS-7-x86_64-DVD-1708.iso",
+    "iso_checksum"                          : "ec7500d4b006702af6af023b1f8f1b890b6c7ee54400bb98cef968b883cd6546",
+    "iso_checksum_type"                     : "sha256",
+    "virtualbox_base_template_os"           : "RedHat_64",
+    "vmware_vsphere_nocm_vmx_data_memsize"  : "4096",
+    "vmware_vsphere_nocm_vmx_data_numvcpus" : "2",
+    "puppet_aio"                            : "http://yum.puppetlabs.com/el/7/PC1/x86_64/puppet-agent-1.10.9-1.el7.x86_64.rpm"
+}

--- a/templates/centos/common/vars.json
+++ b/templates/centos/common/vars.json
@@ -1,7 +1,13 @@
 {
   "floppy_dirs"                               : "",
   "floppy_files"                              : "../common/files/ks.cfg",
+  "http_directory"                            : "../common/files/",
   "boot_command"                              : "<tab> <wait>inst.text inst.ks=hd:fd0:/ks.cfg<wait><enter>",
+  "libvirt_disk_interface"                    : "virtio-scsi",
+  "libvirt_net_device"                        : "virtio-net-pci",
+  "libvirt_base_required_modules"             : "puppetlabs-stdlib saz-ssh saz-sudo",
+  "virtualbox_base_required_modules"          : "puppetlabs-stdlib saz-ssh saz-sudo",
+  "vagrant_required_modules"                  : "puppetlabs-stdlib saz-ssh saz-sudo",
   "vmware_base_vmx_data_ethernet0_virtualDev" : "e1000",
   "vmware_vsphere_nocm_required_modules"      : "puppetlabs-stdlib example42-network puppetlabs-firewall"
 }

--- a/templates/common/docker.nocm.json
+++ b/templates/common/docker.nocm.json
@@ -1,0 +1,99 @@
+{
+  "variables":
+    {
+      "template_name"                        : null,
+      "beakerhost"                           : null,
+      "version"                              : null,
+      "puppet_aio"                           : null,
+
+      "vagrant_required_modules"             : null,
+
+      "project_root"                         : "../../../..",
+      "headless"                             : "true",
+      "template_config"                      : "nocm",
+      "provisioner"                          : "docker",
+      "shutdown_command"                     : "/sbin/halt -h -p",
+
+      "packer_output_dir"                    : "{{env `PACKER_VM_OUTPUT_DIR`}}",
+      "packer_source_dir"                    : "{{env `PACKER_VM_SRC_DIR`}}",
+
+      "docker_base_image"                    : null,
+      "docker_pull_url"                      : "{{env `PACKER_DOCKER_PULL_URL`}}",
+      "docker_pull_port"                     : "{{env `PACKER_DOCKER_PULL_PORT`}}",
+      "docker_push_url"                      : "{{env `PACKER_DOCKER_PUSH_URL`}}",
+      "docker_push_port"                     : "{{env `PACKER_DOCKER_PUSH_PORT`}}",
+      "docker_push_login"                    : "{{env `PACKER_DOCKER_PUSH_LOGIN`}}",
+      "docker_push_password"                 : "{{env `PACKER_DOCKER_PUSH_PASSWORD`}}"
+    },
+
+    "description"                            : "Builds a Linux vagrantbox nocm VM for use with vagrant-docker",
+
+    "builders": [
+    {
+      "type"                                 : "docker",
+      "image"                                : "{{user `docker_pull_url`}}:{{user `docker_pull_port`}}/{{user `docker_base_image`}}",
+      "commit"                               : true,
+      "privileged"                           : true,
+      "changes"                              : [
+                                                  "LABEL version={{user `version`}}",
+                                                  "CMD /usr/sbin/init",
+                                                  "VOLUME [ '/sys/fs/cgroup' ]",
+                                                  "ENV init /lib/systemd/systemd",
+                                                  "ONBUILD RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); rm -f /lib/systemd/system/multi-user.target.wants/*; rm -f /etc/systemd/system/*.wants/*; rm -f /lib/systemd/system/local-fs.target.wants/*; rm -f /lib/systemd/system/sockets.target.wants/*udev*; rm -f /lib/systemd/system/sockets.target.wants/*initctl*; rm -f /lib/systemd/system/basic.target.wants/*; rm -f /lib/systemd/system/anaconda.target.wants/*; systemctl enable sshd;",
+                                                 "CMD ['/sbin/init']"
+                                               ]
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type"                                 : "shell",
+      "inline"                               : ["yum -y install sudo openssh-server openssh-clients"]
+    },
+
+    {
+      "type"                                 : "shell",
+      "execute_command"                      : "{{.Vars}} sh '{{.Path}}' {{user `vagrant_required_modules`}}",
+      "environment_vars"                     : [ "PUPPET_AIO={{user `puppet_aio`}}" ],
+      "scripts"                              : [ "{{user `project_root`}}/scripts/bootstrap-aio.sh" ]
+    },
+
+    {
+      "type"                                 : "file",
+      "source"                               : "{{user `project_root`}}/hiera",
+      "destination"                          : "/tmp/packer-puppet-masterless"
+    },
+
+    {
+      "type"                                : "puppet-masterless",
+      "execute_command"                     : "{{.FacterVars}} PATH=$PATH:/opt/puppetlabs/bin /opt/puppetlabs/bin/puppet apply --verbose --detailed-exitcodes --hiera_config='/tmp/packer-puppet-masterless/hiera/hiera.yaml' --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "facter"                              : {
+                                                 "provisioner": "{{user `provisioner`}}"
+                                              },
+      "manifest_dir"                        : "{{user `project_root`}}/manifests",
+      "manifest_file"                       : "{{user `project_root`}}/manifests/vagrant/{{user `template_config`}}.pp"
+    },
+
+    {
+      "type"                                : "shell",
+      "environment_vars"                    : [ "PUPPET_AIO={{user `puppet_aio`}}" ],
+      "scripts"                             : [
+                                                "{{user `project_root`}}/scripts/cleanup-aio.sh",
+                                                "{{user `project_root`}}/scripts/cleanup-packer.sh",
+                                                "{{user `project_root`}}/scripts/cleanup-scrub.sh"
+                                              ]
+    }
+  ],
+
+  "post-processors": [
+    [
+      {
+        "type"                              : "docker-tag",
+        "repository"                        : "{{user `docker_push_url`}}:{{user `docker_push_port`}}/{{user `template_name`}}-{{user `template_config`}}",
+        "tag"                               : "{{user `version`}}"
+      },
+      "docker-push"
+    ]
+  ]
+
+}

--- a/templates/common/docker.puppet.json
+++ b/templates/common/docker.puppet.json
@@ -1,0 +1,98 @@
+{
+  "variables":
+    {
+      "template_name"                        : null,
+      "beakerhost"                           : null,
+      "version"                              : null,
+      "puppet_aio"                           : null,
+
+      "vagrant_required_modules"             : null,
+
+      "project_root"                         : "../../../..",
+      "headless"                             : "true",
+      "template_config"                      : "puppet",
+      "provisioner"                          : "docker",
+      "shutdown_command"                     : "/sbin/halt -h -p",
+
+      "packer_output_dir"                    : "{{env `PACKER_VM_OUTPUT_DIR`}}",
+      "packer_source_dir"                    : "{{env `PACKER_VM_SRC_DIR`}}",
+
+      "docker_base_image"                    : null,
+      "docker_pull_url"                      : "{{env `PACKER_DOCKER_PULL_URL`}}",
+      "docker_pull_port"                     : "{{env `PACKER_DOCKER_PULL_PORT`}}",
+      "docker_push_url"                      : "{{env `PACKER_DOCKER_PUSH_URL`}}",
+      "docker_push_port"                     : "{{env `PACKER_DOCKER_PUSH_PORT`}}",
+      "docker_push_login"                    : "{{env `PACKER_DOCKER_PUSH_LOGIN`}}",
+      "docker_push_password"                 : "{{env `PACKER_DOCKER_PUSH_PASSWORD`}}"
+    },
+
+    "description"                            : "Builds a Linux vagrantbox nocm VM for use with vagrant-docker",
+
+    "builders": [
+    {
+      "type"                                 : "docker",
+      "image"                                : "{{user `docker_pull_url`}}:{{user `docker_pull_port`}}/{{user `docker_base_image`}}",
+      "commit"                               : true,
+      "privileged"                           : true,
+      "changes"                              : [
+                                                  "LABEL version={{user `version`}}",
+                                                  "CMD /usr/sbin/init",
+                                                  "VOLUME [ '/sys/fs/cgroup' ]",
+                                                  "ENV init /lib/systemd/systemd",
+                                                  "ONBUILD RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); rm -f /lib/systemd/system/multi-user.target.wants/*; rm -f /etc/systemd/system/*.wants/*; rm -f /lib/systemd/system/local-fs.target.wants/*; rm -f /lib/systemd/system/sockets.target.wants/*udev*; rm -f /lib/systemd/system/sockets.target.wants/*initctl*; rm -f /lib/systemd/system/basic.target.wants/*; rm -f /lib/systemd/system/anaconda.target.wants/*; systemctl enable sshd;",
+                                                 "CMD ['/sbin/init']"
+                                               ]
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type"                                 : "shell",
+      "inline"                               : ["yum -y install sudo openssh-server openssh-clients"]
+    },
+
+    {
+      "type"                                 : "shell",
+      "execute_command"                      : "{{.Vars}} sh '{{.Path}}' {{user `vagrant_required_modules`}}",
+      "environment_vars"                     : [ "PUPPET_AIO={{user `puppet_aio`}}" ],
+      "scripts"                              : [ "{{user `project_root`}}/scripts/bootstrap-aio.sh" ]
+    },
+
+    {
+      "type"                                 : "file",
+      "source"                               : "{{user `project_root`}}/hiera",
+      "destination"                          : "/tmp/packer-puppet-masterless"
+    },
+
+    {
+      "type"                                : "puppet-masterless",
+      "execute_command"                     : "{{.FacterVars}} PATH=$PATH:/opt/puppetlabs/bin /opt/puppetlabs/bin/puppet apply --verbose --detailed-exitcodes --hiera_config='/tmp/packer-puppet-masterless/hiera/hiera.yaml' --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "facter"                              : {
+                                                 "provisioner": "{{user `provisioner`}}"
+                                              },
+      "manifest_dir"                        : "{{user `project_root`}}/manifests",
+      "manifest_file"                       : "{{user `project_root`}}/manifests/vagrant/{{user `template_config`}}.pp"
+    },
+
+    {
+      "type"                                : "shell",
+      "environment_vars"                    : [ "PUPPET_AIO={{user `puppet_aio`}}" ],
+      "scripts"                             : [
+                                                "{{user `project_root`}}/scripts/cleanup-packer.sh",
+                                                "{{user `project_root`}}/scripts/cleanup-scrub.sh"
+                                              ]
+    }
+  ],
+
+  "post-processors": [
+    [
+      {
+        "type"                              : "docker-tag",
+        "repository"                        : "{{user `docker_push_url`}}:{{user `docker_push_port`}}/{{user `template_name`}}-{{user `template_config`}}",
+        "tag"                               : "{{user `version`}}"
+      },
+      "docker-push"
+    ]
+  ]
+
+}

--- a/templates/common/libvirt.base.json
+++ b/templates/common/libvirt.base.json
@@ -1,0 +1,104 @@
+{
+  "variables":
+    {
+      "template_name"                        : null,
+      "template_os"                          : null,
+      "iso_url"                              : null,
+      "iso_checksum"                         : null,
+      "iso_checksum_type"                    : null,
+      "puppet_aio"                           : null,
+      "floppy_dirs"                          : null,
+      "floppy_files"                         : null,
+      "http_directory"                       : null,
+      "boot_command"                         : null,
+      "project_root"                         : "../../../..",
+      "headless"                             : "true",
+      "template_config"                      : "base",
+      "provisioner"                          : "libvirt",
+      "shutdown_command"                     : "/sbin/halt -h -p",
+      "disk_size"                            : "20480",
+      "libvirt_base_boot_wait"               : "45s",
+      "libvirt_base_required_modules"        : null,
+      "packer_output_dir"                    : "{{env `PACKER_VM_OUTPUT_DIR`}}",
+      "libvirt_base_qemuargs_mem_size"       : "512",
+      "libvirt_base_qemuargs_cpu_count"      : "1",
+      "libvirt_net_device"                   : null,
+      "libvirt_disk_interface"               : null,
+      "libvirt_base_provisioning_scripts"    : "../../../../scripts/bootstrap-aio.sh"
+    },
+
+    "description"                            : "Builds a Linux base template VM for use with vagrant-libvirt",
+
+    "builders": [
+    {
+      "name"                                 : "{{user `template_name`}}-{{user `provisioner`}}-{{user `template_config`}}",
+      "type"                                 : "qemu",
+      "iso_url"                              : "{{user `iso_url`}}",
+      "iso_checksum"                         : "{{user `iso_checksum`}}",
+      "iso_checksum_type"                    : "{{user `iso_checksum_type`}}",
+
+      "output_directory"                     : "{{user `packer_output_dir`}}/output-{{build_name}}-{{user `version`}}",
+
+      "headless"                             : "{{user `headless`}}",
+
+      "ssh_username"                         : "root",
+      "ssh_password"                         : "puppet",
+      "ssh_port"                             : "22",
+      "ssh_wait_timeout"                     : "10000s",
+
+      "shutdown_command"                     : "{{user `shutdown_command`}}",
+
+      "disk_size"                            : "{{user `disk_size`}}",
+      "http_directory"                       : "{{user `http_directory`}}",
+
+      "accelerator"                          : "kvm",
+      "format"                               : "qcow2",
+      "net_device"                           : "{{user `libvirt_net_device`}}",
+      "disk_interface"                       : "{{user `libvirt_disk_interface`}}",
+      "boot_wait"                            : "{{user `boot_wait`}}",
+      "boot_command"                         : [
+                                                  "<tab> <wait>",
+                                                  "text <wait>",
+                                                  "ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg <wait>",
+                                                  "<enter>"
+                                               ],
+      "qemuargs"                             : [
+                                                 [ "-m", "{{user `libvirt_base_qemuargs_mem_size`}}" ],
+                                                 [ "-smp",
+                                                   "cpus={{user `libvirt_base_qemuargs_cpu_count`}},",
+                                                   "cores=1",
+                                                   ""
+                                                 ]
+                                               ]
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type"                                 : "shell",
+      "execute_command"                      : "{{.Vars}} sh '{{.Path}}' {{user `libvirt_base_required_modules`}}",
+      "environment_vars"                     : [ "PUPPET_AIO={{user `puppet_aio`}}" ],
+      "scripts"                              : [ "{{user `libvirt_base_provisioning_scripts`}}" ]
+    },
+
+    {
+      "type"                                 : "puppet-masterless",
+      "execute_command"                      : "{{.FacterVars}} PATH=$PATH:/opt/puppetlabs/bin /opt/puppetlabs/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "facter"                               : {
+                                                 "provisioner": "{{user `provisioner`}}"
+                                               },
+      "manifest_dir"                         : "{{user `project_root`}}/manifests",
+      "manifest_file"                        : "{{user `project_root`}}/manifests/base.pp"
+    },
+
+    {
+      "type"                                 : "shell",
+      "environment_vars"                     : [ "PUPPET_AIO={{user `puppet_aio`}}" ],
+      "scripts"                              : [
+                                                 "{{user `project_root`}}/scripts/cleanup-aio.sh",
+                                                 "{{user `project_root`}}/scripts/cleanup-packer.sh"
+                                               ]
+    }
+  ]
+
+}

--- a/templates/common/libvirt.nocm.json
+++ b/templates/common/libvirt.nocm.json
@@ -1,0 +1,102 @@
+{
+  "variables":
+    {
+      "template_name"                        : null,
+      "beakerhost"                           : null,
+      "version"                              : null,
+      "puppet_aio"                           : null,
+
+      "vagrant_required_modules"             : null,
+      "libvirt_nocm_qemuargs_mem_size"       : "512",
+      "libvirt_nocm_qemuargs_cpu_count"      : "1",
+
+      "project_root"                         : "../../../..",
+      "headless"                             : "true",
+      "template_config"                      : "nocm",
+      "provisioner"                          : "libvirt",
+      "shutdown_command"                     : "/sbin/halt -h -p",
+
+      "packer_output_dir"                    : "{{env `PACKER_VM_OUTPUT_DIR`}}",
+      "packer_source_dir"                    : "{{env `PACKER_VM_SRC_DIR`}}",
+      "libvirt_nocm_qemuargs_mem_size"       : "512",
+      "libvirt_nocm_qemuargs_cpu_count"      : "1",
+      "libvirt_nocm_provisioning_scripts"    : "../../../../scripts/bootstrap-aio.sh"
+    },
+
+    "description"                            : "Builds a Linux vagrantbox nocm VM for use with vagrant-libvirt",
+
+    "builders": [
+    {
+      "name"                                 : "{{user `template_name`}}-{{user `provisioner`}}",
+      "vm_name"                              : "packer-{{build_name}}",
+      "type"                                 : "qemu",
+      "disk_image"                           : "true",
+      "iso_url"                              : "{{user `packer_source_dir`}}/output-{{user `template_name`}}-{{user `provisioner`}}-base-{{user `version`}}/packer-{{user `template_name`}}-{{user `provisioner`}}-base",
+      "iso_checksum_type"                    : "none",
+      "output_directory"                     : "{{user `packer_output_dir`}}/output-{{build_name}}-{{user `template_config`}}-{{user `version`}}",
+
+      "headless"                             : "{{user `headless`}}",
+
+      "ssh_username"                         : "root",
+      "ssh_password"                         : "puppet",
+      "ssh_port"                             : "22",
+      "ssh_wait_timeout"                     : "10000s",
+
+      "shutdown_command"                     : "{{user `shutdown_command`}}",
+
+      "accelerator"                          : "kvm",
+      "format"                               : "qcow2",
+      "qemuargs"                             : [
+                                                 [ "-m", "{{user `libvirt_nocm_qemuargs_mem_size`}}" ],
+                                                 [ "-smp",
+                                                   "cpus={{user `libvirt_nocm_qemuargs_cpu_count`}},",
+                                                   "cores=1",
+                                                   ""
+                                                 ]
+                                               ]
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type"                                 : "shell",
+      "execute_command"                      : "{{.Vars}} sh '{{.Path}}' {{user `vagrant_required_modules`}}",
+      "environment_vars"                     : [ "PUPPET_AIO={{user `puppet_aio`}}" ],
+      "scripts"                              : [ "{{user `libvirt_nocm_provisioning_scripts`}}" ]
+    },
+
+    {
+      "type"                                 : "file",
+      "source"                               : "{{user `project_root`}}/hiera",
+      "destination"                          : "/tmp/packer-puppet-masterless"
+    },
+
+    {
+      "type"                                : "puppet-masterless",
+      "execute_command"                     : "{{.FacterVars}} PATH=$PATH:/opt/puppetlabs/bin /opt/puppetlabs/bin/puppet apply --verbose --detailed-exitcodes --hiera_config='/tmp/packer-puppet-masterless/hiera/hiera.yaml' --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "facter"                              : {
+                                                 "provisioner": "{{user `provisioner`}}"
+                                              },
+      "manifest_dir"                        : "{{user `project_root`}}/manifests",
+      "manifest_file"                       : "{{user `project_root`}}/manifests/vagrant/{{user `template_config`}}.pp"
+    },
+
+    {
+      "type"                                 : "shell",
+      "environment_vars"                     : [ "PUPPET_AIO={{user `puppet_aio`}}" ],
+      "scripts"                              : [
+                                                 "{{user `project_root`}}/scripts/cleanup-aio.sh",
+                                                 "{{user `project_root`}}/scripts/cleanup-packer.sh",
+                                                 "{{user `project_root`}}/scripts/cleanup-scrub.sh"
+                                               ]
+    }
+  ],
+
+  "post-processors": [
+    {
+      "type"                                 : "vagrant",
+      "output"                               : "{{user `packer_output_dir`}}/output-{{user `template_name`}}-{{user `provisioner`}}-{{user `version`}}/output-{{build_name}}-{{user `template_config`}}.box"
+    }
+  ]
+
+}

--- a/templates/common/libvirt.puppet.json
+++ b/templates/common/libvirt.puppet.json
@@ -1,0 +1,101 @@
+{
+  "variables":
+    {
+      "template_name"                        : null,
+      "beakerhost"                           : null,
+      "version"                              : null,
+      "puppet_aio"                           : null,
+
+      "vagrant_required_modules"             : null,
+      "libvirt_nocm_qemuargs_mem_size"       : "512",
+      "libvirt_nocm_qemuargs_cpu_count"      : "1",
+
+      "project_root"                         : "../../../..",
+      "headless"                             : "true",
+      "template_config"                      : "puppet",
+      "provisioner"                          : "libvirt",
+      "shutdown_command"                     : "/sbin/halt -h -p",
+
+      "packer_output_dir"                    : "{{env `PACKER_VM_OUTPUT_DIR`}}",
+      "packer_source_dir"                    : "{{env `PACKER_VM_SRC_DIR`}}",
+      "libvirt_puppet_qemuargs_mem_size"     : "512",
+      "libvirt_puppet_qemuargs_cpu_count"    : "1",
+      "libvirt_puppet_provisioning_scripts"  : "../../../../scripts/bootstrap-aio.sh"
+    },
+
+    "description"                            : "Builds a Linux vagrantbox nocm VM for use with vagrant-libvirt",
+
+    "builders": [
+    {
+      "name"                                 : "{{user `template_name`}}-{{user `provisioner`}}",
+      "vm_name"                              : "packer-{{build_name}}-{{user `template_config`}}",
+      "type"                                 : "qemu",
+      "disk_image"                           : "true",
+      "iso_url"                              : "{{user `packer_source_dir`}}/output-{{user `template_name`}}-{{user `provisioner`}}-base-{{user `version`}}/packer-{{user `template_name`}}-{{user `provisioner`}}-base",
+      "iso_checksum_type"                    : "none",
+      "output_directory"                     : "{{user `packer_output_dir`}}/output-{{build_name}}-{{user `template_config`}}-{{user `version`}}",
+
+      "headless"                             : "{{user `headless`}}",
+
+      "ssh_username"                         : "root",
+      "ssh_password"                         : "puppet",
+      "ssh_port"                             : "22",
+      "ssh_wait_timeout"                     : "10000s",
+
+      "shutdown_command"                     : "{{user `shutdown_command`}}",
+
+      "accelerator"                          : "kvm",
+      "format"                               : "qcow2",
+      "qemuargs"                             : [
+                                                 [ "-m", "{{user `libvirt_puppet_qemuargs_mem_size`}}" ],
+                                                 [ "-smp",
+                                                   "cpus={{user `libvirt_puppet_qemuargs_cpu_count`}},",
+                                                   "cores=1",
+                                                   ""
+                                                 ]
+                                               ]
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type"                                 : "shell",
+      "execute_command"                      : "{{.Vars}} sh '{{.Path}}' {{user `vagrant_required_modules`}}",
+      "environment_vars"                     : [ "PUPPET_AIO={{user `puppet_aio`}}" ],
+      "scripts"                              : [ "{{user `libvirt_puppet_provisioning_scripts`}}" ]
+    },
+
+    {
+      "type"                                 : "file",
+      "source"                               : "{{user `project_root`}}/hiera",
+      "destination"                          : "/tmp/packer-puppet-masterless"
+    },
+
+    {
+      "type"                                : "puppet-masterless",
+      "execute_command"                     : "{{.FacterVars}} PATH=$PATH:/opt/puppetlabs/bin /opt/puppetlabs/bin/puppet apply --verbose --detailed-exitcodes --hiera_config='/tmp/packer-puppet-masterless/hiera/hiera.yaml' --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "facter"                              : {
+                                                 "provisioner": "{{user `provisioner`}}"
+                                              },
+      "manifest_dir"                        : "{{user `project_root`}}/manifests",
+      "manifest_file"                       : "{{user `project_root`}}/manifests/vagrant/{{user `template_config`}}.pp"
+    },
+
+    {
+      "type"                                 : "shell",
+      "environment_vars"                     : [ "PUPPET_AIO={{user `puppet_aio`}}" ],
+      "scripts"                              : [
+                                                 "{{user `project_root`}}/scripts/cleanup-packer.sh",
+                                                 "{{user `project_root`}}/scripts/cleanup-scrub.sh"
+                                               ]
+    }
+  ],
+
+  "post-processors": [
+    {
+      "type"                                 : "vagrant",
+      "output"                               : "{{user `packer_output_dir`}}/output-{{user `template_name`}}-{{user `provisioner`}}-{{user `version`}}/output-{{build_name}}-{{user `template_config`}}.box"
+    }
+  ]
+
+}

--- a/templates/common/virtualbox.base.json
+++ b/templates/common/virtualbox.base.json
@@ -1,0 +1,109 @@
+{
+  "variables":
+    {
+      "template_name"                        : null,
+      "iso_url"                              : null,
+      "iso_checksum"                         : null,
+      "iso_checksum_type"                    : null,
+      "puppet_aio"                           : null,
+      "floppy_dirs"                          : null,
+      "floppy_files"                         : null,
+      "http_directory"                       : null,
+      "boot_command"                         : null,
+      "project_root"                         : "../../../..",
+      "headless"                             : "true",
+      "template_config"                      : "base",
+      "provisioner"                          : "virtualbox",
+      "shutdown_command"                     : "/sbin/halt -h -p",
+      "disk_size"                            : "20480",
+      "virtualbox_base_template_os"          : null,
+      "virtualbox_base_boot_wait"            : "45s",
+      "virtualbox_base_required_modules"     : null,
+      "packer_output_dir"                    : "{{env `PACKER_VM_OUTPUT_DIR`}}",
+      "virtualbox_base_vboxmanage_mem_size"  : "512",
+      "virtualbox_base_vboxmanage_cpu_count" : "1",
+      "virtualbox_base_provisioning_scripts" : "../../../../scripts/bootstrap-aio.sh"
+    },
+
+    "description"                            : "Builds a Linux base template VM for use with virtualbox",
+
+    "builders": [
+    {
+      "vm_name"                              : "{{user `template_name`}}-{{user `provisioner`}}-{{user `template_config`}}",
+      "type"                                 : "virtualbox-iso",
+      "iso_url"                              : "{{user `iso_url`}}",
+      "iso_checksum"                         : "{{user `iso_checksum`}}",
+      "iso_checksum_type"                    : "{{user `iso_checksum_type`}}",
+
+      "output_directory"                     : "{{user `packer_output_dir`}}/output-{{user `template_name`}}-{{user `provisioner`}}-{{user `template_config`}}-{{user `version`}}",
+
+      "headless"                             : "{{user `headless`}}",
+
+      "ssh_username"                         : "root",
+      "ssh_password"                         : "puppet",
+      "ssh_port"                             : "22",
+      "ssh_wait_timeout"                     : "10000s",
+
+      "shutdown_command"                     : "{{user `shutdown_command`}}",
+
+      "guest_os_type"                        : "{{user `virtualbox_base_template_os`}}",
+      "disk_size"                            : "{{user `disk_size`}}",
+      "http_directory"                       : "{{user `http_directory`}}",
+
+      "boot_wait"                            : "{{user `boot_wait`}}",
+      "boot_command"                         : [
+                                                  "<tab> <wait>",
+                                                  "text <wait>",
+                                                  "ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg <wait>",
+                                                  "console=ttyS0,115200n8 <wait>",
+                                                  "console=tty0 <wait>",
+                                                  "ignore_loglevel <wait>",
+                                                  "<enter>"
+                                               ],
+      "virtualbox_version_file"              : ".vbox_version",
+      "vboxmanage"                           : [
+                                                  [
+                                                    "modifyvm",
+                                                    "{{.Name}}",
+                                                    "--memory",
+                                                    "{{user `virtualbox_base_vboxmanage_mem_size`}}"
+                                                  ],
+                                                  [
+                                                    "modifyvm",
+                                                    "{{.Name}}",
+                                                    "--cpus",
+                                                    "{{user `virtualbox_base_vboxmanage_cpu_count`}}"
+                                                  ]
+                                               ]
+    }
+  ],
+  "provisioners": [
+    {
+      "type"                                 : "shell",
+      "execute_command"                      : "{{.Vars}} sh '{{.Path}}' {{user `virtualbox_base_required_modules`}}",
+      "environment_vars"                     : [ "PUPPET_AIO={{user `puppet_aio`}}" ],
+      "scripts"                              : [ "{{user `virtualbox_base_provisioning_scripts`}}" ]
+    },
+
+    {
+      "type"                                 : "puppet-masterless",
+      "execute_command"                      : "{{.FacterVars}} PATH=$PATH:/opt/puppetlabs/bin /opt/puppetlabs/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "facter"                               : {
+                                                 "provisioner": "{{user `provisioner`}}"
+                                               },
+      "manifest_dir"                         : "{{user `project_root`}}/manifests",
+      "manifest_file"                        : "{{user `project_root`}}/manifests/base.pp"
+    },
+
+    {
+      "type"                                 : "shell",
+      "execute_command"                      : "{{.Vars}} sh '{{.Path}}' {{user `required_modules`}}",
+      "environment_vars"                     : [ "PUPPET_AIO={{user `puppet_aio`}}" ],
+      "scripts"                              : [
+                                                 "{{user `project_root`}}/scripts/cleanup-aio.sh",
+                                                 "{{user `project_root`}}/scripts/cleanup-packer.sh"
+                                               ]
+    }
+  ]
+
+}

--- a/templates/common/virtualbox.nocm.json
+++ b/templates/common/virtualbox.nocm.json
@@ -1,0 +1,111 @@
+{
+  "variables":
+    {
+      "template_name"                        : null,
+      "beakerhost"                           : null,
+      "version"                              : null,
+      "puppet_aio"                           : null,
+
+      "vagrant_required_modules"             : null,
+      "libvirt_nocm_qemuargs_mem_size"       : "512",
+      "libvirt_nocm_qemuargs_cpu_count"      : "1",
+
+      "project_root"                         : "../../../..",
+      "headless"                             : "true",
+      "template_config"                      : "nocm",
+      "provisioner"                          : "virtualbox",
+      "shutdown_command"                     : "/sbin/halt -h -p",
+
+      "packer_output_dir"                    : "{{env `PACKER_VM_OUTPUT_DIR`}}",
+      "packer_source_dir"                    : "{{env `PACKER_VM_SRC_DIR`}}",
+      "virtualbox_nocm_vboxmanage_mem_size"  : "512",
+      "virtualbox_nocm_vboxmanage_cpu_count" : "1",
+      "virtualbox_nocm_provisioning_scripts" : "../../../../scripts/bootstrap-aio.sh"
+    },
+
+    "description"                            : "Builds a Linux vagrantbox nocm VM for use with virtualbox",
+
+    "builders": [
+    {
+      "name"                                 : "{{user `template_name`}}-{{user `provisioner`}}",
+      "vm_name"                              : "packer-{{build_name}}",
+      "type"                                 : "virtualbox-ovf",
+      "format"                               : "ovf",
+      "source_path"                          : "{{user `packer_output_dir`}}/output-{{user `template_name`}}-{{user `provisioner`}}-base-{{user `version`}}/{{user `template_name`}}-{{user `provisioner`}}-base.ovf",
+      "output_directory"                     : "{{user `packer_output_dir`}}/output-{{build_name}}-{{user `template_config`}}-{{user `version`}}",
+
+      "headless"                             : "{{user `headless`}}",
+
+      "ssh_username"                         : "root",
+      "ssh_password"                         : "puppet",
+      "ssh_port"                             : "22",
+      "ssh_wait_timeout"                     : "10000s",
+
+      "shutdown_command"                     : "{{user `shutdown_command`}}",
+      "virtualbox_version_file"              : ".vbox_version",
+      "vboxmanage"                           : [
+                                                  [
+                                                    "modifyvm",
+                                                    "{{.Name}}",
+                                                    "--memory",
+                                                    "{{user `virtualbox_nocm_vboxmanage_mem_size`}}"
+                                                  ],
+                                                  [
+                                                    "modifyvm",
+                                                    "{{.Name}}",
+                                                    "--cpus",
+                                                    "{{user `virtualbox_nocm_vboxmanage_cpu_count`}}"
+                                                  ]
+                                               ],
+      "export_opts"                          : [
+                                                  "--manifest",
+                                                  "--vsys", "0",
+                                                  "--description", "{{user `provisioner`}} {{user `template_name`}} {{user `template_config`}} vagrant box.",
+                                                  "--version", "{{user `version`}}"
+                                               ]
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type"                                 : "shell",
+      "execute_command"                      : "{{.Vars}} sh '{{.Path}}' {{user `vagrant_required_modules`}}",
+      "environment_vars"                     : [ "PUPPET_AIO={{user `puppet_aio`}}" ],
+      "scripts"                              : [ "{{user `virtualbox_nocm_provisioning_scripts`}}" ]
+    },
+
+    {
+      "type"                                 : "file",
+      "source"                               : "{{user `project_root`}}/hiera",
+      "destination"                          : "/tmp/packer-puppet-masterless"
+    },
+
+    {
+      "type"                                : "puppet-masterless",
+      "execute_command"                     : "{{.FacterVars}} PATH=$PATH:/opt/puppetlabs/bin /opt/puppetlabs/bin/puppet apply --verbose --detailed-exitcodes --hiera_config='/tmp/packer-puppet-masterless/hiera/hiera.yaml' --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "facter"                              : {
+                                                 "provisioner": "{{user `provisioner`}}"
+                                              },
+      "manifest_dir"                        : "{{user `project_root`}}/manifests",
+      "manifest_file"                       : "{{user `project_root`}}/manifests/vagrant/{{user `template_config`}}.pp"
+    },
+
+    {
+      "type"                                 : "shell",
+      "environment_vars"                     : [ "PUPPET_AIO={{user `puppet_aio`}}" ],
+      "scripts"                              : [
+                                                 "{{user `project_root`}}/scripts/cleanup-aio.sh",
+                                                 "{{user `project_root`}}/scripts/cleanup-packer.sh",
+                                                 "{{user `project_root`}}/scripts/cleanup-scrub.sh"
+                                               ]
+    }
+  ],
+
+  "post-processors": [
+    {
+      "type"                                 : "vagrant",
+      "output"                               : "{{user `packer_output_dir`}}/output-{{user `template_name`}}-{{user `provisioner`}}-{{user `version`}}/output-{{build_name}}-{{user `template_config`}}.box"
+    }
+  ]
+
+}

--- a/templates/common/virtualbox.puppet.json
+++ b/templates/common/virtualbox.puppet.json
@@ -1,0 +1,110 @@
+{
+  "variables":
+    {
+      "template_name"                          : null,
+      "beakerhost"                             : null,
+      "version"                                : null,
+      "puppet_aio"                             : null,
+
+      "vagrant_required_modules"               : null,
+      "libvirt_nocm_qemuargs_mem_size"         : "512",
+      "libvirt_nocm_qemuargs_cpu_count"        : "1",
+
+      "project_root"                           : "../../../..",
+      "headless"                               : "true",
+      "template_config"                        : "puppet",
+      "provisioner"                            : "virtualbox",
+      "shutdown_command"                       : "/sbin/halt -h -p",
+
+      "packer_output_dir"                      : "{{env `PACKER_VM_OUTPUT_DIR`}}",
+      "packer_source_dir"                      : "{{env `PACKER_VM_SRC_DIR`}}",
+      "virtualbox_puppet_vboxmanage_mem_size"  : "512",
+      "virtualbox_puppet_vboxmanage_cpu_count" : "1",
+      "virtualbox_puppet_provisioning_scripts" : "../../../../scripts/bootstrap-aio.sh"
+    },
+
+    "description"                              : "Builds a Linux vagrantbox puppet VM for use with virtualbox",
+
+    "builders": [
+    {
+      "name"                                   : "{{user `template_name`}}-{{user `provisioner`}}",
+      "vm_name"                                : "packer-{{build_name}}",
+      "type"                                   : "virtualbox-ovf",
+      "format"                                 : "ovf",
+      "source_path"                            : "{{user `packer_output_dir`}}/output-{{user `template_name`}}-{{user `provisioner`}}-base-{{user `version`}}/{{user `template_name`}}-{{user `provisioner`}}-base.ovf",
+      "output_directory"                       : "{{user `packer_output_dir`}}/output-{{build_name}}-{{user `template_config`}}-{{user `version`}}",
+
+      "headless"                               : "{{user `headless`}}",
+
+      "ssh_username"                           : "root",
+      "ssh_password"                           : "puppet",
+      "ssh_port"                               : "22",
+      "ssh_wait_timeout"                       : "10000s",
+
+      "shutdown_command"                       : "{{user `shutdown_command`}}",
+      "virtualbox_version_file"                : ".vbox_version",
+      "vboxmanage"                             : [
+                                                    [
+                                                      "modifyvm",
+                                                      "{{.Name}}",
+                                                      "--memory",
+                                                      "{{user `virtualbox_puppet_vboxmanage_mem_size`}}"
+                                                    ],
+                                                    [
+                                                      "modifyvm",
+                                                      "{{.Name}}",
+                                                      "--cpus",
+                                                      "{{user `virtualbox_puppet_vboxmanage_cpu_count`}}"
+                                                    ]
+                                                 ],
+      "export_opts"                            : [
+                                                    "--manifest",
+                                                    "--vsys", "0",
+                                                    "--description", "{{user `provisioner`}} {{user `template_name`}} {{user `template_config`}} vagrant box.",
+                                                    "--version", "{{user `version`}}"
+                                                 ]
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type"                                   : "shell",
+      "execute_command"                        : "{{.Vars}} sh '{{.Path}}' {{user `vagrant_required_modules`}}",
+      "environment_vars"                       : [ "PUPPET_AIO={{user `puppet_aio`}}" ],
+      "scripts"                                : [ "{{user `virtualbox_puppet_provisioning_scripts`}}" ]
+    },
+
+    {
+      "type"                                   : "file",
+      "source"                                 : "{{user `project_root`}}/hiera",
+      "destination"                            : "/tmp/packer-puppet-masterless"
+    },
+
+    {
+      "type"                                  : "puppet-masterless",
+      "execute_command"                       : "{{.FacterVars}} PATH=$PATH:/opt/puppetlabs/bin /opt/puppetlabs/bin/puppet apply --verbose --detailed-exitcodes --hiera_config='/tmp/packer-puppet-masterless/hiera/hiera.yaml' --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
+      "facter"                                : {
+                                                   "provisioner": "{{user `provisioner`}}"
+                                                },
+      "manifest_dir"                          : "{{user `project_root`}}/manifests",
+      "manifest_file"                         : "{{user `project_root`}}/manifests/vagrant/{{user `template_config`}}.pp"
+    },
+
+    {
+      "type"                                   : "shell",
+      "environment_vars"                       : [ "PUPPET_AIO={{user `puppet_aio`}}" ],
+      "scripts"                                : [
+                                                   "{{user `project_root`}}/scripts/cleanup-packer.sh",
+                                                   "{{user `project_root`}}/scripts/cleanup-scrub.sh"
+                                                 ]
+    }
+  ],
+
+  "post-processors": [
+    {
+      "type"                                   : "vagrant",
+      "output"                                 : "{{user `packer_output_dir`}}/output-{{user `template_name`}}-{{user `provisioner`}}-{{user `version`}}/output-{{build_name}}-{{user `template_config`}}.box"
+    }
+  ]
+
+}


### PR DESCRIPTION
@ScottGarman 
Except for the little modification in the puppet code, everything is separated form the other base code.
I think the naming of the vars I used are subject to changes to follow the naming convention ...

Adds vagrant boxes nocm and puppet for vagrant supporting following hypervisors : 
* libvirt (kvm)
* virtualbox
* docker

