### PR TITLE
(PE-23924) Fixes for CentOS/Scientific Linux 6 repo configurations

### DIFF
--- a/templates/centos/6.8/i386/vars.json
+++ b/templates/centos/6.8/i386/vars.json
@@ -2,7 +2,7 @@
     "template_name"                         : "centos-6.8-i386",
     "template_os"                           : "rhel6",
     "beakerhost"                            : "centos6-32",
-    "version"                               : "0.0.1",
+    "version"                               : "0.0.2",
     "iso_url"                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/CentOS-6.8-i386-bin-DVD1.iso",
     "iso_checksum"                          : "720d185fdf063383a4471657076b72fc162d3c3c3bca2e5e5ae13a25b3046519",
     "iso_checksum_type"                     : "sha256",

--- a/templates/centos/6.8/x86_64/vars.json
+++ b/templates/centos/6.8/x86_64/vars.json
@@ -2,7 +2,7 @@
     "template_name"                         : "centos-6.8-x86_64",
     "template_os"                           : "rhel6-64",
     "beakerhost"                            : "centos6-64",
-    "version"                               : "0.0.1",
+    "version"                               : "0.0.2",
     "iso_url"                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/CentOS-6.8-x86_64-bin-DVD1.iso",
     "iso_checksum"                          : "1dda55622614a8b43b448a72f87d6cb7f79de1eff49ee8c5881a7d9db28d4e35",
     "iso_checksum_type"                     : "sha256",

--- a/templates/scientific/6.8/i386/vars.json
+++ b/templates/scientific/6.8/i386/vars.json
@@ -2,7 +2,7 @@
     "template_name"                         : "scientific-6.8-i386",
     "template_os"                           : "rhel6",
     "beakerhost"                            : "scientific6-32",
-    "version"                               : "0.0.1",
+    "version"                               : "0.0.2",
     "iso_url"                               : "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_scientific/6.8/i386/iso/SL-68-i386-2016-06-29-DVD-DL.iso",
     "iso_checksum"                          : "f46ca847a468e79b69fc2f3ab71893803bd45b00b22aaf30019ea576e498c655",
     "iso_checksum_type"                     : "sha256",

--- a/templates/scientific/6.8/x86_64/vars.json
+++ b/templates/scientific/6.8/x86_64/vars.json
@@ -2,7 +2,7 @@
     "template_name"                         : "scientific-6.8-x86_64",
     "template_os"                           : "rhel6-64",
     "beakerhost"                            : "scientific6-64",
-    "version"                               : "0.0.1",
+    "version"                               : "0.0.2",
     "iso_url"                               : "https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_scientific/6.8/x86_64/iso/SL-68-x86_64-2016-06-29-DVD-DL.iso",
     "iso_checksum"                          : "ada95b0e920612a5a9c56e268515a9965663377407a7897167be7a2efdade804",
     "iso_checksum_type"                     : "sha256",


### PR DESCRIPTION
The CentOS and Scientific Linux mirror repos do *not* include updates in
their base 'os' repos as was previously assumed. This configures yum to
use separate repos for each of the required os/updates/extras/etc repos,
which differ depending on the distro. I've deliberately kept the
configuration branches separate and self-contained for readability,
given how confusing this has been.