### PR TITLE
(IMAGES-31) Pin Powershell and other apps to the taskbar

### DIFF
--- a/templates/win/common/files/Autounattend.xslt
+++ b/templates/win/common/files/Autounattend.xslt
@@ -156,8 +156,7 @@
   <!-- Select correct OOBE elements depending on OS Version -->
   <xsl:template match='u:unattend/u:settings/u:component[@name="Microsoft-Windows-Shell-Setup"]/u:OOBE/u:HideOnlineAccountScreens | 
                        u:unattend/u:settings/u:component[@name="Microsoft-Windows-Shell-Setup"]/u:OOBE/u:HideLocalAccountScreen | 
-                       u:unattend/u:settings/u:component[@name="Microsoft-Windows-Shell-Setup"]/u:OOBE/u:HideOEMRegistrationScreen |
-                       u:unattend/u:settings/u:component[@name="Microsoft-Windows-Shell-Setup"]/u:TaskbarLinks'>
+                       u:unattend/u:settings/u:component[@name="Microsoft-Windows-Shell-Setup"]/u:OOBE/u:HideOEMRegistrationScreen'>
     <xsl:choose>
       <xsl:when test="$WindowsVersion = 'Windows-2008'" />
       <xsl:when test="$WindowsVersion = 'Windows-2008r2'" />

--- a/templates/win/common/files/PostCloneTemplate.xml
+++ b/templates/win/common/files/PostCloneTemplate.xml
@@ -150,12 +150,6 @@
                 <LogonCount>99999</LogonCount>
                 <Username>Administrator</Username>
             </AutoLogon>
-            <TaskbarLinks>
-                <Link0>%SYSTEMROOT%\Explorer.exe</Link0>
-                <Link1>%SYSTEMROOT%\System32\WindowsPowershell\v1.0\Powershell.exe</Link1>
-                <Link2>%ALLUSERSPROFILE%\Microsoft\Windows\Start Menu\Programs\Google Chrome.lnk</Link2>
-                <Link3>%ALLUSERSPROFILE%\Microsoft\Windows\Start Menu\Programs\Notepad++\Notepad++.lnk</Link3>
-            </TaskbarLinks>
         </component>
     </settings>
 </unattend>

--- a/templates/win/common/puppet/windows_template/manifests/policies/local_group_policies.pp
+++ b/templates/win/common/puppet/windows_template/manifests/policies/local_group_policies.pp
@@ -378,5 +378,20 @@ class windows_template::policies::local_group_policies ()
             type   => 'REG_DWORD',
             notify => Windows_group_policy::Gpupdate['GPUpdate'],
         }
+        # 21. Configure the Start Layour
+        windows_group_policy::local::user { 'StartLayoutConfigLock':
+            key    => 'Software\Policies\Microsoft\Windows\Explorer',
+            value  => 'LockedStartLayout',
+            data   => 1,
+            type   => 'REG_DWORD',
+            notify => Windows_group_policy::Gpupdate['GPUpdate'],
+        }
+        windows_group_policy::local::user { 'StartLayoutConfig':
+            key    => 'Software\Policies\Microsoft\Windows\Explorer',
+            value  => 'StartLayoutFile',
+            data   => 'C:\\Packer\\Config\\StartMenuLayout.xml',
+            type   => 'REG_SZ',
+            notify => Windows_group_policy::Gpupdate['GPUpdate'],
+        }
     }
 }

--- a/templates/win/common/scripts/common/Pin-AppsToTaskBar.ps1
+++ b/templates/win/common/scripts/common/Pin-AppsToTaskBar.ps1
@@ -1,0 +1,69 @@
+
+# This code has been adopted from https://gallery.technet.microsoft.com/scriptcenter/b66434f1-4b3f-4a94-8dc3-e406eb30b750
+# and modified to be a single script to pin selected items to the taskbar.
+
+
+function Set-PinnedApplication 
+{ 
+  param( 
+    [Parameter(Mandatory=$true)][string]$Action,  
+    [Parameter(Mandatory=$true)][string]$FilePath 
+  )
+
+
+  $verbs = @{  
+    "PintoStartMenu"=5381
+    "UnpinfromStartMenu"=5382 
+    "PintoTaskbar"=5386 
+    "UnpinfromTaskbar"=5387
+    }
+    function InvokeVerb { 
+        param([string]$FilePath,$verb) 
+        $verb = $verb.Replace("&","") 
+        $path= split-path $FilePath 
+        $shell=new-object -com "Shell.Application"  
+        $folder=$shell.Namespace($path)    
+        $item = $folder.Parsename((split-path $FilePath -leaf)) 
+        $itemVerb = $item.Verbs() | ? {$_.Name.Replace("&","") -eq $verb} 
+        if($itemVerb -eq $null){ 
+            throw "Verb $verb not found."
+        } else { 
+            $itemVerb.DoIt() 
+        } 
+    } 
+    function GetVerb { 
+        param([int]$verbId) 
+        try { 
+            $t = [type]"CosmosKey.Util.MuiHelper" 
+        } catch { 
+            $def = [Text.StringBuilder]"" 
+            [void]$def.AppendLine('[DllImport("user32.dll")]') 
+            [void]$def.AppendLine('public static extern int LoadString(IntPtr h,uint id, System.Text.StringBuilder sb,int maxBuffer);') 
+            [void]$def.AppendLine('[DllImport("kernel32.dll")]') 
+            [void]$def.AppendLine('public static extern IntPtr LoadLibrary(string s);') 
+            add-type -MemberDefinition $def.ToString() -name MuiHelper -namespace CosmosKey.Util             
+        } 
+        if($global:CosmosKey_Utils_MuiHelper_Shell32 -eq $null){         
+            $global:CosmosKey_Utils_MuiHelper_Shell32 = [CosmosKey.Util.MuiHelper]::LoadLibrary("shell32.dll") 
+        } 
+        $maxVerbLength=255 
+        $verbBuilder = new-object Text.StringBuilder "",$maxVerbLength 
+        [void][CosmosKey.Util.MuiHelper]::LoadString($CosmosKey_Utils_MuiHelper_Shell32,$verbId,$verbBuilder,$maxVerbLength) 
+        return $verbBuilder.ToString() 
+    } 
+
+
+  if(-not (test-path $FilePath)) {  
+     throw "FilePath does not exist."   
+  } 
+
+  if($verbs.$Action -eq $null){ 
+     Throw "Action $action not supported`nSupported actions are:`n`tPintoStartMenu`n`tUnpinfromStartMenu`n`tPintoTaskbar`n`tUnpinfromTaskbar" 
+  }
+
+  InvokeVerb -FilePath $FilePath -Verb $(GetVerb -VerbId $verbs.$action) 
+} 
+
+# Unable to get File Explorer or Documents pinned, so start with these apps initially.
+Set-PinnedApplication -Action PintoTaskbar -FilePath "$ENV:ProgramFiles\Notepad++\Notepad++.exe"
+Set-PinnedApplication -Action PintoTaskbar -FilePath "$ENV:Windir\system32\WindowsPowerShell\v1.0\powershell.exe"

--- a/templates/win/common/scripts/config/StartMenuLayout.xml
+++ b/templates/win/common/scripts/config/StartMenuLayout.xml
@@ -1,0 +1,29 @@
+<LayoutModificationTemplate xmlns:defaultlayout="http://schemas.microsoft.com/Start/2014/FullDefaultLayout" xmlns:start="http://schemas.microsoft.com/Start/2014/StartLayout" Version="1" xmlns="http://schemas.microsoft.com/Start/2014/LayoutModification" xmlns:taskbar="http://schemas.microsoft.com/Start/2014/TaskbarLayout">
+  <LayoutOptions StartTileGroupCellWidth="6" />
+  <DefaultLayoutOverride LayoutCustomizationRestrictionType="OnlySpecifiedGroups">
+    <StartLayoutCollection>
+      <defaultlayout:StartLayout GroupCellWidth="6">
+         <start:Group Name="Explore">
+          <start:Tile Size="2x2" Column="4" Row="0" AppUserModelID="Microsoft.MicrosoftEdge_8wekyb3d8bbwe!MicrosoftEdge" />
+        </start:Group>
+        <start:Group Name="Apps">
+          <start:DesktopApplicationTile Size="2x2" Column="4" Row="1" DesktopApplicationLinkPath="%APPDATA%\Microsoft\Windows\Start Menu\Programs\System Tools\File Explorer.lnk" />
+          <start:DesktopApplicationTile Size="2x2" Column="3" Row="1" DesktopApplicationLinkPath="%APPDATA%\Microsoft\Windows\Start Menu\Programs\Windows PowerShell\Windows PowerShell.lnk" />
+          <start:DesktopApplicationTile Size="2x2" Column="1" Row="1" DesktopApplicationLinkPath="%ALLUSERSPROFILE%\Microsoft\Windows\Start Menu\Programs\Google Chrome.lnk" />
+          <start:DesktopApplicationTile Size="2x2" Column="2" Row="1" DesktopApplicationLinkPath="%ALLUSERSPROFILE%\Microsoft\Windows\Start Menu\Programs\Notepad++\Notepad++.lnk" />
+        </start:Group>
+      </defaultlayout:StartLayout>
+    </StartLayoutCollection>
+  </DefaultLayoutOverride>
+  <CustomTaskbarLayoutCollection PinListPlacement="Replace">
+   <defaultlayout:TaskbarLayout>
+    <taskbar:TaskbarPinList>
+     <taskbar:DesktopApp DesktopApplicationLinkPath="%APPDATA%\Microsoft\Windows\Start Menu\Programs\System Tools\File Explorer.lnk" />
+	 <taskbar:DesktopApp DesktopApplicationLinkPath="%ALLUSERSPROFILE%\Microsoft\Windows\Start Menu\Programs\Internet Explorer.lnk" />
+     <taskbar:DesktopApp DesktopApplicationLinkPath="%APPDATA%\Microsoft\Windows\Start Menu\Programs\Windows PowerShell\Windows PowerShell.lnk" />
+     <taskbar:DesktopApp DesktopApplicationLinkPath="%ALLUSERSPROFILE%\Microsoft\Windows\Start Menu\Programs\Google Chrome.lnk" />
+     <taskbar:DesktopApp DesktopApplicationLinkPath="%ALLUSERSPROFILE%\Microsoft\Windows\Start Menu\Programs\Notepad++\Notepad++.lnk" />
+    </taskbar:TaskbarPinList>
+   </defaultlayout:TaskbarLayout>
+  </CustomTaskbarLayoutCollection>
+</LayoutModificationTemplate>

--- a/templates/win/common/scripts/vmpooler/vmpooler-post-clone-configuration.ps1
+++ b/templates/win/common/scripts/vmpooler/vmpooler-post-clone-configuration.ps1
@@ -125,6 +125,17 @@ Set-Service "sshd" -StartupType Automatic
 schtasks /create /tn UpdateBGInfo /ru "$AdministratorName" /RP "$qa_root_passwd" /F /SC Minute /mo 20 /IT /TR 'C:\Packer\Scripts\sched-bginfo.vbs'
 schtasks /run /tn UpdateBGInfo
 
+# Pin apps to taskbar as long as we aren't win-10/2016
+
+if ($WindowsVersioni -notlike $WindowsServer2016) {
+  try {
+    Write-Output "Pin Apps to Taskbar"
+    & $PackerScripts\Pin-AppsToTaskBar.ps1
+  }
+  catch {
+    Write-Output "Ignoring Pin App errors"
+  }
+}
 # Rename this machine to that of the VM name in vSphere
 # Windows 7/2008R2- and earlier doesn't use the Rename-Computer cmdlet
 Write-Output "Renaming Host to $NewVMName"


### PR DESCRIPTION
This PR requires two different methods depending on platform:
1. Windows-10/2016 uses the new StartLayout GPO policy to define taskbar items.
2. Windows-2012r2 and earlier uses a simple script run during the post-clone configuration.

The <TaskBarLinks> elements used in the Post-Clone Autounattend have also been removed as they didn't work reliably.
