### PR TITLE
(IMAGES-31) No TaskbarLinks for Win-2008

### DIFF
--- a/templates/win/common/files/Autounattend.xslt
+++ b/templates/win/common/files/Autounattend.xslt
@@ -156,7 +156,8 @@
   <!-- Select correct OOBE elements depending on OS Version -->
   <xsl:template match='u:unattend/u:settings/u:component[@name="Microsoft-Windows-Shell-Setup"]/u:OOBE/u:HideOnlineAccountScreens | 
                        u:unattend/u:settings/u:component[@name="Microsoft-Windows-Shell-Setup"]/u:OOBE/u:HideLocalAccountScreen | 
-                       u:unattend/u:settings/u:component[@name="Microsoft-Windows-Shell-Setup"]/u:OOBE/u:HideOEMRegistrationScreen'>
+                       u:unattend/u:settings/u:component[@name="Microsoft-Windows-Shell-Setup"]/u:OOBE/u:HideOEMRegistrationScreen |
+                       u:unattend/u:settings/u:component[@name="Microsoft-Windows-Shell-Setup"]/u:TaskbarLinks'>
     <xsl:choose>
       <xsl:when test="$WindowsVersion = 'Windows-2008'" />
       <xsl:when test="$WindowsVersion = 'Windows-2008r2'" />


### PR DESCRIPTION
Having TaskbarLinks in the post-clone autounattend for win-2008 stops
the sysprep booting correctly, so filter this out.

As noted earlier, further work needs to be done on this ticket, so just
making this change to allow the May 2018 Patch Tuesday builds to
complete.