### PR TITLE
(IMAGES-752) Ubuntu 18.04 systemd updates

### DIFF
--- a/manifests/modules/packer/manifests/vsphere.pp
+++ b/manifests/modules/packer/manifests/vsphere.pp
@@ -24,6 +24,15 @@ class packer::vsphere inherits packer::vsphere::params {
         }
       }
     }
+    debian: {
+      if $::operatingsystemrelease in ['18.04'] {
+        # Enable systemd service for vsphere bootstrap instead of relying on rc.local
+        file { "/etc/systemd/system/multi-user.target.wants/${startup_file_source}":
+          ensure => 'link',
+          target => $startup_file,
+        }
+      }
+    }
   }
 
   package { $ruby_package:

--- a/manifests/modules/packer/manifests/vsphere/params.pp
+++ b/manifests/modules/packer/manifests/vsphere/params.pp
@@ -8,10 +8,15 @@ class packer::vsphere::params {
 
   case $::operatingsystem {
     'Ubuntu': {
-      $startup_file          = '/etc/rc.local'
-      $startup_file_source   = 'rc.local'
       $bootstrap_file        = '/etc/vsphere-bootstrap.rb'
       $bootstrap_file_source = 'ubuntu.rb.erb'
+      if $::operatingsystemrelease in ['18.04'] {
+        $startup_file          = '/etc/systemd/system/vsphere.bootstrap.service'
+        $startup_file_source   = 'vsphere.bootstrap.service'
+      } else {
+        $startup_file          = '/etc/rc.local'
+        $startup_file_source   = 'rc.local'
+      }
       if $facts[os][release] in ['12.04', '14.04'] {
         $periodic_file         = '/etc/apt/apt.conf.d/02periodic'
       }

--- a/manifests/modules/packer/templates/vsphere/ubuntu.rb.erb
+++ b/manifests/modules/packer/templates/vsphere/ubuntu.rb.erb
@@ -1,5 +1,5 @@
 #!/usr/bin/ruby
- 
+
 hostname = `vmtoolsd --cmd "info-get guestinfo.hostname"`
 
 hostname = hostname.chomp
@@ -14,19 +14,23 @@ File.open('/etc/hostname', 'w') do |f|
   f.write(hostname)
 end
  
+<% if ['18.04'].include? @operatingsystemrelease -%>
+# systemd-networkd
+Kernel.system("/usr/bin/hostnamectl set-hostname #{hostname}")
+<% else -%>
+# NetworkManager
 Kernel.system('hostname -F /etc/hostname')
- 
 dhc = File.read('/etc/dhcp/dhclient.conf')
- 
 File.open('/etc/dhcp/dhclient.conf', 'w') do |f|
-  <% if ['15.10', '16.04', '16.10', '18.04'].include? @operatingsystemrelease -%>
+  <% if ['15.10', '16.04', '16.10'].include? @operatingsystemrelease -%>
   dhc.gsub!(/^(send host-name.*)/, "send host-name \"#{hostname}\";")
   <% else -%>
   dhc.gsub!(/^(#send host-name.*)/, "send host-name \"#{hostname}\";")
   <% end -%>
   f.write(dhc)
 end
- 
+<% end -%>
+
 File.open('/etc/hosts', 'w') do |f|
   f.puts "127.0.0.1 localhost"
   f.puts "127.0.1.1 #{hostname}"
@@ -35,18 +39,29 @@ end
 puts '- Re-obtaining DHCP lease...'
  
 <% if ['15.10', '16.04', '16.10'].include? @operatingsystemrelease -%>
+# NetworkManager
 Kernel.system('/usr/sbin/service networking restart')
 <% elsif ['18.04'].include? @operatingsystemrelease -%>
+# systemd-networkd's DHCP client uses /etc/machine-id instead of the link layer address (as dhclient does) to generate a client ID
+# /etc/machine-id will be the same on VMs cloned from the same template, so regenerate it:
+File.delete('/etc/machine-id')
+Kernel.system('/bin/systemd-machine-id-setup')
+Kernel.system('/bin/systemctl daemon-reload')
 Kernel.system('/bin/systemctl restart systemd-networkd')
 <% else -%>
 Kernel.system('/sbin/ifdown eth0 && /sbin/ifup eth0')
 <% end -%>
  
 puts '- Cleaning up...'
- 
-#Kernel.system('rm /etc/vsphere-bootstrap.rb')
+
+<% if ['18.04'].include? @operatingsystemrelease -%>
+# With systemd-networkd, disable the oneshot service that runs this script:
+Kernel.system('/bin/systemctl disable --now vsphere.bootstrap.service')
+<% else -%>
+# With NetworkManager, /etc/rc.local is what runs this script; Make it a noop after the first run:
 Kernel.system('echo "exit 0" > /etc/rc.local')
- 
+<% end -%>
+
 puts "\n"
  
 puts 'Done!'

--- a/manifests/modules/packer/templates/vsphere/vsphere.bootstrap.service
+++ b/manifests/modules/packer/templates/vsphere/vsphere.bootstrap.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=puppetlabs-packer vsphere bootstrap script
+
+[Service]
+Type=oneshot
+ExecStart=/etc/vsphere-bootstrap.rb
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/ubuntu/18.04/common/files/preseed.cfg
+++ b/templates/ubuntu/18.04/common/files/preseed.cfg
@@ -21,11 +21,12 @@ d-i passwd/root-password password puppet
 d-i passwd/root-password-again password puppet
 d-i passwd/make-user boolean false
 d-i user-setup/allow-password-weak boolean true
-d-i pkgsel/include string curl gcc make nfs-common ntp openssh-server perl wget
+d-i pkgsel/include string curl gcc make nfs-common openssh-server perl wget
 d-i pkgsel/install-language-support boolean false
 d-i pkgsel/update-policy select none
 d-i pkgsel/upgrade select full-upgrade
-d-i time/zone string US/Pacific
+d-i time/zone string GMT
+d-i clock-setup/utc boolean true
 tasksel tasksel/first multiselect standard, ubuntu-server
 d-i preseed/late_command string \
 sed -i 's/\(GRUB_CMDLINE_LINUX_DEFAULT=\).*/\1\"\"/g' /target/etc/default/grub; \


### PR DESCRIPTION
18.04 commits more heavily to systemd than the previous LTS; Update
several parts of the vsphere bootstrap script for 18.04 to rely on
systemd tools:

- Run the bootstrap script via a oneshot vsphere.bootstrap systemd
  service instead of via rc.local
- systemd-networkd's DHCP client uses /etc/machine-id to create a client
  ID - this value is the same on hosts cloned from the same template, so
  regenerate it during bootstrap
- Use systemd-timesyncd instead of NTP
- Use hostnamectl to set the hostname