### PR TITLE
(IMAGES-752) Add template for Ubuntu 18.04

### DIFF
--- a/templates/ubuntu/18.04/common/files/preseed.cfg
+++ b/templates/ubuntu/18.04/common/files/preseed.cfg
@@ -1,0 +1,34 @@
+choose-mirror-bin mirror/http/proxy string
+d-i base-installer/kernel/override-image string linux-server
+d-i clock-setup/utc boolean true
+d-i clock-setup/utc-auto boolean true
+d-i finish-install/reboot_in_progress note
+d-i grub-installer/only_debian boolean true
+d-i grub-installer/with_other_os boolean true
+d-i partman-auto-lvm/guided_size string max
+d-i partman-auto/choose_recipe select atomic
+d-i partman-auto/method string lvm
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/confirm_nooverwrite boolean true
+d-i partman-lvm/device_remove_lvm boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+d-i partman/confirm_write_new_label boolean true
+d-i passwd/root-login boolean true
+d-i passwd/root-password password puppet
+d-i passwd/root-password-again password puppet
+d-i passwd/make-user boolean false
+d-i user-setup/allow-password-weak boolean true
+d-i pkgsel/include string curl gcc make nfs-common ntp openssh-server perl wget
+d-i pkgsel/install-language-support boolean false
+d-i pkgsel/update-policy select none
+d-i pkgsel/upgrade select full-upgrade
+d-i time/zone string US/Pacific
+tasksel tasksel/first multiselect standard, ubuntu-server
+d-i preseed/late_command string \
+sed -i 's/\(GRUB_CMDLINE_LINUX_DEFAULT=\).*/\1\"\"/g' /target/etc/default/grub; \
+in-target bash -c 'update-grub2'; \
+in-target sed -i 's/.*PermitRootLogin.*/PermitRootLogin yes/g' /etc/ssh/sshd_config ; \
+in-target apt-get -y upgrade

--- a/templates/ubuntu/18.04/common/vars.json
+++ b/templates/ubuntu/18.04/common/vars.json
@@ -1,0 +1,4 @@
+{
+    "boot_command" : "<esc><wait><esc><wait><enter><wait>/install/vmlinuz console-setup/ask_detect=false console-setup/layoutcode=us console-setup/modelcode=pc105 debconf/frontend=noninteractive debian-installer=en_US fb=false initrd=/install/initrd.gz kbd-chooser/method=us keyboard-configuration/layout=USA keyboard-configuration/variant=USA locale=en_US.UTF-8 netcfg/get_domain=vm netcfg/get_hostname=localhost grub-installer/bootdev=/dev/sda noapic preseed/file=/floppy/preseed.cfg -- <wait><enter>",
+    "vmware_base_boot_wait" : "15s"
+}

--- a/templates/ubuntu/18.04/x86_64/vars.json
+++ b/templates/ubuntu/18.04/x86_64/vars.json
@@ -1,0 +1,12 @@
+{
+    "template_name"                         : "ubuntu-18.04-x86_64",
+    "template_os"                           : "ubuntu-64",
+    "beakerhost"                            : "ubuntu1804-64",
+    "version"                               : "0.0.1",
+    "iso_url"                               : "http://osmirror.delivery.puppetlabs.net/iso/ubuntu-18.04-daily-server-amd64.iso",
+    "iso_checksum"                          : "dc45b1bef1c699af16fde18688b38f81c1d559abc70ac92ca975baa7aaeed07a",
+    "iso_checksum_type"                     : "sha256",
+    "vmware_vsphere_nocm_vmx_data_memsize"  : "6144",
+    "vmware_vsphere_nocm_vmx_data_numvcpus" : "2",
+    "puppet_aio"                            : "http://apt.puppetlabs.com/pool/stretch/puppet5/p/puppet-agent/puppet-agent_5.3.2-1stretch_amd64.deb"
+}


### PR DESCRIPTION
Adds a template for the 18.04 Ubuntu LTS, Bionic Beaver:

- Uses a daily build of the server image for now
- Uses the debian 9 puppet-agent until we can build for this platform

Canoncial will not be distributing an i386 image for 18.04.