### PR TITLE
(MAINT) Disable ScreenSaverEngine on macOS 10.13 (High Sierra)

### DIFF
--- a/templates/macos/10.13/x86_64/vars.json
+++ b/templates/macos/10.13/x86_64/vars.json
@@ -6,5 +6,5 @@
   "beakerhost"              : "osx1013-64",
   "template_name"           : "macos-1013-x86_64",
   "guest_os_type"           : "darwin13-64",
-  "version"                 : "0.1.0"
+  "version"                 : "0.1.1"
 }

--- a/templates/macos/common/files/base/shrink.sh
+++ b/templates/macos/common/files/base/shrink.sh
@@ -8,6 +8,13 @@ OSX_VERS=$(sw_vers -productVersion | awk -F "." '{print $2}')
 pmset hibernatemode 0
 rm -f /var/vm/sleepimage
 
+# Turn off login window screensaver on High Sierra (it seems to use an
+# inordinate amount of CPU
+if [ "$OSX_VERS" -eq 13 ]; then
+  defaults write /Library/Preferences/com.apple.screensaver loginWindowIdleTime 0
+  osascript -e 'tell application "ScreenSaverEngine" to quit'
+fi
+
 # Stop the pager process and drop swap files. These will be re-created on boot.
 # Starting with El Cap we can only stop the dynamic pager if SIP is disabled.
 if [ "$OSX_VERS" -lt 11 ] || $(csrutil status | grep -q disabled); then


### PR DESCRIPTION
I noticed on the vmpooler VMs that ScreenSaverEngine seems to be using
an inordinate amount of CPU time (30-50%) so this change should disable
the login window screen saver entirely since there is no need for a
headless VM to have it running.

I have no idea if this is the best place to add this or not. I tried to build locally (first a 10.12 image since 10.13 is based on that) but I seemed to be missing some settings. :/