### PR TITLE
(IMAGES-783) Disable firewall service for redhat-6 templates

### DIFF
--- a/manifests/modules/packer/manifests/vsphere/fw.pp
+++ b/manifests/modules/packer/manifests/vsphere/fw.pp
@@ -1,7 +1,7 @@
 class packer::vsphere::fw {
 
   if ($::osfamily == 'RedHat')
-  and ($::operatingsystemmajrelease == '7') {
+  and ($::operatingsystemmajrelease in ['6', '7']) {
     class { 'firewall':
       ensure => stopped,
     }

--- a/templates/redhat/6.8/i386/vars.json
+++ b/templates/redhat/6.8/i386/vars.json
@@ -2,7 +2,7 @@
     "template_name"                         : "redhat-6.8-i386",
     "template_os"                           : "rhel6",
     "beakerhost"                            : "redhat6-32",
-    "version"                               : "0.0.2",
+    "version"                               : "0.0.3",
     "iso_url"                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/rhel-server-6.8-i386-dvd.iso",
     "iso_checksum"                          : "22d1754f3e642c2b60234c3f97d1d6689b33bef4dd2252e3f52cd9aa823bb5f3",
     "iso_checksum_type"                     : "sha256",

--- a/templates/redhat/6.8/x86_64/vars.json
+++ b/templates/redhat/6.8/x86_64/vars.json
@@ -2,7 +2,7 @@
     "template_name"                         : "redhat-6.8-x86_64",
     "template_os"                           : "rhel6-64",
     "beakerhost"                            : "redhat6-64",
-    "version"                               : "0.0.2",
+    "version"                               : "0.0.3",
     "iso_url"                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/rhel-server-6.8-x86_64-dvd.iso",
     "iso_checksum"                          : "d35fd1af20f6adef9b11b46c2534ae8b6e18de7754889e2b51808b436dff2804",
     "iso_checksum_type"                     : "sha256",


### PR DESCRIPTION
During the update from RHEL 6.5 -> 6.8, RedHat enabled a firewall
service by default. We disable this in the redhat-7 template build
process, so do this also for redhat-6.