### PR TITLE
(IMAGES-739) Add Scientific Linux 6.8 images (i386, x86_64)

### DIFF
--- a/manifests/modules/packer/manifests/vsphere/repos.pp
+++ b/manifests/modules/packer/manifests/vsphere/repos.pp
@@ -89,6 +89,7 @@ class packer::vsphere::repos inherits packer::vsphere::params {
         $base_url = $::operatingsystem ? {
           'Fedora'      => "${repo_mirror}/rpm__remote_fedora/releases/${::operatingsystemmajrelease}/Everything/${::architecture}/os",
           'CentOS'      => "${repo_mirror}/rpm__remote_centos/${::operatingsystemmajrelease}/os/${::architecture}",
+          'Scientific'  => "${repo_mirror}/rpm__remote_scientific/${::operatingsystemmajrelease}/${::architecture}/os",
           'OracleLinux' => "${os_mirror}/${loweros}-${::operatingsystemmajrelease}-${::architecture}/RPMS.all"
         }
       }

--- a/templates/scientific/6.8/common/files/ks.cfg
+++ b/templates/scientific/6.8/common/files/ks.cfg
@@ -1,0 +1,39 @@
+install
+cdrom
+lang en_US.UTF-8
+keyboard us
+network --bootproto=dhcp
+rootpw --iscrypted $1$v4K9E8Wj$gZIHJ5JtQL5ZGZXeqSSsd0
+firewall --enabled --service=ssh
+authconfig --enableshadow --passalgo=sha512
+selinux --disabled
+timezone UTC
+bootloader --location=mbr
+
+text
+skipx
+zerombr
+
+clearpart --all --initlabel
+autopart
+
+auth  --useshadow  --enablemd5
+firstboot --disabled
+reboot --eject
+
+%packages --ignoremissing
+@core
+bzip2
+kernel-devel
+kernel-headers
+gcc
+make
+perl
+curl
+wget
+nfs-utils
+-ipw2100-firmware
+-ipw2200-firmware
+-ivtv-firmware
+-yum-autoupdate
+%end

--- a/templates/scientific/6.8/i386/vars.json
+++ b/templates/scientific/6.8/i386/vars.json
@@ -1,0 +1,12 @@
+{
+    "template_name"                         : "scientific-6.8-i386",
+    "template_os"                           : "rhel6",
+    "beakerhost"                            : "scientific6-32",
+    "version"                               : "0.0.1",
+    "iso_url"                               : "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_scientific/6.8/i386/iso/SL-68-i386-2016-06-29-DVD-DL.iso",
+    "iso_checksum"                          : "f46ca847a468e79b69fc2f3ab71893803bd45b00b22aaf30019ea576e498c655",
+    "iso_checksum_type"                     : "sha256",
+    "vmware_vsphere_nocm_vmx_data_memsize"  : "2048",
+    "vmware_vsphere_nocm_vmx_data_numvcpus" : "2",
+    "puppet_aio"                            : "http://yum.puppetlabs.com/el/6/PC1/i386/puppet-agent-1.10.10-1.el6.i386.rpm"
+}

--- a/templates/scientific/6.8/x86_64/vars.json
+++ b/templates/scientific/6.8/x86_64/vars.json
@@ -1,0 +1,12 @@
+{
+    "template_name"                         : "scientific-6.8-x86_64",
+    "template_os"                           : "rhel6-64",
+    "beakerhost"                            : "scientific6-64",
+    "version"                               : "0.0.1",
+    "iso_url"                               : "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_scientific/6.8/x86_64/iso/SL-68-x86_64-2016-06-29-DVD-DL.iso",
+    "iso_checksum"                          : "ada95b0e920612a5a9c56e268515a9965663377407a7897167be7a2efdade804",
+    "iso_checksum_type"                     : "sha256",
+    "vmware_vsphere_nocm_vmx_data_memsize"  : "6144",
+    "vmware_vsphere_nocm_vmx_data_numvcpus" : "2",
+    "puppet_aio"                            : "http://yum.puppetlabs.com/el/6/PC1/x86_64/puppet-agent-1.10.10-1.el6.x86_64.rpm"
+}


### PR DESCRIPTION
These images will replace our v6.5 images to address the GitHub TLS
compatibility change.

They build locally and appear to be working with our local mirrors, yum package groups are working, and the firewall is disabled by default.