### PR TITLE
(maint) CentOS 6 updates

### DIFF
--- a/templates/centos/6.8/common/files/ks.cfg
+++ b/templates/centos/6.8/common/files/ks.cfg
@@ -39,4 +39,3 @@ yum-autoupdate
 -ipw2200-firmware
 -ivtv-firmware
 %end
-

--- a/templates/centos/6.8/i386/vars.json
+++ b/templates/centos/6.8/i386/vars.json
@@ -8,5 +8,5 @@
     "iso_checksum_type"                     : "sha256",
     "vmware_vsphere_nocm_vmx_data_memsize"  : "2048",
     "vmware_vsphere_nocm_vmx_data_numvcpus" : "2",
-    "puppet_aio"                            : "http://yum.puppetlabs.com/el/6/PC1/i386/puppet-agent-1.8.3-1.el6.i386.rpm"
+    "puppet_aio"                            : "http://yum.puppetlabs.com/el/6/PC1/i386/puppet-agent-1.10.10-1.el6.i386.rpm"
 }

--- a/templates/centos/6.8/x86_64/vars.json
+++ b/templates/centos/6.8/x86_64/vars.json
@@ -6,7 +6,7 @@
     "iso_url"                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/CentOS-6.8-x86_64-bin-DVD1.iso",
     "iso_checksum"                          : "1dda55622614a8b43b448a72f87d6cb7f79de1eff49ee8c5881a7d9db28d4e35",
     "iso_checksum_type"                     : "sha256",
-    "vmware_vsphere_nocm_vmx_data_memsize"  : "4096",
+    "vmware_vsphere_nocm_vmx_data_memsize"  : "6144",
     "vmware_vsphere_nocm_vmx_data_numvcpus" : "2",
-    "puppet_aio"                            : "http://yum.puppetlabs.com/el/6/PC1/x86_64/puppet-agent-1.8.3-1.el6.x86_64.rpm"
+    "puppet_aio"                            : "http://yum.puppetlabs.com/el/6/PC1/x86_64/puppet-agent-1.10.10-1.el6.x86_64.rpm"
 }

--- a/templates/centos/README.md
+++ b/templates/centos/README.md
@@ -9,8 +9,11 @@ This contains all of the var files required to build any of the templates in the
 
 All templates must be built in the `<os_dist>/<variant>/<arch>` directory. Make sure that the environment variable PACKER\_VM\_OUT\_DIR is set so that Packer knows where to copy the build artifacts (it is common to set it to ".", the current `<os_dist>/<variant>/<arch>` directory). If you are building a template with a vmware-vmx builder, be sure to set the PACKER\_VM\_SRC\_DIR environment variable to the directory containing the directory containing the relevant vm files. It is common to set PACKER\_VM\_SRC\_DIR = PACKER\_VM\_OUT\_DIR to make it easy to build a vmware-vmx template from a previous vmware build.
 
-## Centos 5.11/6.6
-To build any template in the `templates/common` directory for Centos 5.11/6.6, type:
+## Centos 5.11/6.8
+
+The boot command for Centos < 7 is slightly different, so we have an additional var file to include in the build process.
+
+To build any template in the `templates/common` directory for Centos 5.11/6.8, type:
 ```
 packer build -var-file=../../common/vars.json -var-file=../common/vars.json -var-file=vars.json ../../../common/<template-file>
 ```


### PR DESCRIPTION
This includes some minor tweaks to the CentOS 6 templates:

* Updated x86_64 template to have 6 GB of RAM
* Updated puppet-agent version to 1.10.10
* Updated README file to explain why we have separate build instructions
for different versions of CentOS