### PR TITLE
(IMAGES-824) Bump the template version number in vars.json in centos 7.2

### DIFF
--- a/templates/centos/7.2/x86_64/vars.json
+++ b/templates/centos/7.2/x86_64/vars.json
@@ -2,7 +2,7 @@
     "template_name"                         : "centos-7.2-x86_64",
     "template_os"                           : "rhel7-64",
     "beakerhost"                            : "centos7-64",
-    "version"                               : "0.0.4",
+    "version"                               : "0.0.5",
     "iso_url"                               : "http://osmirror.delivery.puppetlabs.net/iso/CentOS-7-x86_64-DVD-1511.iso",
     "iso_checksum"                          : "907e5755f824c5848b9c8efbb484f3cd945e93faa024bad6ba875226f9683b16",
     "iso_checksum_type"                     : "sha256",


### PR DESCRIPTION
(IMAGES-824) Bump the template version number in vars.json in centos 7.2 to read from the new template that adds the extras repository, allowing installation from Docker CE.