### PR TITLE
(IMAGES-752) Fix networking restart on Ubuntu 18.04

### DIFF
--- a/manifests/modules/packer/templates/vsphere/ubuntu.rb.erb
+++ b/manifests/modules/packer/templates/vsphere/ubuntu.rb.erb
@@ -34,8 +34,10 @@ end
  
 puts '- Re-obtaining DHCP lease...'
  
-<% if ['15.10', '16.04', '16.10', '18.04'].include? @operatingsystemrelease -%>
+<% if ['15.10', '16.04', '16.10'].include? @operatingsystemrelease -%>
 Kernel.system('/usr/sbin/service networking restart')
+<% elsif ['18.04'].include? @operatingsystemrelease -%>
+Kernel.system('/bin/systemctl restart systemd-networkd')
 <% else -%>
 Kernel.system('/sbin/ifdown eth0 && /sbin/ifup eth0')
 <% end -%>


### PR DESCRIPTION
The `service` command is no longer a valid way to restart networking on
Ubuntu 18.04 - this commit updates the networking restart command in the
vsphere provisioning script template to use the systemd equivalent
instead.