### PR TITLE
(maint) Bump CentOS 7.2 RAM to 6 GB

### DIFF
--- a/templates/centos/7.2/x86_64/vars.json
+++ b/templates/centos/7.2/x86_64/vars.json
@@ -2,12 +2,12 @@
     "template_name"                         : "centos-7.2-x86_64",
     "template_os"                           : "rhel7-64",
     "beakerhost"                            : "centos7-64",
-    "version"                               : "0.0.5",
+    "version"                               : "0.0.6",
     "iso_url"                               : "http://osmirror.delivery.puppetlabs.net/iso/CentOS-7-x86_64-DVD-1511.iso",
     "iso_checksum"                          : "907e5755f824c5848b9c8efbb484f3cd945e93faa024bad6ba875226f9683b16",
     "iso_checksum_type"                     : "sha256",
-    "vmware_vsphere_nocm_vmx_data_memsize"  : "4096",
+    "vmware_vsphere_nocm_vmx_data_memsize"  : "6144",
     "vmware_vsphere_nocm_vmx_data_numvcpus" : "2",
-    "puppet_aio"                            : "http://yum.puppetlabs.com/el/7/PC1/x86_64/puppet-agent-1.8.3-1.el7.x86_64.rpm",
+    "puppet_aio"                            : "http://yum.puppetlabs.com/el/7/PC1/x86_64/puppet-agent-1.10.12-1.el7.x86_64.rpm",
     "required_modules"                      : "puppetlabs-stdlib saz-ssh puppetlabs-firewall"
 }


### PR DESCRIPTION
Since this is a platform we use for testing PE masters, bring this
template in line with our other master test platforms by setting the
amount of RAM to 6 GB.