### PR TITLE
(IMAGES-822) Fix Network Adapter error for Win-2008R2 WMF

### DIFF
--- a/templates/win/common/scripts/vmpooler/vmpooler-clone-startup.ps1
+++ b/templates/win/common/scripts/vmpooler/vmpooler-clone-startup.ps1
@@ -14,9 +14,9 @@
 #--- Help ---#
 <#
 .SYNOPSIS
-	Update the passwd shadow file and start the SSH server.
+    Update the passwd shadow file and start the SSH server.
 .DESCRIPTION
-	Update the passwd shadow file and start the SSH server.
+    Update the passwd shadow file and start the SSH server.
 .PARAMETER
 .INPUTS
 .OUTPUTS

--- a/templates/win/common/scripts/vmpooler/vmpooler-post-clone-configuration.ps1
+++ b/templates/win/common/scripts/vmpooler/vmpooler-post-clone-configuration.ps1
@@ -101,12 +101,16 @@ try {
   Write-Warning "Disable Power Management failed"
 }
 
-if (($PSVersionTable.PSVersion.Major) -ge 4 ) {
+# Although Get-NetAdapter is availble in PS3/5 it is NOT available on Windows-7/2008R2
+if ((($PSVersionTable.PSVersion.Major) -ge 4) -and ($WindowsVersion -notlike $WindowsServer2008R2) ) {
   # Disable IPV6 on all network adapters (mainly to stop discovery pings causing firefall errors)
   # The cmdlets are only available on PSVersion 4.0 or later, so only really doing this for win-2012+
   Write-Output "Disabling IPV6 on network adapters"
   Get-NetAdapter | ForEach-Object { Disable-NetAdapterBinding -InterfaceAlias $_.Name -ComponentID ms_tcpip6 }
   Get-NetAdapter | ForEach-Object  { Get-NetAdapterBinding -InterfaceAlias $_.Name -ComponentID ms_tcpip6 }
+}
+else {
+  Write-Output "Skipping IPV6 Disablement"
 }
 
 # Set Service startups following the reboot/rename operation.


### PR DESCRIPTION
Need to add a special case for Win-2008R2 WMF5 as although the Get-NetAdapter cmdlet may be present, it is not supported, so filter it out.