### PR TITLE
Documentation improvements re: support status

### DIFF
--- a/templates/centos/README.md
+++ b/templates/centos/README.md
@@ -2,8 +2,13 @@
 
 ### About
 
-This contains all of the var files required to build any of the templates in the
-`templates/common` directory for Centos platforms.
+This contains all of the var files required to build any of the templates in the `templates/common` directory for Centos platforms.
+
+### Support Status
+
+This repository includes OS platforms that are officially supported at Puppet and ones that are entirely maintained by the community. Packer templates include a `support_status` variable which indicates whether the template is puppet maintained vs. community maintained.
+
+Puppet maintained CentOS versions include 5.11, 6.8, and 7.2. Any other versions of CentOS here are community maintained.
 
 ### Building
 

--- a/templates/common/docker.nocm.json
+++ b/templates/common/docker.nocm.json
@@ -8,6 +8,7 @@
 
       "vagrant_required_modules"             : null,
 
+      "support_status"                       : "community_maintained",
       "project_root"                         : "../../../..",
       "headless"                             : "true",
       "template_config"                      : "nocm",

--- a/templates/common/docker.puppet.json
+++ b/templates/common/docker.puppet.json
@@ -8,6 +8,7 @@
 
       "vagrant_required_modules"             : null,
 
+      "support_status"                       : "community_maintained",
       "project_root"                         : "../../../..",
       "headless"                             : "true",
       "template_config"                      : "puppet",

--- a/templates/common/libvirt.base.json
+++ b/templates/common/libvirt.base.json
@@ -11,6 +11,7 @@
       "floppy_files"                         : null,
       "http_directory"                       : null,
       "boot_command"                         : null,
+      "support_status"                       : "community_maintained",
       "project_root"                         : "../../../..",
       "headless"                             : "true",
       "template_config"                      : "base",

--- a/templates/common/libvirt.nocm.json
+++ b/templates/common/libvirt.nocm.json
@@ -10,6 +10,7 @@
       "libvirt_nocm_qemuargs_mem_size"       : "512",
       "libvirt_nocm_qemuargs_cpu_count"      : "1",
 
+      "support_status"                       : "community_maintained",
       "project_root"                         : "../../../..",
       "headless"                             : "true",
       "template_config"                      : "nocm",

--- a/templates/common/libvirt.puppet.json
+++ b/templates/common/libvirt.puppet.json
@@ -10,6 +10,7 @@
       "libvirt_nocm_qemuargs_mem_size"       : "512",
       "libvirt_nocm_qemuargs_cpu_count"      : "1",
 
+      "support_status"                       : "community_maintained",
       "project_root"                         : "../../../..",
       "headless"                             : "true",
       "template_config"                      : "puppet",

--- a/templates/common/virtualbox.base.json
+++ b/templates/common/virtualbox.base.json
@@ -10,6 +10,7 @@
       "floppy_files"                         : null,
       "http_directory"                       : null,
       "boot_command"                         : null,
+      "support_status"                       : "community_maintained",
       "project_root"                         : "../../../..",
       "headless"                             : "true",
       "template_config"                      : "base",

--- a/templates/common/virtualbox.nocm.json
+++ b/templates/common/virtualbox.nocm.json
@@ -10,6 +10,7 @@
       "libvirt_nocm_qemuargs_mem_size"       : "512",
       "libvirt_nocm_qemuargs_cpu_count"      : "1",
 
+      "support_status"                       : "community_maintained",
       "project_root"                         : "../../../..",
       "headless"                             : "true",
       "template_config"                      : "nocm",

--- a/templates/common/virtualbox.puppet.json
+++ b/templates/common/virtualbox.puppet.json
@@ -10,6 +10,7 @@
       "libvirt_nocm_qemuargs_mem_size"         : "512",
       "libvirt_nocm_qemuargs_cpu_count"        : "1",
 
+      "support_status"                         : "community_maintained",
       "project_root"                           : "../../../..",
       "headless"                               : "true",
       "template_config"                        : "puppet",

--- a/templates/common/vmware.base.json
+++ b/templates/common/vmware.base.json
@@ -11,6 +11,7 @@
     "floppy_files"                                 : null,
     "boot_command"                                 : null,
 
+    "support_status"                               : "puppet_maintained",
     "project_root"                                 : "../../../..",
     "headless"                                     : "true",
     "template_config"                              : "base",

--- a/templates/common/vmware.vsphere.nocm.json
+++ b/templates/common/vmware.vsphere.nocm.json
@@ -11,6 +11,7 @@
     "vmware_vsphere_nocm_vmx_data_ethernet0_virtualDev"    : "vmxnet3",
     "vmware_vsphere_nocm_vmx_data_ethernet0_pciSlotNumber" : "33",
 
+    "support_status"                        : "puppet_maintained",
     "project_root"                          : "../../../..",
     "headless"                              : "true",
     "template_config"                       : "vsphere-nocm",

--- a/templates/debian/README.md
+++ b/templates/debian/README.md
@@ -2,10 +2,13 @@
 
 ### About
 
-This contains the vmware.base image template for Debian platforms, as well as all of the var files
-required to build any of the other templates in the `templates/common` directory.
+This contains the vmware.base image template for Debian platforms, as well as all of the var files required to build any of the other templates in the `templates/common` directory.
 
-Currently, only Debian 7.8, 8.2 and 9.0 are supported for both the 64-bit and 32-bit architectures.
+### Support Status
+
+This repository includes OS platforms that are officially supported at Puppet and ones that are entirely maintained by the community. Packer templates include a `support_status` variable which indicates whether the template is puppet maintained vs. community maintained.
+
+Puppet maintained Debian versions include 7.8, 8.2, and 9.0. Any other versions of Debian here are community maintained.
 
 ### Building
 

--- a/templates/debian/common/vmware.base.json
+++ b/templates/debian/common/vmware.base.json
@@ -7,6 +7,7 @@
     "iso_checksum_type"                            : null,
     "puppet_aio"                                   : null,
 
+    "support_status"                               : "puppet_maintained",
     "project_root"                                 : "../../../..",
     "headless"                                     : "true",
     "template_config"                              : "base",

--- a/templates/fedora/README.md
+++ b/templates/fedora/README.md
@@ -2,8 +2,13 @@
 
 ### About
 
-This contains all of the var files required to build any of the other templates in the
-`templates/common` directory.
+This contains all of the var files required to build any of the other templates in the `templates/common` directory.
+
+### Support Status
+
+This repository includes OS platforms that are officially supported at Puppet and ones that are entirely maintained by the community. Packer templates include a `support_status` variable which indicates whether the template is puppet maintained vs. community maintained.
+
+Puppet maintained Fedora versions include 26, 27, and 28. Any other versions of Fedora here are community maintained.
 
 ### Building
 

--- a/templates/macos/10.12/x86_64/vmware.base.json
+++ b/templates/macos/10.12/x86_64/vmware.base.json
@@ -15,7 +15,8 @@
     "template_name"                                : null,
     "update_system"                                : null,
     "output_directory"                             : "{{env `PACKER_VM_OUT_DIR`}}",
-    "ssh_password"                                 : "{{env `QA_ROOT_PASSWORD`}}"
+    "ssh_password"                                 : "{{env `QA_ROOT_PASSWORD`}}",
+    "support_status"                               : "puppet_maintained"
   },
 
   "builders"                                       : [

--- a/templates/macos/10.13/x86_64/vmware.base.json
+++ b/templates/macos/10.13/x86_64/vmware.base.json
@@ -15,7 +15,8 @@
     "output_directory"                             : "{{env `PACKER_VM_OUT_DIR`}}",
     "source_directory"                             : "{{env `PACKER_VM_SRC_DIR`}}",
     "ssh_password"                                 : "{{env `QA_ROOT_PASSWORD`}}",
-    "base_template_name"                           : "macos-1012-x86_64-vmware-base"
+    "base_template_name"                           : "macos-1012-x86_64-vmware-base",
+    "support_status"                               : "puppet_maintained"
   },
 
   "builders"                                       : [

--- a/templates/macos/README.md
+++ b/templates/macos/README.md
@@ -1,5 +1,9 @@
 # puppetlabs-packer: macOS templates
 
+### Support Status
+
+This repository includes OS platforms that are officially supported at Puppet and ones that are entirely maintained by the community. Packer templates include a `support_status` variable which indicates whether the template is puppet maintained vs. community maintained.
+
 ### Prerequisites
 
 Imaging for macOS has become particularly difficult after the release of 10.12.4. At this point, to build one of these templates, **you must have:**

--- a/templates/macos/common/vmware.vsphere.nocm.json
+++ b/templates/macos/common/vmware.vsphere.nocm.json
@@ -22,7 +22,8 @@
     "packer_vcenter_folder"                 : "{{env `PACKER_VCENTER_FOLDER`}}",
     "packer_vcenter_net"                    : "{{env `PACKER_VCENTER_NET`}}",
     "packer_vcenter_insecure"               : "{{env `PACKER_VCENTER_INSECURE`}}",
-    "packer_sha"                            : "{{env `PACKER_SHA`}}"
+    "packer_sha"                            : "{{env `PACKER_SHA`}}",
+    "support_status"                        : "puppet_maintained"
   },
 
   "builders": [

--- a/templates/redhat/README.md
+++ b/templates/redhat/README.md
@@ -4,6 +4,12 @@
 
 This contains the vmware.base and vmware.vsphere image templates for Redhat FIPS-enabled platforms. FIPS is the Federal Information Processing Standard, which sets certain standards for the use of cryptographic modules in software.
 
+### Support Status
+
+This repository includes OS platforms that are officially supported at Puppet and ones that are entirely maintained by the community. Packer templates include a `support_status` variable which indicates whether the template is puppet maintained vs. community maintained.
+
+Puppet maintained Redhat versions include 6.8, 7.2, and 7.2 (fips-enabled).
+
 ### Building
 
 All templates must be built in the `<os_dist>/<variant>/<arch>` directory. Make sure that the environment variable PACKER\_VM\_OUT\_DIR is set so that Packer knows where to copy the build artifacts (it is common to set it to ".", the current `<os_dist>/<variant>/<arch>` directory). If you are building a template with a vmware-vmx builder, be sure to set the PACKER\_VM\_SRC\_DIR environment variable to the directory containing the directory containing the relevant vm files. It is common to set PACKER\_VM\_SRC\_DIR = PACKER\_VM\_OUT\_DIR to make it easy to build a vmware-vmx template from a previous vmware build.

--- a/templates/scientific/README.md
+++ b/templates/scientific/README.md
@@ -2,8 +2,13 @@
 
 ### About
 
-This contains all of the var files required to build any of the templates in the
-`templates/common` directory for Scientific Linux platforms.
+This contains all of the var files required to build any of the templates in the `templates/common` directory for Scientific Linux platforms.
+
+### Support Status
+
+This repository includes OS platforms that are officially supported at Puppet and ones that are entirely maintained by the community. Packer templates include a `support_status` variable which indicates whether the template is puppet maintained vs. community maintained.
+
+Puppet maintained Scientific Linux versions include 5.10, 6.8, and 7.2. Any other versions of Scientific Linux here are community maintained.
 
 ### Building
 

--- a/templates/sles/README.md
+++ b/templates/sles/README.md
@@ -2,8 +2,13 @@
 
 ### About
 
-This contains all of the var files required to build any of the other templates in the
-`templates/common` directory.
+This contains all of the var files required to build any of the other templates in the `templates/common` directory.
+
+### Support Status
+
+This repository includes OS platforms that are officially supported at Puppet and ones that are entirely maintained by the community. Packer templates include a `support_status` variable which indicates whether the template is puppet maintained vs. community maintained.
+
+Puppet maintained SLES versions include 12.1.
 
 ### Building
 

--- a/templates/solaris/11.2/common/vmware.base.json
+++ b/templates/solaris/11.2/common/vmware.base.json
@@ -8,6 +8,7 @@
 
     "boot_command"                                 : "e<wait>e<wait><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><wait>- nowin install -B install_media=cdrom<enter><wait>b<wait>",
 
+    "support_status"                               : "puppet_maintained",
     "headless"                                     : "true",
     "template_config"                              : "base",
     "provisioner"                                  : "vmware",

--- a/templates/solaris/README.md
+++ b/templates/solaris/README.md
@@ -4,6 +4,12 @@
 
 This contains the vmware.base image templates for Solaris 10u11 and 11.2 found in their respective common directores (e.g. 10u11/common). vmware.vsphere image templates will be added here soon.
 
+### Support Status
+
+This repository includes OS platforms that are officially supported at Puppet and ones that are entirely maintained by the community. Packer templates include a `support_status` variable which indicates whether the template is puppet maintained vs. community maintained.
+
+Puppet maintained Solaris versions include 10u11 and 11.2.
+
 ### Building
 
 All templates must be built in the `<os_dist>/<variant>/<arch>` directory. Make sure that the environment variable PACKER\_VM\_OUT\_DIR is set so that Packer knows where to copy the build artifacts (it is common to set it to ".", the current `<os_dist>/<variant>/<arch>` directory). If you are building a template with a vmware-vmx builder, be sure to set the PACKER\_VM\_SRC\_DIR environment variable to the directory containing the directory containing the relevant vm files. It is common to set PACKER\_VM\_SRC\_DIR = PACKER\_VM\_OUT\_DIR to make it easy to build a vmware-vmx template from a previous vmware build.

--- a/templates/ubuntu/README.md
+++ b/templates/ubuntu/README.md
@@ -2,8 +2,13 @@
 
 ### About
 
-This contains all of the var files required to build any of the templates in the
-`templates/common` directory for Ubuntu platforms.
+This contains all of the var files required to build any of the templates in the `templates/common` directory for Ubuntu platforms.
+
+### Support Status
+
+This repository includes OS platforms that are officially supported at Puppet and ones that are entirely maintained by the community. Packer templates include a `support_status` variable which indicates whether the template is puppet maintained vs. community maintained.
+
+Puppet maintained Ubuntu versions include 14.04, 16.04, and 18.04. Any other versions of Ubuntu here are community maintained.
 
 ### Building
 

--- a/templates/vro/README.md
+++ b/templates/vro/README.md
@@ -2,10 +2,13 @@
 
 ### About
 
-This contains the vmware.vsphere.nocm image template for VRO VMs, as well as all of the var files
-required to build it.
+This contains the vmware.vsphere.nocm image template for VRO VMs, as well as all of the var files required to build it.
 
-Currently, only VRO 7.3 is supported for the 64-bit architecture.
+### Support Status
+
+This repository includes OS platforms that are officially supported at Puppet and ones that are entirely maintained by the community. Packer templates include a `support_status` variable which indicates whether the template is puppet maintained vs. community maintained.
+
+Puppet maintained VRO versions include 7.1, 7.3, 7.4.
 
 ### Building
 

--- a/templates/vro/common/vmware.vsphere.nocm.json
+++ b/templates/vro/common/vmware.vsphere.nocm.json
@@ -4,6 +4,7 @@
     "beakerhost"                : null,
     "version"                   : null,
 
+    "support_status"            : "puppet_maintained",
     "project_root"              : "../../../..",
     "headless"                  : "true",
     "template_config"           : "vsphere-nocm",


### PR DESCRIPTION
Adds a support_status variable to all templates to indicate whether the template is maintained by Puppet vs. community maintained. It also adds a Support Status section in the various OS README.md files to clarify which OS versions are Puppet maintained vs. community maintained. 