### PR TITLE
(IMAGES-801) Add the load balancer repo to redhat-6-x86_64 images

### DIFF
--- a/manifests/modules/packer/manifests/repos.pp
+++ b/manifests/modules/packer/manifests/repos.pp
@@ -46,6 +46,17 @@ class packer::repos {
       gpgcheck => "1",
       gpgkey   => "file:///etc/pki/rpm-gpg/${gpgkey}"
     }
+
+    # We add the lb (load balancer) repo for redhat-6-x86_64 which is
+    # used in puppet modules testing
+    if $::operatingsystemmajrelease == "6" and $::architecture == "x86_64" {
+      yumrepo { "localmirror-lb":
+        descr    => "localmirror-lb",
+        baseurl  => "${base_url}/lb",
+        gpgcheck => "1",
+        gpgkey   => "file:///etc/pki/rpm-gpg/${gpgkey}"
+      }
+    }
   }
 
 }

--- a/manifests/modules/packer/manifests/vsphere/repos.pp
+++ b/manifests/modules/packer/manifests/vsphere/repos.pp
@@ -129,6 +129,17 @@ class packer::vsphere::repos inherits packer::vsphere::params {
           gpgcheck => "1",
           gpgkey   => "file:///etc/pki/rpm-gpg/${gpgkey}"
         }
+
+        # We add the lb (load balancer) repo for redhat-6-x86_64 which is
+        # used in puppet modules testing
+        if $::operatingsystemmajrelease == "6" and $::architecture == "x86_64" {
+          yumrepo { "localmirror-lb":
+            descr    => "localmirror-lb",
+            baseurl  => "${base_url}/lb",
+            gpgcheck => "1",
+            gpgkey   => "file:///etc/pki/rpm-gpg/${gpgkey}"
+          }   
+        }   
       }
 
       if $::operatingsystem == 'CentOS' {

--- a/templates/redhat/6.8/x86_64/vars.json
+++ b/templates/redhat/6.8/x86_64/vars.json
@@ -2,7 +2,7 @@
     "template_name"                         : "redhat-6.8-x86_64",
     "template_os"                           : "rhel6-64",
     "beakerhost"                            : "redhat6-64",
-    "version"                               : "0.0.3",
+    "version"                               : "0.0.4",
     "iso_url"                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/rhel-server-6.8-x86_64-dvd.iso",
     "iso_checksum"                          : "d35fd1af20f6adef9b11b46c2534ae8b6e18de7754889e2b51808b436dff2804",
     "iso_checksum_type"                     : "sha256",


### PR DESCRIPTION
Puppet modules testing CI requires the haproxy package, which is offered
via the lb (load balancer) repo. This is only required for the
redhat-6-x86_64 platform.