### PR TITLE
enable redhat repo url config using env vars

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -3,6 +3,6 @@ include packer::updates
 include packer::sshd
 include packer::networking
 
-unless $::provisioner == 'ec2' or $::provisioner == 'libvirt' {
+unless $::provisioner in [ 'ec2', 'libvirt', 'virtualbox', 'docker' ] {
   include packer::vmtools
 }

--- a/manifests/modules/packer/manifests/repos.pp
+++ b/manifests/modules/packer/manifests/repos.pp
@@ -1,51 +1,12 @@
-# For platforms that come up without any configured software repos
-# (e.g, RHEL), this class is used to configure repos pointing to
-# our internal mirrors so that packages can be installed by other
-# puppet classes (mainly vmtools.pp).
-#
-# TODO: Consolidate this and the vsphere repos manifest into a single
-# module, which can be conditionally included in base.pp for targeted
-# platforms and for all cases in vsphere.pp.
+# warapper class to select which repos to install
+# this way we can run this class on ots own - needed by docker
 class packer::repos {
 
-  if $::operatingsystem == 'RedHat' {
-
-    $repo_mirror = 'https://artifactory.delivery.puppetlabs.net/artifactory'
-    $os_mirror   = 'http://osmirror.delivery.puppetlabs.net'
-    $gpgkey      = 'RPM-GPG-KEY-redhat-release'
-
-    resources { 'yumrepo':
-      purge => true,
-    }
-
-    # We don't have consistent mirror urls between RedHat versions:
-    # TODO: RHEL 5 needs further refactoring
-    $base_url = $::operatingsystemmajrelease ? {
-      '7' => "${repo_mirror}/rpm__remote_rhel-72",
-      '6' => "${repo_mirror}/rpm__remote_rhel-68-${::architecture}",
-      '5' => "${os_mirror}/rhel50server-${::architecture}/RPMS.all"
-    }
-
-    yumrepo { "localmirror-os":
-      descr    => "localmirror-os",
-      baseurl  => "${base_url}/os",
-      gpgcheck => "1",
-      gpgkey   => "file:///etc/pki/rpm-gpg/${gpgkey}"
-    }
-
-    yumrepo { "localmirror-optional":
-      descr    => "localmirror-optional",
-      baseurl  => "${base_url}/optional",
-      gpgcheck => "1",
-      gpgkey   => "file:///etc/pki/rpm-gpg/${gpgkey}"
-    }
-
-    yumrepo { "localmirror-extras":
-      descr    => "localmirror-extras",
-      baseurl  => "${base_url}/extras",
-      gpgcheck => "1",
-      gpgkey   => "file:///etc/pki/rpm-gpg/${gpgkey}"
-    }
+  if ($::redhat_os_repo or $::redhat_optional_repo or $::redhat_extra_repo) and
+  ($::redhat_os_repo != '' or $::redhat_optional_repo != '' or $::redhat_extra_repo != '') {
+    include packer::repos::community
+  } else {
+    include packer::repos::repos
   }
-
 }
+

--- a/manifests/modules/packer/manifests/repos/community.pp
+++ b/manifests/modules/packer/manifests/repos/community.pp
@@ -1,0 +1,52 @@
+# For platforms that come up without any configured software repos
+# (e.g, RHEL), this class is used to configure repos pointing to
+# your internal mirrors so that packages can be installed by other
+# puppet classes (mainly vmtools.pp).
+#
+# We only add yum repo definitions when following facts are set using
+# environment variables :
+#
+# * redhat_os_repo
+# * redhat_extra_repo
+# * redhat_optional_repo
+#
+# Other local mirrored repos qre out of scope for packer.
+#
+class packer::repos::community {
+
+  if $::operatingsystem == 'RedHat' {
+
+    $gpgkey      = 'RPM-GPG-KEY-redhat-release'
+
+    resources { 'yumrepo':
+      purge => true,
+    }
+
+    if $::redhat_os_repo and $::redhat_os_repo != '' {
+      yumrepo { "localmirror-os":
+        descr    => "localmirror-os",
+        baseurl  => $::redhat_os_repo,
+        gpgcheck => "1",
+        gpgkey   => "file:///etc/pki/rpm-gpg/${gpgkey}"
+      }
+    }
+
+    if $::redhat_optional_repo and $::redhat_optional_repo != '' {
+      yumrepo { "localmirror-optional":
+        descr    => "localmirror-optional",
+        baseurl  => $::redhat_optional_repo,
+        gpgcheck => "1",
+        gpgkey   => "file:///etc/pki/rpm-gpg/${gpgkey}"
+      }
+    }
+
+    if $::redhat_extra_repo and $::redhat_extra_repo != '' {
+      yumrepo { "localmirror-extras":
+        descr    => "localmirror-extras",
+        baseurl  => $::redhat_extra_repo,
+        gpgcheck => "1",
+        gpgkey   => "file:///etc/pki/rpm-gpg/${gpgkey}"
+      }
+    }
+  }
+}

--- a/manifests/modules/packer/manifests/repos/puppetlabs.pp
+++ b/manifests/modules/packer/manifests/repos/puppetlabs.pp
@@ -1,0 +1,51 @@
+# For platforms that come up without any configured software repos
+# (e.g, RHEL), this class is used to configure repos pointing to
+# our internal mirrors so that packages can be installed by other
+# puppet classes (mainly vmtools.pp).
+#
+# TODO: Consolidate this and the vsphere repos manifest into a single
+# module, which can be conditionally included in base.pp for targeted
+# platforms and for all cases in vsphere.pp.
+class packer::repos::puppetlabs {
+
+  if $::operatingsystem == 'RedHat' {
+
+    $repo_mirror = 'https://artifactory.delivery.puppetlabs.net/artifactory'
+    $os_mirror   = 'http://osmirror.delivery.puppetlabs.net'
+    $gpgkey      = 'RPM-GPG-KEY-redhat-release'
+
+    resources { 'yumrepo':
+      purge => true,
+    }
+
+    # We don't have consistent mirror urls between RedHat versions:
+    # TODO: RHEL 5 needs further refactoring
+    $base_url = $::operatingsystemmajrelease ? {
+      '7' => "${repo_mirror}/rpm__remote_rhel-72",
+      '6' => "${repo_mirror}/rpm__remote_rhel-68-${::architecture}",
+      '5' => "${os_mirror}/rhel50server-${::architecture}/RPMS.all"
+    }
+
+    yumrepo { "localmirror-os":
+      descr    => "localmirror-os",
+      baseurl  => "${base_url}/os",
+      gpgcheck => "1",
+      gpgkey   => "file:///etc/pki/rpm-gpg/${gpgkey}"
+    }
+
+    yumrepo { "localmirror-optional":
+      descr    => "localmirror-optional",
+      baseurl  => "${base_url}/optional",
+      gpgcheck => "1",
+      gpgkey   => "file:///etc/pki/rpm-gpg/${gpgkey}"
+    }
+
+    yumrepo { "localmirror-extras":
+      descr    => "localmirror-extras",
+      baseurl  => "${base_url}/extras",
+      gpgcheck => "1",
+      gpgkey   => "file:///etc/pki/rpm-gpg/${gpgkey}"
+    }
+  }
+
+}

--- a/templates/common/libvirt.base.json
+++ b/templates/common/libvirt.base.json
@@ -24,7 +24,10 @@
       "libvirt_base_qemuargs_cpu_count"      : "1",
       "libvirt_net_device"                   : null,
       "libvirt_disk_interface"               : null,
-      "libvirt_base_provisioning_scripts"    : "../../../../scripts/bootstrap-aio.sh"
+      "libvirt_base_provisioning_scripts"    : "../../../../scripts/bootstrap-aio.sh",
+      "redhat_os_repo"                       : "{{env `PACKER_REDHAT_OS_REPO`}}",
+      "redhat_optional_repo"                 : "{{env `PACKER_REDHAT_OPTIONAL_REPO`}}",
+      "redhat_extra_repo"                    : "{{env `PACKER_REDHAT_EXTRA_REPO`}}"
     },
 
     "description"                            : "Builds a Linux base template VM for use with vagrant-libvirt",
@@ -85,7 +88,10 @@
       "type"                                 : "puppet-masterless",
       "execute_command"                      : "{{.FacterVars}} PATH=$PATH:/opt/puppetlabs/bin /opt/puppetlabs/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter"                               : {
-                                                 "provisioner": "{{user `provisioner`}}"
+                                                 "provisioner":          "{{user `provisioner`}}",
+                                                 "redhat_os_repo":       "{{user `redhat_os_repo`}}",
+                                                 "redhat_optional_repo": "{{user `redhat_optional_repo`}}",
+                                                 "redhat_extra_repo":    "{{user `redhat_extra_repo`}}"                                                 
                                                },
       "manifest_dir"                         : "{{user `project_root`}}/manifests",
       "manifest_file"                        : "{{user `project_root`}}/manifests/base.pp"

--- a/templates/common/virtualbox.base.json
+++ b/templates/common/virtualbox.base.json
@@ -22,7 +22,10 @@
       "packer_output_dir"                    : "{{env `PACKER_VM_OUTPUT_DIR`}}",
       "virtualbox_base_vboxmanage_mem_size"  : "512",
       "virtualbox_base_vboxmanage_cpu_count" : "1",
-      "virtualbox_base_provisioning_scripts" : "../../../../scripts/bootstrap-aio.sh"
+      "virtualbox_base_provisioning_scripts" : "../../../../scripts/bootstrap-aio.sh",
+      "redhat_os_repo"                       : "{{env `PACKER_REDHAT_OS_REPO`}}",
+      "redhat_optional_repo"                 : "{{env `PACKER_REDHAT_OPTIONAL_REPO`}}",
+      "redhat_extra_repo"                    : "{{env `PACKER_REDHAT_EXTRA_REPO`}}"      
     },
 
     "description"                            : "Builds a Linux base template VM for use with virtualbox",
@@ -89,7 +92,10 @@
       "type"                                 : "puppet-masterless",
       "execute_command"                      : "{{.FacterVars}} PATH=$PATH:/opt/puppetlabs/bin /opt/puppetlabs/puppet/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter"                               : {
-                                                 "provisioner": "{{user `provisioner`}}"
+                                                 "provisioner": "{{user `provisioner`}}",
+                                                 "redhat_os_repo":       "{{user `redhat_os_repo`}}",
+                                                 "redhat_optional_repo": "{{user `redhat_optional_repo`}}",
+                                                 "redhat_extra_repo":    "{{user `redhat_extra_repo`}}"
                                                },
       "manifest_dir"                         : "{{user `project_root`}}/manifests",
       "manifest_file"                        : "{{user `project_root`}}/manifests/base.pp"

--- a/templates/common/vmware.base.json
+++ b/templates/common/vmware.base.json
@@ -26,7 +26,10 @@
     "vmware_base_vmx_data_ethernet0_virtualDev"    : "vmxnet3",
     "vmware_base_vmx_data_ethernet0_pciSlotNumber" : "33",
 
-    "vmware_base_provisioning_scripts"             : "../../../../scripts/bootstrap-aio.sh"
+    "vmware_base_provisioning_scripts"             : "../../../../scripts/bootstrap-aio.sh",
+    "redhat_os_repo"                               : "{{env `PACKER_REDHAT_OS_REPO`}}",
+    "redhat_optional_repo"                         : "{{env `PACKER_REDHAT_OPTIONAL_REPO`}}",
+    "redhat_extra_repo"                            : "{{env `PACKER_REDHAT_EXTRA_REPO`}}"
   },
 
   "description"                                    : "Builds a Linux base template VM for use in VMWare",
@@ -83,7 +86,10 @@
       "type"                                       : "puppet-masterless",
       "execute_command"                            : "{{.FacterVars}} PATH=$PATH:/opt/puppetlabs/bin /opt/puppetlabs/bin/puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",
       "facter"                                     : {
-        "provisioner"                              : "{{user `provisioner`}}"
+        "provisioner"                              : "{{user `provisioner`}}",
+        "redhat_os_repo"                           : "{{user `redhat_os_repo`}}",
+        "redhat_optional_repo"                     : "{{user `redhat_optional_repo`}}",
+        "redhat_extra_repo"                        : "{{user `redhat_extra_repo`}}"         
       },
       "manifest_dir"                               : "{{user `project_root`}}/manifests",
       "manifest_file"                              : "{{user `project_root`}}/manifests/base.pp"


### PR DESCRIPTION
Attempt to make the uri settings for redhat mirrored repos configurable using environment.  This introduces following envs : 
PACKER_REDHAT_OS_REPO = someurl
PACKER_REDHAT_OPTIONAL_REPO = someurl
PACKER_REDHAT_EXTRA_REPO = someurl

These are translates to facts in the *.base.json.
Whenever unset or all are empty, we include the stock packer::repo class, otherwise we include the packer::community_repso class.  Last one include only those repos if the environment is set.