### PR TITLE
(maint) Fixes for redhat-6 templates

### DIFF
--- a/manifests/modules/packer/manifests/updates.pp
+++ b/manifests/modules/packer/manifests/updates.pp
@@ -11,6 +11,14 @@ class packer::updates {
     'openssh-server',
   ]
 
+  # Updating the EL 6.8 kernel causes a kernel panic on bootup in
+  # vCenter 5.5, so it is not included here. Remove this workaround
+  # when vCenter gets updated.
+  $redhat6_pkgs = [
+    'glibc',
+    'openssh',
+  ]
+
   $redhat_pkgs = [
     'glibc',
     'openssh',
@@ -25,6 +33,8 @@ class packer::updates {
 
   if $::osfamily == 'Debian' {
     $pkgs_to_update = $linux_pkgs + $debian_pkgs
+  } elsif $::osfamily == 'Redhat' and $::operatingsystemmajrelease == '6' {
+    $pkgs_to_update = $linux_pkgs + $redhat6_pkgs
   } elsif $::osfamily == 'Redhat' {
     $pkgs_to_update = $linux_pkgs + $redhat_pkgs
   } elsif $::osfamily == 'Suse' {

--- a/templates/redhat/6.8/i386/vars.json
+++ b/templates/redhat/6.8/i386/vars.json
@@ -7,7 +7,7 @@
     "iso_checksum"                          : "22d1754f3e642c2b60234c3f97d1d6689b33bef4dd2252e3f52cd9aa823bb5f3",
     "iso_checksum_type"                     : "sha256",
     "boot_command"                          : "<tab> <wait>text ks=hd:fd0:/ks.cfg<wait><enter>",
-    "vmware_vsphere_nocm_vmx_data_memsize"  : "4096",
+    "vmware_vsphere_nocm_vmx_data_memsize"  : "2048",
     "vmware_vsphere_nocm_vmx_data_numvcpus" : "2",
     "puppet_aio"                            : "http://yum.puppetlabs.com/el/6/PC1/i386/puppet-agent-1.10.9-1.el6.i386.rpm"
 }

--- a/templates/redhat/6.8/x86_64/vars.json
+++ b/templates/redhat/6.8/x86_64/vars.json
@@ -7,7 +7,7 @@
     "iso_checksum"                          : "d35fd1af20f6adef9b11b46c2534ae8b6e18de7754889e2b51808b436dff2804",
     "iso_checksum_type"                     : "sha256",
     "boot_command"                          : "<tab> <wait>text ks=hd:fd0:/ks.cfg<wait><enter>",
-    "vmware_vsphere_nocm_vmx_data_memsize"  : "4096",
+    "vmware_vsphere_nocm_vmx_data_memsize"  : "6144",
     "vmware_vsphere_nocm_vmx_data_numvcpus" : "2",
     "puppet_aio"                            : "http://yum.puppetlabs.com/el/6/PC1/x86_64/puppet-agent-1.10.9-1.el6.x86_64.rpm"
 }


### PR DESCRIPTION
This updates the RAM settings to match what is currently used in the
redhat-6 vmpooler templates, and adds a workaround preventing the kernel
pacakge from being upgraded when building the template, to avoid a
kernel panic on bootup.