### PR TITLE
(IMAGES-712) Refactor Win-10 Store App Removal 

### DIFF
--- a/templates/win/10-1511/x86_64/files/platform-packages.ps1
+++ b/templates/win/10-1511/x86_64/files/platform-packages.ps1
@@ -4,5 +4,5 @@ $ErrorActionPreference = "Stop"
 
 Write-Host "Running Win-10 Package Customisationtemplates/windows-10/files/i386/platform-packages.ps1"
 
-# Remove Store/Apps packages that break sysprep
-Remove-AppsPackages
+# Flag to remove Apps packages and other nuisances
+Touch-File "$PackerLogs\AppsPackageRemove.Required"

--- a/templates/win/10-1511/x86_64/vars.json
+++ b/templates/win/10-1511/x86_64/vars.json
@@ -6,7 +6,7 @@
     "windows_version"   : "Windows-10",
     "image_name"        : "Windows 10 Enterprise 2015 LTSB",
     "product_key"       : "WNMTR-4C88C-JK8YV-HQ7T2-76DF9",
-    "version"           : "20180315_1800",
+    "version"           : "20180323_0000",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_10_enterprise_2015_ltsb_x64_dvd_6848446.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "da938d65c548738900810181a78203f8",

--- a/templates/win/10-1607/x86_64/files/platform-packages.ps1
+++ b/templates/win/10-1607/x86_64/files/platform-packages.ps1
@@ -4,5 +4,5 @@ $ErrorActionPreference = "Stop"
 
 Write-Host "Running Win-10 Package Customisationtemplates/windows-10/files/i386/platform-packages.ps1"
 
-# Remove Store/Apps packages that break sysprep
-Remove-AppsPackages
+# Flag to remove Apps packages and other nuisances
+Touch-File "$PackerLogs\AppsPackageRemove.Required"

--- a/templates/win/10-1607/x86_64/vars.json
+++ b/templates/win/10-1607/x86_64/vars.json
@@ -6,7 +6,7 @@
     "windows_version"   : "Windows-10",
     "image_name"        : "Windows 10 Enterprise 2016 LTSB",
     "product_key"       : "DCPHK-NFMTC-H88MJ-PFHPY-QJ4BJ",
-    "version"           : "20180315_1800",
+    "version"           : "20180323_0000",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_10_enterprise_2016_ltsb_x64_dvd_9059483.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "e39ea2af41b3710682fe3bbdac35ec9a",

--- a/templates/win/10-ent/i386/files/platform-packages.ps1
+++ b/templates/win/10-ent/i386/files/platform-packages.ps1
@@ -4,5 +4,5 @@ $ErrorActionPreference = "Stop"
 
 Write-Host "Running Win-10 Package Customisation"
 
-# Remove Store/Apps packages that break sysprep
-Remove-AppsPackages
+# Flag to remove Apps packages and other nuisances
+Touch-File "$PackerLogs\AppsPackageRemove.Required"

--- a/templates/win/10-ent/i386/vars.json
+++ b/templates/win/10-ent/i386/vars.json
@@ -7,7 +7,7 @@
     "windows_version"   : "Windows-10",
     "image_name"        : "Windows 10 Enterprise",
     "product_key"       : "NPPR9-FWDCX-D2C8J-H872K-2YT43",
-    "version"           : "20180315_1800",
+    "version"           : "20180323_0000",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_10_multi-edition_vl_version_1709_updated_dec_2017_x86_dvd_100406182.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "e5bd5877a9e7f0e29abc94e4664523c0",

--- a/templates/win/10-ent/x86_64/files/platform-packages.ps1
+++ b/templates/win/10-ent/x86_64/files/platform-packages.ps1
@@ -4,5 +4,5 @@ $ErrorActionPreference = "Stop"
 
 Write-Host "Running Win-10 Package Customisationtemplates/windows-10/files/i386/platform-packages.ps1"
 
-# Remove Store/Apps packages that break sysprep
-Remove-AppsPackages
+# Flag to remove Apps packages and other nuisances
+Touch-File "$PackerLogs\AppsPackageRemove.Required"

--- a/templates/win/10-ent/x86_64/vars.json
+++ b/templates/win/10-ent/x86_64/vars.json
@@ -6,7 +6,7 @@
     "windows_version"   : "Windows-10",
     "image_name"        : "Windows 10 Enterprise",
     "product_key"       : "NPPR9-FWDCX-D2C8J-H872K-2YT43",
-    "version"           : "20180315_1800",
+    "version"           : "20180323_0000",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_10_multi-edition_vl_version_1709_updated_dec_2017_x64_dvd_100406172.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "c6dad7a55f8af7ae5e38b33d1d65805b",

--- a/templates/win/10-pro/x86_64/files/platform-packages.ps1
+++ b/templates/win/10-pro/x86_64/files/platform-packages.ps1
@@ -4,5 +4,5 @@ $ErrorActionPreference = "Stop"
 
 Write-Host "Running Win-10 Package Customisationtemplates/windows-10/files/i386/platform-packages.ps1"
 
-# Remove Store/Apps packages that break sysprep
-Remove-AppsPackages
+# Flag to remove Apps packages and other nuisances
+Touch-File "$PackerLogs\AppsPackageRemove.Required"

--- a/templates/win/10-pro/x86_64/vars.json
+++ b/templates/win/10-pro/x86_64/vars.json
@@ -6,7 +6,7 @@
     "windows_version"   : "Windows-10",
     "image_name"        : "Windows 10 Pro",
     "product_key"       : "W269N-WFGWX-YVC9B-4J6C9-T83GX",
-    "version"           : "20180315_1800",
+    "version"           : "20180323_0000",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_10_multi-edition_vl_version_1709_updated_dec_2017_x64_dvd_100406172.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "c6dad7a55f8af7ae5e38b33d1d65805b",

--- a/templates/win/2008/x86_64/vars.json
+++ b/templates/win/2008/x86_64/vars.json
@@ -6,7 +6,7 @@
     "windows_version"   : "Windows-2008",
     "image_name"        : "Windows Longhorn SERVERSTANDARD",
     "product_key"       : "TM24T-X9RMF-VWXK6-X8JC9-BFGM2",
-    "version"           : "20180315_1800",
+    "version"           : "20180323_0000",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_server_2008_with_sp2_x64_dvd_342336_SlipStream_03.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "ab418a455fea422d2582c660ee8cd8f1",

--- a/templates/win/2008r2-wmf2/x86_64/vars.json
+++ b/templates/win/2008r2-wmf2/x86_64/vars.json
@@ -3,5 +3,5 @@
 
     "template_name"             : "win-2008r2-wmf2-x86_64",
     "gce_source_image_family"   : "windows-2008-r2",
-    "version"                   : "20180315_1800"
+    "version"                   : "20180323_0000"
 }

--- a/templates/win/2008r2-wmf3/x86_64/vars.json
+++ b/templates/win/2008r2-wmf3/x86_64/vars.json
@@ -3,5 +3,5 @@
     
     "template_name"             : "win-2008r2-wmf3-x86_64",
     "gce_source_image_family"   : "windows-2008-r2",
-    "version"                   : "20180315_1800"
+    "version"                   : "20180323_0000"
 }

--- a/templates/win/2008r2-wmf4/x86_64/vars.json
+++ b/templates/win/2008r2-wmf4/x86_64/vars.json
@@ -3,5 +3,5 @@
 
     "template_name"             : "win-2008r2-wmf4-x86_64",
     "gce_source_image_family"   : "windows-2008-r2",
-    "version"                   : "20180315_1800"
+    "version"                   : "20180323_0000"
 }

--- a/templates/win/2008r2-wmf5/x86_64/vars.json
+++ b/templates/win/2008r2-wmf5/x86_64/vars.json
@@ -6,7 +6,7 @@
     "windows_version"   : "Windows-2008r2",
     "image_name"        : "Windows Server 2008 R2 SERVERSTANDARD",
     "product_key"       : "YC6KT-GKW9T-YTKYR-T4X34-R7VHC",
-    "version"           : "20180315_1800",
+    "version"           : "20180323_0000",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_server_2008_r2_with_sp1_x64_dvd_617601_SlipStream_03.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "f94011cfdc4e0498a01a86a0cafe403e",

--- a/templates/win/2008r2/x86_64/vars.json
+++ b/templates/win/2008r2/x86_64/vars.json
@@ -6,7 +6,7 @@
     "windows_version"           : "Windows-2008r2",
     "image_name"                : "Windows Server 2008 R2 SERVERSTANDARD",
     "product_key"               : "YC6KT-GKW9T-YTKYR-T4X34-R7VHC",
-    "version"                   : "20180315_1800",
+    "version"                   : "20180323_0000",
     "iso_url"                   : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_server_2008_r2_with_sp1_x64_dvd_617601_SlipStream_03.iso",
     "iso_checksum_type"         : "md5",
     "iso_checksum"              : "f94011cfdc4e0498a01a86a0cafe403e",

--- a/templates/win/2012/x86_64/vars.json
+++ b/templates/win/2012/x86_64/vars.json
@@ -6,7 +6,7 @@
     "windows_version"   : "Windows-2012",
     "image_name"        : "Windows Server 2012 SERVERSTANDARD",
     "product_key"       : "XC9B7-NBPP2-83J2H-RHMBY-92BT4",
-    "version"           : "20180315_1800",
+    "version"           : "20180323_0000",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_server_2012_x64_dvd_915478_SlipStream_03.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "8cc8b3f54bb56dce7936bb1e97e3fc31",

--- a/templates/win/2012r2-core/x86_64/vars.json
+++ b/templates/win/2012r2-core/x86_64/vars.json
@@ -7,7 +7,7 @@
     "image_index"       : "1",
     "image_name"        : "Windows Server 2012 R2 SERVERSTANDARDCORE",
     "product_key"       : "D2N9P-3P6X9-2R39C-7RTCD-MDVJX",
-    "version"           : "20180315_1800",
+    "version"           : "20180323_0000",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_server_2012_r2_with_update_x64_dvd_6052708_SlipStream_03.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "8b30b370cfd32e2b90ab4e1b77a31bd3",

--- a/templates/win/2012r2-fr/x86_64/vars.json
+++ b/templates/win/2012r2-fr/x86_64/vars.json
@@ -8,7 +8,7 @@
     "windows_version"   : "Windows-2012r2",
     "image_name"        : "Windows Server 2012 R2 SERVERSTANDARD",
     "product_key"       : "D2N9P-3P6X9-2R39C-7RTCD-MDVJX",
-    "version"           : "20180315_1800",
+    "version"           : "20180323_0000",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/fr_windows_server_2012_r2_with_update_x64_dvd_6052713_SlipStream_01.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "2aaeb548f739f417a33439fd6a614090",

--- a/templates/win/2012r2-ja/x86_64/vars.json
+++ b/templates/win/2012r2-ja/x86_64/vars.json
@@ -7,7 +7,7 @@
     "windows_version"   : "Windows-2012r2",
     "image_name"        : "Windows Server 2012 R2 SERVERSTANDARD",
     "product_key"       : "D2N9P-3P6X9-2R39C-7RTCD-MDVJX",
-    "version"           : "20180315_1800",
+    "version"           : "20180323_0000",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/ja_windows_server_2012_r2_with_update_x64_dvd_6052738_SlipStream_01.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "d06430e4ddc79330649b4b16d984a3d5",

--- a/templates/win/2012r2-wmf5/x86_64/vars.json
+++ b/templates/win/2012r2-wmf5/x86_64/vars.json
@@ -6,7 +6,7 @@
     "windows_version"   : "Windows-2012r2",
     "image_name"        : "Windows Server 2012 R2 SERVERSTANDARD",
     "product_key"       : "D2N9P-3P6X9-2R39C-7RTCD-MDVJX",
-    "version"           : "20180315_1800",
+    "version"           : "20180323_0000",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_server_2012_r2_with_update_x64_dvd_6052708_SlipStream_02.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "3feae58c235f88126a1c099d58abfb8f",

--- a/templates/win/2012r2/x86_64/vars.json
+++ b/templates/win/2012r2/x86_64/vars.json
@@ -7,7 +7,7 @@
     "post_memsize"      : "6144",
     "image_name"        : "Windows Server 2012 R2 SERVERSTANDARD",
     "product_key"       : "D2N9P-3P6X9-2R39C-7RTCD-MDVJX",
-    "version"           : "20180315_1800",
+    "version"           : "20180323_0000",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_server_2012_r2_with_update_x64_dvd_6052708_SlipStream_02.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "3feae58c235f88126a1c099d58abfb8f",

--- a/templates/win/2016-core/x86_64/vars.json
+++ b/templates/win/2016-core/x86_64/vars.json
@@ -6,7 +6,7 @@
     "windows_version"   : "Windows-2016",
     "image_name"        : "Windows Server 2016 SERVERSTANDARDCORE",
     "product_key"       : "WC2BQ-8NRM3-FDDYY-2BFGV-KHKQY",
-    "version"           : "20180315_1800",
+    "version"           : "20180323_0000",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_server_2016_updated_feb_2018_x64_dvd_11636692.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "e8adeebcd8076702593469e33cc2d092",

--- a/templates/win/2016-hyperv/x86_64/vars.json
+++ b/templates/win/2016-hyperv/x86_64/vars.json
@@ -6,7 +6,7 @@
     "windows_version"   : "Windows-2016",
     "image_name"        : "Windows Server 2016 SERVERSTANDARD",
     "product_key"       : "WC2BQ-8NRM3-FDDYY-2BFGV-KHKQY",
-    "version"           : "20180315_1800",
+    "version"           : "20180323_0000",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_server_2016_updated_feb_2018_x64_dvd_11636692.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "e8adeebcd8076702593469e33cc2d092",

--- a/templates/win/2016/x86_64/vars.json
+++ b/templates/win/2016/x86_64/vars.json
@@ -6,7 +6,7 @@
     "windows_version"   : "Windows-2016",
     "image_name"        : "Windows Server 2016 SERVERSTANDARD",
     "product_key"       : "WC2BQ-8NRM3-FDDYY-2BFGV-KHKQY",
-    "version"           : "20180315_1800",
+    "version"           : "20180323_0000",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_server_2016_updated_feb_2018_x64_dvd_11636692.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "e8adeebcd8076702593469e33cc2d092",

--- a/templates/win/7-wmf5/x86_64/vars.json
+++ b/templates/win/7-wmf5/x86_64/vars.json
@@ -7,7 +7,7 @@
     "image_name"        : "Windows 7 Enterprise",
     "product_key"       : "33PXH-7Y6KF-2VJC9-XBBR8-HVTHH",
     "hypervisor"        : "VMWare",
-    "version"           : "20180315_1800",
+    "version"           : "20180323_0000",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_7_enterprise_with_sp1_x64_dvd_u_677651_SlipStream_03.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "4246cfa663a9a581d2da4ba784554308",

--- a/templates/win/7/x86_64/vars.json
+++ b/templates/win/7/x86_64/vars.json
@@ -7,7 +7,7 @@
     "image_name"        : "Windows 7 Enterprise",
     "product_key"       : "33PXH-7Y6KF-2VJC9-XBBR8-HVTHH",
     "hypervisor"        : "VMWare",
-    "version"           : "20180315_1800",
+    "version"           : "20180323_0000",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_7_enterprise_with_sp1_x64_dvd_u_677651_SlipStream_03.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "4246cfa663a9a581d2da4ba784554308",

--- a/templates/win/81/x86_64/files/platform-packages.ps1
+++ b/templates/win/81/x86_64/files/platform-packages.ps1
@@ -4,5 +4,5 @@ $ErrorActionPreference = "Stop"
 
 Write-Host "Running Win-8.1 Package Customisation"
 
-# Remove Store/Apps packages that break sysprep
-Remove-AppsPackages
+# Flag to remove Apps packages and other nuisances
+Touch-File "$PackerLogs\AppsPackageRemove.Required"

--- a/templates/win/81/x86_64/vars.json
+++ b/templates/win/81/x86_64/vars.json
@@ -6,7 +6,7 @@
     "windows_version"   : "Windows-8.1",
     "image_name"        : "Windows 8.1 Enterprise",
     "product_key"       : "MHF9N-XY6XB-WVXMC-BTDCT-MKKG7",
-    "version"           : "20180315_1800",
+    "version"           : "20180323_0000",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_8.1_enterprise_with_update_x64_dvd_6054382_SlipStream_01.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "ce996fb7136d55314747c5cef2602b27",

--- a/templates/win/common/files/AutoUnattendTemplate.xml
+++ b/templates/win/common/files/AutoUnattendTemplate.xml
@@ -254,9 +254,13 @@
                         <Order>4</Order>
                     </SynchronousCommand>
                     <SynchronousCommand wcm:action="add">
-                        <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\start-pswindowsupdate.ps1 -HyperVisor vmware</CommandLine>
-                        <Description>Start PSWindowsUpdate</Description>
+                        <CommandLine>cmd.exe /c mkdir C:\Packer\Logs</CommandLine>
                         <Order>5</Order>
+                    </SynchronousCommand>
+                    <SynchronousCommand wcm:action="add">
+                        <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\start-pswindowsupdate.ps1 -HyperVisor vmware &gt;&gt; C:\Packer\Logs\start-pswindowsupdate.log</CommandLine>
+                        <Description>Start PSWindowsUpdate</Description>
+                        <Order>6</Order>
                     </SynchronousCommand>
                 </FirstLogonCommands>
             </PackerLogonSequence>
@@ -280,10 +284,14 @@
                         <CommandLine>wmic useraccount where &quot;sid like &apos;S-1-5-21-%-500&apos;&quot; set PasswordExpires=FALSE</CommandLine>
                         <Order>4</Order>
                     </SynchronousCommand>
-                   <SynchronousCommand wcm:action="add">
-                        <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\start-pswindowsupdate.ps1 -HyperVisor virtualbox</CommandLine>
-                        <Description>Start PSWindowsUpdate</Description>
+                    <SynchronousCommand wcm:action="add">
+                        <CommandLine>cmd.exe /c mkdir C:\Packer\Logs</CommandLine>
                         <Order>5</Order>
+                    </SynchronousCommand>
+                   <SynchronousCommand wcm:action="add">
+                        <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\start-pswindowsupdate.ps1 -HyperVisor virtualbox &gt;&gt; C:\Packer\Logs\start-pswindowsupdate.log</CommandLine>
+                        <Description>Start PSWindowsUpdate</Description>
+                        <Order>6</Order>
                     </SynchronousCommand>
                 </FirstLogonCommands>
             </PackerLogonSequence>

--- a/templates/win/common/files/Autounattend.xslt
+++ b/templates/win/common/files/Autounattend.xslt
@@ -177,6 +177,25 @@
     </xsl:choose>
   </xsl:template>
 
+  <!-- Select correct OOBE elements depending on OS Version -->
+  <xsl:template match='u:unattend/u:settings/u:component[@name="Microsoft-Windows-Shell-Setup"]/u:OOBE/u:SkipUserOOBE | 
+                       u:unattend/u:settings/u:component[@name="Microsoft-Windows-Shell-Setup"]/u:OOBE/u:SkipMachineOOBE'>
+    <xsl:choose>
+      <xsl:when test="$WindowsVersion = 'Windows-10'" >
+        <xsl:copy>
+          <!-- 
+            Copy Skip OOBE Elements for these Operating Systems.
+            Windows-10 only
+             -->
+          <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+      </xsl:when>
+      <xsl:otherwise>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+
   <!-- Insert correct Administrator Password -->
   <xsl:template match='u:unattend/u:settings/u:component[@name="Microsoft-Windows-Shell-Setup"]/u:UserAccounts/u:AdministratorPassword/u:Value |
                        u:unattend/u:settings/u:component[@name="Microsoft-Windows-Shell-Setup"]/u:UserAccounts/u:LocalAccounts/u:LocalAccount/u:Password/u:Value | 

--- a/templates/win/common/files/PostCloneTemplate.xml
+++ b/templates/win/common/files/PostCloneTemplate.xml
@@ -83,7 +83,7 @@
                         <Order>3</Order>
                     </SynchronousCommand>
                     <SynchronousCommand wcm:action="add">
-                        <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File C:\Packer\Scripts\vmpooler-post-clone-configuration.ps1</CommandLine>
+                        <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File C:\Packer\Scripts\vmpooler-post-clone-configuration.ps1 &gt;&gt; C:\Packer\Logs\post-clone-run-once.log</CommandLine>
                         <Description>Post Clone configuration</Description>
                         <Order>4</Order>
                     </SynchronousCommand>

--- a/templates/win/common/files/PostCloneTemplate.xml
+++ b/templates/win/common/files/PostCloneTemplate.xml
@@ -116,6 +116,8 @@
                 <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>
                 <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
                 <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+                <SkipMachineOOBE>true</SkipMachineOOBE>
+                <SkipUserOOBE>true</SkipUserOOBE>
                 <NetworkLocation>Work</NetworkLocation>
                 <ProtectYourPC>1</ProtectYourPC>
             </OOBE>

--- a/templates/win/common/puppet/windows_template/manifests/policies/local_group_policies.pp
+++ b/templates/win/common/puppet/windows_template/manifests/policies/local_group_policies.pp
@@ -222,7 +222,7 @@ class windows_template::policies::local_group_policies ()
 
     # Screen out these policies for anything earlier than Win-2012r2
     #
-    if ("$::kernelmajversion" > '6.1' ) {
+    if ("$::kernelmajversion" == '10.0' ) {
         # Mostly Win-10 policies.
         #  1. Turn off Tile Notifications
         windows_group_policy::local::user { 'NotileApplicationNotification':

--- a/templates/win/common/scripts/bootstrap/start-pswindowsupdate.ps1
+++ b/templates/win/common/scripts/bootstrap/start-pswindowsupdate.ps1
@@ -17,9 +17,6 @@ If ( $WindowsServerCore ) {
   Install-CoreStartupWorkaround
 }
 
-# Record sessions in transcript
-Start-Transcript -Append -Path "$PackerLogs\start-pswindowsupdate.log"
-
 # Enable WSUS - this is being put at the top of the script deliberately as a recycle of wuauserv is
 # required - this most reliable way to do this is with a reboot so we want to get this out the way first
 # to prevent windows update starting anything.
@@ -145,7 +142,16 @@ else {
 # Run Windows Update - this will repeat as often as needed through the Invoke-Reboot cycle.
 # When no more reboots are needed, the script falls through to the end.
 Write-Output "Searching for Windows Updates"
+if ($WindowsVersion -like $WindowsServer2016) {
+  Write-Output "Disabling some more Windows Update (10) parameters"
+  Write-Output "Disable seeding of updates to other computers via Group Policies"
+  force-mkdir "HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeliveryOptimization"
+  Set-ItemProperty "HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeliveryOptimization" "DODownloadMode" 0
+}
+
+Write-Output "Using PSWindowsUpdate module"
 Import-Module "$PackerStaging\PSWindowsUpdate\PSWindowsUpdate.psd1"
+
 # Repeat this command twice to ensure any interrupted downloads are re-attempted for install.
 # Windows-10 in particular seems to be affected by intermittency here - so try and improve reliability
 $Attempt = 1

--- a/templates/win/common/scripts/bootstrap/start-pswindowsupdate.ps1
+++ b/templates/win/common/scripts/bootstrap/start-pswindowsupdate.ps1
@@ -34,6 +34,13 @@ else {
 if (-not (Test-Path "$PackerLogs\HyperVisorExtensions.installed")) {
   Write-Output "Installing HyperVisor ($HyperVisor) Extensions/Tools"
 
+  # This is a Windows 10 only workaround to make sure the trusted installer is actually running.
+  # This needs to be done early on in the initialisation sequence well before we apply updates.
+  # Not certain, but this appears to improve the reliability of the windows update.
+  if ($WindowsVersion -Like $WindowsServer2016) {
+    Set-Service "trustedinstaller" -StartupType Automatic -ErrorAction SilentlyContinue
+  }
+
   switch ($HyperVisor) {
     "vmware" {
       # VMWare installs only
@@ -164,11 +171,10 @@ do {
   $Attempt++
 } while ($Attempt -le 2)
 
-# Rerun the Apps Package Cleaner again.
-
-if (Test-Path "$PackerLogs\AppsPackageRemove.Pass2.Required") {
-  Write-Output "Running second pass of the Apps Package Cleaner post windows update"
-  Remove-AppsPackages -AppPackageCheckpoint AppsPackageRemove.Pass2
+# Run the Application Package Cleaner
+if (Test-Path "$PackerLogs\AppsPackageRemove.Required") {
+  Write-Output "Running Apps Package Cleaner post windows update"
+  Remove-AppsPackages -AppPackageCheckpoint AppsPackageRemove.Pass1
 }
 
 # Enable Remote Desktop (with reduce authentication resetting here again)

--- a/templates/win/common/scripts/common/windows-env.ps1
+++ b/templates/win/common/scripts/common/windows-env.ps1
@@ -1,5 +1,5 @@
 # Placeholder Environment script for common variable definition.
-$ErrorActionPreference = 'Stop'
+$ErrorActionPreference = 'Continue'
 
 # Defining set of constants for Windows version checking used throughout the code.
 # Using Major/Minor versions only as listed in:
@@ -305,6 +305,120 @@ Function Install-DotNetLatest
 }
 
 
+# This code lifted from https://github.com/W4RH4WK/Debloat-Windows-10
+# Windows-10 only ?
+function Takeown-Registry($key) {
+  # TODO does not work for all root keys yet
+  switch ($key.split('\')[0]) {
+      "HKEY_CLASSES_ROOT" {
+          $reg = [Microsoft.Win32.Registry]::ClassesRoot
+          $key = $key.substring(18)
+      }
+      "HKEY_CURRENT_USER" {
+          $reg = [Microsoft.Win32.Registry]::CurrentUser
+          $key = $key.substring(18)
+      }
+      "HKEY_LOCAL_MACHINE" {
+          $reg = [Microsoft.Win32.Registry]::LocalMachine
+          $key = $key.substring(19)
+      }
+  }
+
+  # get Admin group
+  $admins = New-Object System.Security.Principal.SecurityIdentifier("S-1-5-32-544")
+  $admins = $admins.Translate([System.Security.Principal.NTAccount])
+
+  # set owner
+  $key = $reg.OpenSubKey($key, "ReadWriteSubTree", "TakeOwnership")
+  $acl = $key.GetAccessControl()
+  $acl.SetOwner($admins)
+  $key.SetAccessControl($acl)
+
+  # set FullControl
+  $acl = $key.GetAccessControl()
+  $rule = New-Object System.Security.AccessControl.RegistryAccessRule($admins, "FullControl", "Allow")
+  $acl.SetAccessRule($rule)
+  $key.SetAccessControl($acl)
+}
+
+function Takeown-File($path) {
+  takeown.exe /A /F $path
+  $acl = Get-Acl $path
+
+  # get Admin group
+  $admins = New-Object System.Security.Principal.SecurityIdentifier("S-1-5-32-544")
+  $admins = $admins.Translate([System.Security.Principal.NTAccount])
+
+  # add NT Authority\SYSTEM
+  $rule = New-Object System.Security.AccessControl.FileSystemAccessRule($admins, "FullControl", "None", "None", "Allow")
+  $acl.AddAccessRule($rule)
+
+  Set-Acl -Path $path -AclObject $acl
+}
+
+function Takeown-Folder($path) {
+  Takeown-File $path
+  foreach ($item in Get-ChildItem $path) {
+      if (Test-Path $item -PathType Container) {
+          Takeown-Folder $item.FullName
+      } else {
+          Takeown-File $item.FullName
+      }
+  }
+}
+
+function Elevate-Privileges {
+  param($Privilege)
+  $Definition = @"
+  using System;
+  using System.Runtime.InteropServices;
+  public class AdjPriv {
+      [DllImport("advapi32.dll", ExactSpelling = true, SetLastError = true)]
+          internal static extern bool AdjustTokenPrivileges(IntPtr htok, bool disall, ref TokPriv1Luid newst, int len, IntPtr prev, IntPtr rele);
+      [DllImport("advapi32.dll", ExactSpelling = true, SetLastError = true)]
+          internal static extern bool OpenProcessToken(IntPtr h, int acc, ref IntPtr phtok);
+      [DllImport("advapi32.dll", SetLastError = true)]
+          internal static extern bool LookupPrivilegeValue(string host, string name, ref long pluid);
+      [StructLayout(LayoutKind.Sequential, Pack = 1)]
+          internal struct TokPriv1Luid {
+              public int Count;
+              public long Luid;
+              public int Attr;
+          }
+      internal const int SE_PRIVILEGE_ENABLED = 0x00000002;
+      internal const int TOKEN_QUERY = 0x00000008;
+      internal const int TOKEN_ADJUST_PRIVILEGES = 0x00000020;
+      public static bool EnablePrivilege(long processHandle, string privilege) {
+          bool retVal;
+          TokPriv1Luid tp;
+          IntPtr hproc = new IntPtr(processHandle);
+          IntPtr htok = IntPtr.Zero;
+          retVal = OpenProcessToken(hproc, TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, ref htok);
+          tp.Count = 1;
+          tp.Luid = 0;
+          tp.Attr = SE_PRIVILEGE_ENABLED;
+          retVal = LookupPrivilegeValue(null, privilege, ref tp.Luid);
+          retVal = AdjustTokenPrivileges(htok, false, ref tp, 0, IntPtr.Zero, IntPtr.Zero);
+          return retVal;
+      }
+  }
+"@
+  $ProcessHandle = (Get-Process -id $pid).Handle
+  $type = Add-Type $definition -PassThru
+  $type[0]::EnablePrivilege($processHandle, $Privilege)
+}
+
+
+# While `mkdir -force` works fine when dealing with regular folders, it behaves
+# strange when using it at registry level. If the target registry key is
+# already present, all values within that key are purged.
+function force-mkdir($path) {
+  if (!(Test-Path $path)) {
+      #Write-Host "-- Creating full path to: " $path -ForegroundColor White -BackgroundColor DarkGreen
+      New-Item -ItemType Directory -Force -Path $path
+  }
+}
+
 # Helper function to remove Store/Apps packages that break sysprep (packages are not needed in our test env)
 
 Function Remove-AppsPackages
@@ -313,57 +427,129 @@ Function Remove-AppsPackages
 
   if (-not (Test-Path "$PackerLogs\$AppPackageCheckpoint"))
   {
-    try {
-      Write-Output "Remove All Win-10 App/Packages to prevent Sysprep Issues"
+    Write-Output "Remove All Win-10 App/Packages to prevent Sysprep Issues"
 
-      Import-Module Appx
-      Import-Module Dism
+    Write-Output "Elevating privileges for this process"
+    do {} until (Elevate-Privileges SeTakeOwnershipPrivilege)
 
-      Write-Output "Removing AppxPackages"
-      Get-AppxPackage -AllUsers | Remove-AppxPackage -ErrorAction SilentlyContinue
+    Write-Output "Uninstalling default apps"
+    $apps = @(
+        # default Windows 10 apps
+        "Microsoft.3DBuilder"
+        "Microsoft.Appconnector"
+        "Microsoft.BingFinance"
+        "Microsoft.BingNews"
+        "Microsoft.BingSports"
+        "Microsoft.BingWeather"
+        #"Microsoft.FreshPaint"
+        "Microsoft.Getstarted"
+        "Microsoft.MicrosoftOfficeHub"
+        "Microsoft.MicrosoftSolitaireCollection"
+        #"Microsoft.MicrosoftStickyNotes"
+        "Microsoft.Office.OneNote"
+        #"Microsoft.OneConnect"
+        "Microsoft.People"
+        "Microsoft.SkypeApp"
+        #"Microsoft.Windows.Photos"
+        "Microsoft.WindowsAlarms"
+        #"Microsoft.WindowsCalculator"
+        "Microsoft.WindowsCamera"
+        "Microsoft.WindowsMaps"
+        "Microsoft.WindowsPhone"
+        "Microsoft.WindowsSoundRecorder"
+        #"Microsoft.WindowsStore"
+        "Microsoft.XboxApp"
+        "Microsoft.ZuneMusic"
+        "Microsoft.ZuneVideo"
+        "microsoft.windowscommunicationsapps"
+        "Microsoft.MinecraftUWP"
+        "Microsoft.MicrosoftPowerBIForWindows"
+        "Microsoft.NetworkSpeedTest"
+        "Microsoft.RemoteDesktop"
 
-      Write-Output "Removing Online Provisioned Packages"
-      Get-AppXProvisionedPackage -online | Remove-AppxProvisionedPackage -online -ErrorAction SilentlyContinue
+        # Threshold 2 apps
+        "Microsoft.CommsPhone"
+        "Microsoft.ConnectivityStore"
+        "Microsoft.Messaging"
+        "Microsoft.Office.Sway"
+        "Microsoft.OneConnect"
+        "Microsoft.WindowsFeedbackHub"
+
+        #Redstone apps
+        "Microsoft.BingFoodAndDrink"
+        "Microsoft.BingTravel"
+        "Microsoft.BingHealthAndFitness"
+        "Microsoft.WindowsReadingList"
+
+        # non-Microsoft
+        "9E2F88E3.Twitter"
+        "PandoraMediaInc.29680B314EFC2"
+        "Flipboard.Flipboard"
+        "ShazamEntertainmentLtd.Shazam"
+        "king.com.CandyCrushSaga"
+        "king.com.CandyCrushSodaSaga"
+        "king.com.*"
+        "ClearChannelRadioDigital.iHeartRadio"
+        "4DF9E0F8.Netflix"
+        "6Wunderkinder.Wunderlist"
+        "Drawboard.DrawboardPDF"
+        "2FE3CB00.PicsArt-PhotoStudio"
+        "D52A8D61.FarmVille2CountryEscape"
+        "TuneIn.TuneInRadio"
+        "GAMELOFTSA.Asphalt8Airborne"
+        #"TheNewYorkTimes.NYTCrossword"
+        "DB6EA5DB.CyberLinkMediaSuiteEssentials"
+        "Facebook.Facebook"
+        "flaregamesGmbH.RoyalRevolt2"
+        "Playtika.CaesarsSlotsFreeCasino"
+        "A278AB0D.MarchofEmpires"
+        "KeeperSecurityInc.Keeper"
+        "ThumbmunkeysLtd.PhototasticCollage"
+        "XINGAG.XING"
+        "89006A2E.AutodeskSketchBook"
+        "D5EA27B7.Duolingo-LearnLanguagesforFree"
+        "46928bounde.EclipseManager"
+        "ActiproSoftwareLLC.562882FEEB491" # next one is for the Code Writer from Actipro Software LLC
+        "DolbyLaboratories.DolbyAccess"
+        "SpotifyAB.SpotifyMusic"
+        "A278AB0D.DisneyMagicKingdoms"
+        "WinZipComputing.WinZipUniversal"
+
+
+        # apps which cannot be removed using Remove-AppxPackage
+        #"Microsoft.BioEnrollment"
+        #"Microsoft.MicrosoftEdge"
+        #"Microsoft.Windows.Cortana"
+        #"Microsoft.WindowsFeedback"
+        #"Microsoft.XboxGameCallableUI"
+        #"Microsoft.XboxIdentityProvider"
+        #"Windows.ContactSupport"
+    )
+
+    foreach ($app in $apps) {
+
+      Write-Output "Trying to remove $app"
+      try {
+        Get-AppxPackage -Name $app -AllUsers | Remove-AppxPackage -ErrorAction SilentlyContinue
+        Get-AppxPackage -Name $app -AllUsers | Remove-AppxPackage -AllUsers -ErrorAction SilentlyContinue
+
+        Get-AppXProvisionedPackage -Online |
+            Where-Object DisplayName -EQ $app |
+            Remove-AppxProvisionedPackage -Online -ErrorAction SilentlyContinue
+      }
+      catch {
+        Write-Output "Ignoring errors in pkgremoval for $app"
+      }
     }
-    catch {
-      Write-Output "Ignoring errors in pkgremoval"
-    }
 
-    if ("$ARCH" -eq "x86_64") {
-      $SystemDir = "SysWOW64"
-    } else {
-      $SystemDir = "System32"
-    }
+    # Specials for the tricky ones
+    Get-AppXPackage -Name Microsoft.Windows.Cortana |
+        ForEach-Object {Add-AppxPackage -DisableDevelopmentMode -Register "$($_.InstallLocation)\AppXManifest.xml"} -ErrorAction SilentlyContinue
 
-    try {
-      Write-Output "Stopping OneDrive"
-      taskkill /f /im OneDrive.exe
-    }
-    catch {
-      Write-Output "Ignoring OneDrive taskkill error"
-    }
-
-    try {
-      Write-Output "Uninstalling OneDrive"
-      $zproc = Start-Process "$env:SystemRoot\$SystemDir\OneDriveSetup.exe" -PassThru -NoNewWindow -ArgumentList "/uninstall"
-      $zproc.WaitForExit()
-
-      Remove-Item "$Env:UserProfile\OneDrive" -Recurse -Force -ErrorAction SilentlyContinue | Out-Null
-      Remove-Item "$Env:LocalAppData\Microsoft\OneDrive" -Recurse -Force -ErrorAction SilentlyContinue | Out-Null
-      Remove-Item "$Env:ProgramData\Microsoft OneDrive" -Recurse -Force -ErrorAction SilentlyContinue | Out-Null
-      Remove-Item "C:\OneDriveTemp" -Recurse -Force -ErrorAction SilentlyContinue | Out-Null
-    }
-    catch {
-      Write-Output "Ignoring OneDrive uninstall error"
-    }
-
-    # Flag that this operation needs to be re-run
-    Touch-File "$PackerLogs\AppsPackageRemove.Pass2.Required"
-
-    if (Test-PendingReboot) { Invoke-Reboot }
     Touch-File "$PackerLogs\$AppPackageCheckpoint"
   }
 }
+
 
 # Helper Function to test for Pending Reboot
 # This is modelled from: https://github.com/mwrock/boxstarter/blob/master/Boxstarter.Bootstrapper/Get-PendingReboot.ps1

--- a/templates/win/common/scripts/common/windows-env.ps1
+++ b/templates/win/common/scripts/common/windows-env.ps1
@@ -98,14 +98,14 @@ function ExitScript([int]$ExitCode){
 
 # Helper to create consistent staging directories.
 function Create-PackerStagingDirectories {
-  if (-not (Test-Path "$PackerStaging")) {
+  if (-not (Test-Path "$PackerStaging\puppet\modules")) {
     Write-Host "Creating $PackerStaging"
     mkdir -Path $PackerStaging\puppet\modules
     mkdir -Path $PackerStaging\Downloads
     mkdir -Path $PackerStaging\Downloads\Cygwin
     mkdir -Path $PackerStaging\Config
     mkdir -Path $PackerStaging\Scripts
-    mkdir -Path $PackerStaging\Logs
+    # mkdir -Path $PackerStaging\Logs
     mkdir -Path $PackerStaging\Sysinternals
   }
 }
@@ -441,6 +441,7 @@ Function Remove-AppsPackages
         "Microsoft.BingNews"
         "Microsoft.BingSports"
         "Microsoft.BingWeather"
+        "Microsoft.BingTranslator"
         #"Microsoft.FreshPaint"
         "Microsoft.Getstarted"
         "Microsoft.MicrosoftOfficeHub"
@@ -514,6 +515,7 @@ Function Remove-AppsPackages
         "SpotifyAB.SpotifyMusic"
         "A278AB0D.DisneyMagicKingdoms"
         "WinZipComputing.WinZipUniversal"
+        "AdobeSystemsIncorporated.AdobePhotoshopExpress"
 
 
         # apps which cannot be removed using Remove-AppxPackage
@@ -621,7 +623,7 @@ function Test-PendingReboot {
 function Invoke-Reboot {
     Write-Output "Starting Reboot sequence"
     Write-Output "writing restart file"
-    $restartScript="Call PowerShell -NoProfile -ExecutionPolicy bypass -command `"& A:\start-pswindowsupdate.ps1`""
+    $restartScript="Call PowerShell -NoProfile -ExecutionPolicy bypass -command `"& A:\start-pswindowsupdate.ps1 >> c:\Packer\Logs\start-pswindowsupdate.log`""
     New-Item "$startup\packer-post-restart.bat" -type file -force -value $restartScript | Out-Null
 
 	  shutdown /t 0 /r /f

--- a/templates/win/common/scripts/config/vmpooler-clone-arm-runonce.reg
+++ b/templates/win/common/scripts/config/vmpooler-clone-arm-runonce.reg
@@ -1,4 +1,4 @@
 Windows Registry Editor Version 5.00
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce]
-"Sysprep Command"="C:\\Windows\\System32\\sysprep\\sysprep /generalize /oobe /reboot /quiet /unattend:C:\\Packer\\Config\\post-clone.autounattend.xml"
+"Sysprep Command"="c:\\WINDOWS\\system32\\WindowsPowerShell\\v1.0\\powershell.exe -noprofile -sta -WindowStyle Hidden -file C:\\Packer\\Scripts\\vmpooler-sysprep.ps1"

--- a/templates/win/common/scripts/config/vmpooler-clone-arm-startup.reg
+++ b/templates/win/common/scripts/config/vmpooler-clone-arm-startup.reg
@@ -3,4 +3,3 @@ Windows Registry Editor Version 5.00
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Run]
 "VMware User Process"="\"C:\\Program Files\\VMware\\VMware Tools\\vmtoolsd.exe\" -n vmusr"
 "Bootstrap Script"="c:\\WINDOWS\\system32\\WindowsPowerShell\\v1.0\\powershell.exe -noprofile -sta -WindowStyle Hidden -file C:\\Packer\\Scripts\\vmpooler-clone-startup.ps1"
-"BGInfo Screen"="c:\\WINDOWS\\system32\\WindowsPowerShell\\v1.0\\powershell.exe -noprofile -sta -WindowStyle Hidden -file C:\\Packer\\Scripts\\Set-Bginfo.ps1"

--- a/templates/win/common/scripts/provisioners/config-winsettings.ps1
+++ b/templates/win/common/scripts/provisioners/config-winsettings.ps1
@@ -17,7 +17,6 @@ Write-Output "Enable permissive firewall rules"
 netsh advfirewall firewall add rule name="All Incoming" dir=in action=allow enable=yes interfacetype=any profile=any localip=any remoteip=any
 netsh advfirewall firewall add rule name="All Outgoing" dir=out action=allow enable=yes interfacetype=any profile=any localip=any remoteip=any
 
-
 If ( ($WindowsVersion -like $WindowsServer2008R2) -and ($psversiontable.psversion.major -eq 5) ) {
 
     # WMF5/Win-2008r2 fails to sysprep without this fix.
@@ -27,6 +26,13 @@ If ( ($WindowsVersion -like $WindowsServer2008R2) -and ($psversiontable.psversio
     reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows\StreamProvider"    /v "LastFullPayloadTime" /t REG_DWORD /d 0 /f
 }
 
+# Run the Application Package Cleaner again if required.
+if (Test-Path "$PackerLogs\AppsPackageRemove.Required") {
+    Write-Output "Running Apps Package Cleaner post windows update"
+    Remove-AppsPackages -AppPackageCheckpoint AppsPackageRemove.Pass2
+
+}
+  
 # Re-Enable AutoAdminLogon
 autologon -AcceptEula Administrator . PackerAdmin
 

--- a/templates/win/common/scripts/vmpooler/vmpooler-clone-startup.ps1
+++ b/templates/win/common/scripts/vmpooler/vmpooler-clone-startup.ps1
@@ -33,12 +33,6 @@ $CygwinMkgroup = "$CygwinDir\bin\mkgroup.exe -l"
 $CygwinPasswdFile = "$CygwinDir\etc\passwd"
 $CygwinGroupFile = "$CygwinDir\etc\group"
 
-#--- FUNCTIONS ---#
-function ExitScript([int]$ExitCode){
-	Stop-Transcript
-	exit $ExitCode
-}
-
 #Snooze for a bit
 sleep -s 10
 
@@ -48,5 +42,3 @@ Write-Output "Updating the Cygwin passwd file!"
 #Update the passwd file.
 Invoke-Expression $CygwinMkpasswd | Out-File $CygwinPasswdFile -Force -Encoding "ASCII"
 Invoke-Expression $CygwinMkgroup | Out-File $CygwinGroupFile -Force -Encoding "ASCII"
-
-ExitScript 0

--- a/templates/win/common/scripts/vmpooler/vmpooler-post-clone-configuration.ps1
+++ b/templates/win/common/scripts/vmpooler/vmpooler-post-clone-configuration.ps1
@@ -114,7 +114,7 @@ Write-Output "Set SSHD to start after next boot"
 Set-Service "sshd" -StartupType Automatic
 
 # Create BGINFO Scheduled Task to update the lifetime every 20 minutes
-schtasks /create /tn UpdateBGInfo /ru "$AdministratorName" /RP "$qa_root_passwd" /F /SC Minute /mo 20 /IT /TR 'cmd /c c:\WINDOWS\system32\WindowsPowerShell\v1.0\powershell.exe -sta -WindowStyle Hidden -ExecutionPolicy Bypass -NonInteractive -NoProfile -File C:\Packer\Scripts\set-bginfo.ps1'
+schtasks /create /tn UpdateBGInfo /ru "$AdministratorName" /RP "$qa_root_passwd" /F /SC Minute /mo 20 /IT /TR 'c:\WINDOWS\system32\WindowsPowerShell\v1.0\powershell.exe -WindowStyle Hidden -NonInteractive -File C:\Packer\Scripts\set-bginfo.ps1'
 
 # Rename this machine to that of the VM name in vSphere
 # Windows 7/2008R2- and earlier doesn't use the Rename-Computer cmdlet

--- a/templates/win/common/scripts/vmpooler/vmpooler-post-clone-configuration.ps1
+++ b/templates/win/common/scripts/vmpooler/vmpooler-post-clone-configuration.ps1
@@ -2,15 +2,6 @@
 #
 $ErrorActionPreference = "Stop"
 
-#--- Log Session ---#
-Start-Transcript -Path "C:\Packer\Logs\post-clone-run-once.log"
-
-#--- FUNCTIONS ---#
-function ExitScript([int]$ExitCode){
-	Stop-Transcript
-	exit $ExitCode
-}
-
 # Used Frequently throughout
 $CygwinDir = "$ENV:CYGWINDIR"
 
@@ -56,7 +47,7 @@ if ($p.ExitCode -ne 0){
 	Write-Warning "Could not find VM name in vSphere!`n"
 	Write-Warning "If this machine is the template VM, no rename necessary!!"
 	Write-Warning "Remember to reset the 'RunOnce' registry key by Loading C:\Packer\Config\vmpooler-arm-host.reg"
-	ExitScript 1
+	Exit 1
 }
 
 Write-Output "vSphere VMname: $NewVMName`n"
@@ -135,4 +126,4 @@ if ($WindowsVersion -like $WindowsServer2008R2 -or $WindowsVersion -like $Window
 else {
 	Rename-Computer -Newname $NewVMName -Restart
 }
-ExitScript 0
+Exit 0

--- a/templates/win/common/scripts/vmpooler/vmpooler-sysprep.ps1
+++ b/templates/win/common/scripts/vmpooler/vmpooler-sysprep.ps1
@@ -1,0 +1,6 @@
+# Script to run sysprep command.
+
+# Stop the tilemode service
+net stop tiledatamodelsvc
+
+& C:\Windows\System32\sysprep\sysprep.exe /generalize /oobe /reboot /quiet /unattend:C:\Packer\Config\post-clone.autounattend.xml


### PR DESCRIPTION
This is an other attempt to address the sysprep issues which this month
are affecting Win-10 Ent 32 bit. These updates are based on the work at
https://github.com/W4RH4WK/Debloat-Windows-10 and try a few different
approaches at disabling store applications:
1. Remove specific list of Store Apps
2. Make the Remove One-Drive code more robust (and put in function)
3. Disable a number of scheduled tasks that appear to be re-enabling
   store apps.

This is an ongoing task that may need a further ticket, i.e. it seems to
need additional work each Patch Tuesday refresh.