### PR TITLE
(WIN-77) JJB Related Fixups for Appveyor Image Gen

### DIFF
--- a/templates/win/2008r2-wmf2/x86_64/vars.json
+++ b/templates/win/2008r2-wmf2/x86_64/vars.json
@@ -1,15 +1,7 @@
 {
+    "packer_comment"            : "GCE Appveyor only image definition for Win-2008R2 WMF2",
+
     "template_name"             : "win-2008r2-wmf2-x86_64",
-    "beakerhost"                : "windows2008r2-64",
-    "vbox_guest_os"             : "Windows2008_64",
-    "vmware_guest_os"           : "windows7srv-64",
-    "windows_version"           : "Windows-2008r2",
-    "image_name"                : "Windows Server 2008 R2 SERVERSTANDARD",
-    "product_key"               : "YC6KT-GKW9T-YTKYR-T4X34-R7VHC",
     "gce_source_image_family"   : "windows-2008-r2",
-    "version"                   : "20180307_1800",
-    "iso_url"                   : "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2008_r2_with_sp1_x64_dvd_617601_SlipStream_03.iso",
-    "iso_checksum_type"         : "md5",
-    "iso_checksum"              : "f94011cfdc4e0498a01a86a0cafe403e",
-    "boot_command"              : "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter>"
+    "version"                   : "20180307_1800"
 }

--- a/templates/win/2008r2-wmf3/x86_64/vars.json
+++ b/templates/win/2008r2-wmf3/x86_64/vars.json
@@ -1,15 +1,7 @@
 {
+    "packer_comment"            : "GCE Appveyor only image definition for Win-2008R2 WMF3",
+    
     "template_name"             : "win-2008r2-wmf3-x86_64",
-    "beakerhost"                : "windows2008r2-64",
-    "vbox_guest_os"             : "Windows2008_64",
-    "vmware_guest_os"           : "windows7srv-64",
-    "windows_version"           : "Windows-2008r2",
-    "image_name"                : "Windows Server 2008 R2 SERVERSTANDARD",
-    "product_key"               : "YC6KT-GKW9T-YTKYR-T4X34-R7VHC",
     "gce_source_image_family"   : "windows-2008-r2",
-    "version"                   : "20180307_1800",
-    "iso_url"                   : "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2008_r2_with_sp1_x64_dvd_617601_SlipStream_03.iso",
-    "iso_checksum_type"         : "md5",
-    "iso_checksum"              : "f94011cfdc4e0498a01a86a0cafe403e",
-    "boot_command"              : "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter>"
+    "version"                   : "20180307_1800"
 }

--- a/templates/win/2008r2-wmf4/x86_64/vars.json
+++ b/templates/win/2008r2-wmf4/x86_64/vars.json
@@ -1,0 +1,7 @@
+{
+    "packer_comment"            : "GCE Appveyor only image definition for Win-2008R2 WMF4",
+
+    "template_name"             : "win-2008r2-wmf4-x86_64",
+    "gce_source_image_family"   : "windows-2008-r2",
+    "version"                   : "20180307_1800"
+}

--- a/templates/win/2008r2/x86_64/vars.json
+++ b/templates/win/2008r2/x86_64/vars.json
@@ -6,7 +6,6 @@
     "windows_version"           : "Windows-2008r2",
     "image_name"                : "Windows Server 2008 R2 SERVERSTANDARD",
     "product_key"               : "YC6KT-GKW9T-YTKYR-T4X34-R7VHC",
-    "gce_source_image_family"   : "windows-2008-r2",
     "version"                   : "20180307_1800",
     "iso_url"                   : "http://osmirror.delivery.puppetlabs.net/iso/windows/en_windows_server_2008_r2_with_sp1_x64_dvd_617601_SlipStream_03.iso",
     "iso_checksum_type"         : "md5",

--- a/templates/win/common/google.appveyor.json
+++ b/templates/win/common/google.appveyor.json
@@ -28,7 +28,7 @@
   "builders": [{
     "type"                : "googlecompute",
     "name"                : "{{user `template_name`}}-{{user `provisioner`}}-{{user `template_config`}}",
-    "image_name"          : "packer-{{build_name | clean_image_name}}-{{user `version` | clean_image_name}}",
+    "image_name"          : "packer-appveyor-{{user `template_name` | clean_image_name}}-{{user `provisioner` | clean_image_name}}-{{user `version` | clean_image_name}}",
     "network"             : "{{user `gce_network`}}",
     "zone"                : "{{user `gce_zone`}}",
     "account_file"        : "{{user `gce_account_file`}}",


### PR DESCRIPTION
A number of consistency tidy ups to the Google/Appveyor image generation
including:
1. Move 2008R2-WMF4 into its own directory.
2. Remove all other variables from the appveyor defs as they are
   appveyor builds only.
3. Add a "comment" variable for clarity.
4. Shorten generated image name (google isn't necessary)