### PR TITLE
(maint) Ubuntu 18.04 bootstrap process fixups

### DIFF
--- a/manifests/modules/packer/manifests/vsphere.pp
+++ b/manifests/modules/packer/manifests/vsphere.pp
@@ -49,7 +49,7 @@ class packer::vsphere inherits packer::vsphere::params {
   file { $startup_file:
     owner   => 'root',
     group   => 'root',
-    mode    => '0755',
+    mode    => pick($startup_file_perms, '0755'),
     content => template("packer/vsphere/${startup_file_source}"),
   }
 

--- a/manifests/modules/packer/manifests/vsphere/params.pp
+++ b/manifests/modules/packer/manifests/vsphere/params.pp
@@ -13,6 +13,7 @@ class packer::vsphere::params {
       if $::operatingsystemrelease in ['18.04'] {
         $startup_file          = '/etc/systemd/system/vsphere.bootstrap.service'
         $startup_file_source   = 'vsphere.bootstrap.service'
+        $startup_file_perms    = '0644'
       } else {
         $startup_file          = '/etc/rc.local'
         $startup_file_source   = 'rc.local'

--- a/manifests/modules/packer/templates/vsphere/ubuntu.rb.erb
+++ b/manifests/modules/packer/templates/vsphere/ubuntu.rb.erb
@@ -56,12 +56,12 @@ puts '- Cleaning up...'
 
 <% if ['18.04'].include? @operatingsystemrelease -%>
 # With systemd-networkd, disable the oneshot service that runs this script:
-Kernel.system('/bin/systemctl disable --now vsphere.bootstrap.service')
+Kernel.system('/bin/systemctl disable vsphere.bootstrap.service')
 <% else -%>
 # With NetworkManager, /etc/rc.local is what runs this script; Make it a noop after the first run:
 Kernel.system('echo "exit 0" > /etc/rc.local')
 <% end -%>
 
 puts "\n"
- 
+
 puts 'Done!'


### PR DESCRIPTION
Fixes two annoyances in the Ubuntu 18.04 bootstrap process:

1. Removes the executable bit from the vsphere-bootstrap systemd service file
   on Ubuntu 18.04; This worked fine before, but it wrote a few warnings to the
   syslog  (service files should not be executable).
2. Removes the `--now` option when disabling the vsphere-bootstrap systemd
   service. Since the the bootstrap script disables the service that runs it
   as part of normal execution, when the `--now` option is included in the
   disable command, the service will be disabled before the script exits; This
   puts the system into an ostensiblly "degraded" state, although nothing is
   actually broken. The vsphere bootstrap service is a oneshot service, so
   there's no harm in waiting for a reboot for it to be fully disabled.

I've tested this in the dev pooler and all seems well (the 18.04 image currently available there is from this branch).