### PR TITLE
(IMAGES-834) Use env. var. to specify raw VMX file for VRO images

### DIFF
--- a/templates/vro/common/vmware.vsphere.nocm.json
+++ b/templates/vro/common/vmware.vsphere.nocm.json
@@ -14,6 +14,8 @@
     "boot_wait"                 : "90s",
     "boot_command"              : "{{env `QA_ROOT_PASSWD_PLAIN`}}<enter><wait5>{{env `QA_ROOT_PASSWD_PLAIN`}}<enter><wait10><wait10><wait10><wait10><wait10><wait10><wait10><enter><wait5>root<enter><wait5>{{env `QA_ROOT_PASSWD_PLAIN`}}<enter><wait5>sed -i 's/PermitRootLogin .*/PermitRootLogin yes/' /etc/ssh/sshd_config<enter><wait5>/sbin/chkconfig sshd on<enter><wait5>/etc/init.d/sshd start<enter><wait5>",
 
+    "raw_vmx_file"              : "{{env `VRO_RAW_VMX_PATH` }}",
+
     "qa_root_passwd_plain"      : "{{env `QA_ROOT_PASSWD_PLAIN`}}",
     "packer_vcenter_host"       : "{{env `PACKER_VCENTER_HOST`}}",
     "packer_vcenter_username"   : "{{env `PACKER_VCENTER_USERNAME`}}",
@@ -43,7 +45,7 @@
       "name"                    : "{{user `template_name`}}-{{user `provisioner`}}-{{user `template_config`}}",
       "vm_name"                 : "packer-{{build_name}}",
       "type"                    : "vmware-vmx",
-      "source_path"             : "{{user `packer_source_dir`}}/output-{{user `template_name`}}-{{user `provisioner`}}-base/packer-{{user `template_name`}}-{{user `provisioner`}}-base.vmx",
+      "source_path"             : "{{user `raw_vmx_file`}}",
       "output_directory"        : "{{user `packer_output_dir`}}/output-{{build_name}}",
 
       "headless"                : "{{user `headless`}}",


### PR DESCRIPTION
The original template specified the source path for the VRO vmx file
using the same convention for vmware.base images. This was not the right
way to think about building VRO images, because we do not build a base
image. Instead, we download the raw OVA and convert it to its raw VMX
format, slightly modifying its networking config. to use shared instead
of bridged networking.

This commit modifies the vmware.vsphere.nocm template to take in the
path to the raw VMX file via. an environment variable instead, which
also simplifies the CI code for our VRO images.