### PR TITLE
(IMAGES-781) Increase RAM for redhat-7-x86_64 to 6 GB

### DIFF
--- a/templates/redhat/7.2/x86_64/vars.json
+++ b/templates/redhat/7.2/x86_64/vars.json
@@ -2,11 +2,11 @@
     "template_name"                         : "redhat-7.2-x86_64",
     "template_os"                           : "rhel7-64",
     "beakerhost"                            : "redhat7-64",
-    "version"                               : "0.0.2",
+    "version"                               : "0.0.3",
     "iso_url"                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/rhel-server-7.2-x86_64-dvd.iso",
     "iso_checksum"                          : "03f3a0291634335f6995534d829bd21ffaa0d000004dfeb1b2fb81052d64a4d5",
     "iso_checksum_type"                     : "sha256",
-    "vmware_vsphere_nocm_vmx_data_memsize"  : "4096",
+    "vmware_vsphere_nocm_vmx_data_memsize"  : "6144",
     "vmware_vsphere_nocm_vmx_data_numvcpus" : "2",
     "puppet_aio"                            : "http://yum.puppetlabs.com/el/7/PC1/x86_64/puppet-agent-1.10.9-1.el7.x86_64.rpm"
 }


### PR DESCRIPTION
This is a platform we often use for PE master testing and requires 6 GB
of RAM.