### PR TITLE
(maint) Remove vSphere post-processor

### DIFF
--- a/templates/common/vmware.vsphere.nocm.json
+++ b/templates/common/vmware.vsphere.nocm.json
@@ -19,24 +19,6 @@
     "shutdown_command"                      : "/sbin/halt -h -p",
 
     "qa_root_passwd"                        : "{{env `QA_ROOT_PASSWD`}}",
-    "packer_vcenter_host"                   : "{{env `PACKER_VCENTER_HOST`}}",
-    "packer_vcenter_username"               : "{{env `PACKER_VCENTER_USERNAME`}}",
-    "packer_vcenter_password"               : "{{env `PACKER_VCENTER_PASSWORD`}}",
-    "packer_vcenter_dc"                     : "{{env `PACKER_VCENTER_DC`}}",
-    "packer_vcenter_cluster"                : "{{env `PACKER_VCENTER_CLUSTER`}}",
-    "packer_vcenter_datastore"              : "{{env `PACKER_VCENTER_DATASTORE`}}",
-    "packer_vcenter_folder"                 : "{{env `PACKER_VCENTER_FOLDER`}}",
-    "packer_vcenter_net"                    : "{{env `PACKER_VCENTER_NET`}}",
-    "packer_vcenter_insecure"               : "{{env `PACKER_VCENTER_INSECURE`}}",
-    "packer_vcenter2_host"                  : "{{env `PACKER_VCENTER2_HOST`}}",
-    "packer_vcenter2_username"              : "{{env `PACKER_VCENTER2_USERNAME`}}",
-    "packer_vcenter2_password"              : "{{env `PACKER_VCENTER2_PASSWORD`}}",
-    "packer_vcenter2_dc"                    : "{{env `PACKER_VCENTER2_DC`}}",
-    "packer_vcenter2_cluster"               : "{{env `PACKER_VCENTER2_CLUSTER`}}",
-    "packer_vcenter2_datastore"             : "{{env `PACKER_VCENTER2_DATASTORE`}}",
-    "packer_vcenter2_folder"                : "{{env `PACKER_VCENTER2_FOLDER`}}",
-    "packer_vcenter2_net"                   : "{{env `PACKER_VCENTER2_NET`}}",
-    "packer_vcenter2_insecure"              : "{{env `PACKER_VCENTER2_INSECURE`}}",
     "packer_sha"                            : "{{env `PACKER_SHA`}}",
     "packer_source_dir"                     : "{{env `PACKER_VM_SRC_DIR`}}",
     "packer_output_dir"                     : "{{env `PACKER_VM_OUT_DIR`}}"
@@ -111,37 +93,6 @@
         "{{user `project_root`}}/scripts/cleanup-packer.sh",
         "{{user `project_root`}}/scripts/cleanup-scrub.sh"
       ]
-    }
-  ],
-
-  "post-processors"                         : [
-    {
-      "type"                                : "vsphere",
-      "host"                                : "{{user `packer_vcenter_host`}}",
-      "username"                            : "{{user `packer_vcenter_username`}}",
-      "password"                            : "{{user `packer_vcenter_password`}}",
-      "datacenter"                          : "{{user `packer_vcenter_dc`}}",
-      "cluster"                             : "{{user `packer_vcenter_cluster`}}",
-      "datastore"                           : "{{user `packer_vcenter_datastore`}}",
-      "vm_folder"                           : "{{user `packer_vcenter_folder`}}",
-      "vm_name"                             : "{{user `template_name`}}-{{user `version`}}",
-      "vm_network"                          : "{{user `packer_vcenter_net`}}",
-      "insecure"                            : "{{user `packer_vcenter_insecure`}}",
-      "overwrite"                           : "false"
-    },
-    {
-      "type"                                : "vsphere",
-      "host"                                : "{{user `packer_vcenter2_host`}}",
-      "username"                            : "{{user `packer_vcenter2_username`}}",
-      "password"                            : "{{user `packer_vcenter2_password`}}",
-      "datacenter"                          : "{{user `packer_vcenter2_dc`}}",
-      "cluster"                             : "{{user `packer_vcenter2_cluster`}}",
-      "datastore"                           : "{{user `packer_vcenter2_datastore`}}",
-      "vm_folder"                           : "{{user `packer_vcenter2_folder`}}",
-      "vm_name"                             : "{{user `template_name`}}-{{user `version`}}",
-      "vm_network"                          : "{{user `packer_vcenter2_net`}}",
-      "insecure"                            : "{{user `packer_vcenter2_insecure`}}",
-      "overwrite"                           : "false"
     }
   ]
 }

--- a/templates/macos/README.md
+++ b/templates/macos/README.md
@@ -44,7 +44,6 @@ Once the 10.12 base build is finished, you can build and ship the 10.12 vsphere 
     - (The username is automatically set to `osx`)
 - `PACKER_VM_SRC_DIR`, the output directory from the 10.12 base build
 - `PACKER_VM_OUT_DIR`, the desired output directory for this build
-- All vcenter-related environment variables: `PACKER_VCENTER_HOST`, `PACKER_VCENTER_USERNAME`, `PACKER_VCENTER_PASSWORD`, `PACKER_VCENTER_DC`, `PACKER_VCENTER_CLUSTER`, `PACKER_VCENTER_DATASTORE`, `PACKER_VCENTER_FOLDER`, `PACKER_VCENTER_NET`, `PACKER_VCENTER_INSECURE`, `PACKER_SHA`
 
 Example:
 
@@ -52,7 +51,6 @@ Example:
 $ QA_ROOT_PASSWD_PLAIN="<common-pooler-password>" \
     PACKER_VM_OUT_DIR="./output" \
     PACKER_VM_SRC_DIR="./output" \
-    ... (vcenter environment variables) \
     packer build \
     -var-file=./common/vars.json \
     -var-file=./10.12/x86_64/vars.json \
@@ -92,7 +90,6 @@ Once the 10.13 base build is finished, you can build and ship the 10.13 vsphere 
     - (The username is automatically set to `osx`)
 - `PACKER_VM_SRC_DIR`, the output directory from the 10.12 base build
 - `PACKER_VM_OUT_DIR`, the desired output directory for this build
-- All vcenter-related environment variables: `PACKER_VCENTER_HOST`, `PACKER_VCENTER_USERNAME`, `PACKER_VCENTER_PASSWORD`, `PACKER_VCENTER_DC`, `PACKER_VCENTER_CLUSTER`, `PACKER_VCENTER_DATASTORE`, `PACKER_VCENTER_FOLDER`, `PACKER_VCENTER_NET`, `PACKER_VCENTER_INSECURE`, `PACKER_SHA`
 
 Example:
 
@@ -100,7 +97,6 @@ Example:
 $ QA_ROOT_PASSWD_PLAIN="<common-pooler-password>" \
     PACKER_VM_OUT_DIR="./output" \
     PACKER_VM_SRC_DIR="./output" \
-    ... (vcenter environment variables) \
     packer build \
     -var-file=./common/vars.json \
     -var-file=./10.13/x86_64/vars.json \

--- a/templates/macos/common/vmware.vsphere.nocm.json
+++ b/templates/macos/common/vmware.vsphere.nocm.json
@@ -11,24 +11,6 @@
     "update_system"                         : null,
     "version"                               : null,
     "ssh_password"                          : "{{env `QA_ROOT_PASSWD_PLAIN`}}",
-    "packer_vcenter_host"                   : "{{env `PACKER_VCENTER_HOST`}}",
-    "packer_vcenter_username"               : "{{env `PACKER_VCENTER_USERNAME`}}",
-    "packer_vcenter_password"               : "{{env `PACKER_VCENTER_PASSWORD`}}",
-    "packer_vcenter_dc"                     : "{{env `PACKER_VCENTER_DC`}}",
-    "packer_vcenter_cluster"                : "{{env `PACKER_VCENTER_CLUSTER`}}",
-    "packer_vcenter_datastore"              : "{{env `PACKER_VCENTER_DATASTORE`}}",
-    "packer_vcenter_folder"                 : "{{env `PACKER_VCENTER_FOLDER`}}",
-    "packer_vcenter_net"                    : "{{env `PACKER_VCENTER_NET`}}",
-    "packer_vcenter_insecure"               : "{{env `PACKER_VCENTER_INSECURE`}}",
-    "packer_vcenter2_host"                  : "{{env `PACKER_VCENTER2_HOST`}}",
-    "packer_vcenter2_username"              : "{{env `PACKER_VCENTER2_USERNAME`}}",
-    "packer_vcenter2_password"              : "{{env `PACKER_VCENTER2_PASSWORD`}}",
-    "packer_vcenter2_dc"                    : "{{env `PACKER_VCENTER2_DC`}}",
-    "packer_vcenter2_cluster"               : "{{env `PACKER_VCENTER2_CLUSTER`}}",
-    "packer_vcenter2_datastore"             : "{{env `PACKER_VCENTER2_DATASTORE`}}",
-    "packer_vcenter2_folder"                : "{{env `PACKER_VCENTER2_FOLDER`}}",
-    "packer_vcenter2_net"                   : "{{env `PACKER_VCENTER2_NET`}}",
-    "packer_vcenter2_insecure"              : "{{env `PACKER_VCENTER2_INSECURE`}}",
     "packer_sha"                            : "{{env `PACKER_SHA`}}",
     "support_status"                        : "puppet_maintained",
     "packer_output_dir"                     : "{{env `PACKER_VM_OUT_DIR`}}",
@@ -78,37 +60,6 @@
       "scripts"                             : [
         "{{user `common_files`}}/pooler-setup.sh"
       ]
-    }
-  ],
-
-  "post-processors"                         : [
-    {
-      "type"                                : "vsphere",
-      "host"                                : "{{user `packer_vcenter_host`}}",
-      "username"                            : "{{user `packer_vcenter_username`}}",
-      "password"                            : "{{user `packer_vcenter_password`}}",
-      "datacenter"                          : "{{user `packer_vcenter_dc`}}",
-      "cluster"                             : "{{user `packer_vcenter_cluster`}}",
-      "datastore"                           : "{{user `packer_vcenter_datastore`}}",
-      "vm_folder"                           : "{{user `packer_vcenter_folder`}}",
-      "vm_name"                             : "{{user `template_name`}}-{{user `version`}}",
-      "vm_network"                          : "{{user `packer_vcenter_net`}}",
-      "insecure"                            : "{{user `packer_vcenter_insecure`}}",
-      "overwrite"                           : "true"
-    },
-    {
-      "type"                                : "vsphere",
-      "host"                                : "{{user `packer_vcenter2_host`}}",
-      "username"                            : "{{user `packer_vcenter2_username`}}",
-      "password"                            : "{{user `packer_vcenter2_password`}}",
-      "datacenter"                          : "{{user `packer_vcenter2_dc`}}",
-      "cluster"                             : "{{user `packer_vcenter2_cluster`}}",
-      "datastore"                           : "{{user `packer_vcenter2_datastore`}}",
-      "vm_folder"                           : "{{user `packer_vcenter2_folder`}}",
-      "vm_name"                             : "{{user `template_name`}}-{{user `version`}}",
-      "vm_network"                          : "{{user `packer_vcenter2_net`}}",
-      "insecure"                            : "{{user `packer_vcenter2_insecure`}}",
-      "overwrite"                           : "true"
     }
   ]
 }

--- a/templates/vro/common/vmware.vsphere.nocm.json
+++ b/templates/vro/common/vmware.vsphere.nocm.json
@@ -17,24 +17,6 @@
     "raw_vmx_file"              : "{{env `VRO_RAW_VMX_PATH` }}",
 
     "qa_root_passwd_plain"      : "{{env `QA_ROOT_PASSWD_PLAIN`}}",
-    "packer_vcenter_host"       : "{{env `PACKER_VCENTER_HOST`}}",
-    "packer_vcenter_username"   : "{{env `PACKER_VCENTER_USERNAME`}}",
-    "packer_vcenter_password"   : "{{env `PACKER_VCENTER_PASSWORD`}}",
-    "packer_vcenter_dc"         : "{{env `PACKER_VCENTER_DC`}}",
-    "packer_vcenter_cluster"    : "{{env `PACKER_VCENTER_CLUSTER`}}",
-    "packer_vcenter_datastore"  : "{{env `PACKER_VCENTER_DATASTORE`}}",
-    "packer_vcenter_folder"     : "{{env `PACKER_VCENTER_FOLDER`}}",
-    "packer_vcenter_net"        : "{{env `PACKER_VCENTER_NET`}}",
-    "packer_vcenter_insecure"   : "{{env `PACKER_VCENTER_INSECURE`}}",
-    "packer_vcenter2_host"      : "{{env `PACKER_VCENTER2_HOST`}}",
-    "packer_vcenter2_username"  : "{{env `PACKER_VCENTER2_USERNAME`}}",
-    "packer_vcenter2_password"  : "{{env `PACKER_VCENTER2_PASSWORD`}}",
-    "packer_vcenter2_dc"        : "{{env `PACKER_VCENTER2_DC`}}",
-    "packer_vcenter2_cluster"   : "{{env `PACKER_VCENTER2_CLUSTER`}}",
-    "packer_vcenter2_datastore" : "{{env `PACKER_VCENTER2_DATASTORE`}}",
-    "packer_vcenter2_folder"    : "{{env `PACKER_VCENTER2_FOLDER`}}",
-    "packer_vcenter2_net"       : "{{env `PACKER_VCENTER2_NET`}}",
-    "packer_vcenter2_insecure"  : "{{env `PACKER_VCENTER2_INSECURE`}}",
     "packer_sha"                : "{{env `PACKER_SHA`}}",
     "packer_source_dir"         : "{{env `PACKER_VM_SRC_DIR`}}",
     "packer_output_dir"         : "{{env `PACKER_VM_OUT_DIR`}}"
@@ -89,37 +71,6 @@
       "scripts"                 : [
         "../../common/scripts/configure-for-vsphere.sh"
       ]
-    }
-  ],
-
-  "post-processors"             : [
-    {
-      "type"                    : "vsphere",
-      "host"                    : "{{user `packer_vcenter_host`}}",
-      "username"                : "{{user `packer_vcenter_username`}}",
-      "password"                : "{{user `packer_vcenter_password`}}",
-      "datacenter"              : "{{user `packer_vcenter_dc`}}",
-      "cluster"                 : "{{user `packer_vcenter_cluster`}}",
-      "datastore"               : "{{user `packer_vcenter_datastore`}}",
-      "vm_folder"               : "{{user `packer_vcenter_folder`}}",
-      "vm_name"                 : "{{user `template_name`}}-{{user `version`}}",
-      "vm_network"              : "{{user `packer_vcenter_net`}}",
-      "insecure"                : "{{user `packer_vcenter_insecure`}}",
-      "overwrite"               : "true"
-    },
-    {
-      "type"                    : "vsphere",
-      "host"                    : "{{user `packer_vcenter2_host`}}",
-      "username"                : "{{user `packer_vcenter2_username`}}",
-      "password"                : "{{user `packer_vcenter2_password`}}",
-      "datacenter"              : "{{user `packer_vcenter2_dc`}}",
-      "cluster"                 : "{{user `packer_vcenter2_cluster`}}",
-      "datastore"               : "{{user `packer_vcenter2_datastore`}}",
-      "vm_folder"               : "{{user `packer_vcenter2_folder`}}",
-      "vm_name"                 : "{{user `template_name`}}-{{user `version`}}",
-      "vm_network"              : "{{user `packer_vcenter2_net`}}",
-      "insecure"                : "{{user `packer_vcenter2_insecure`}}",
-      "overwrite"               : "true"
     }
   ]
 }

--- a/templates/win/2008/x86_64/vmware.vsphere.cygwin.json
+++ b/templates/win/2008/x86_64/vmware.vsphere.cygwin.json
@@ -15,15 +15,6 @@
     "shutdown_timeout"         : "1h",
 
     "qa_root_passwd"           : "{{env `QA_ROOT_PASSWD_PLAIN`}}",
-    "packer_vcenter_host"      : "{{env `PACKER_VCENTER_HOST`}}",
-    "packer_vcenter_username"  : "{{env `PACKER_VCENTER_USERNAME`}}",
-    "packer_vcenter_password"  : "{{env `PACKER_VCENTER_PASSWORD`}}",
-    "packer_vcenter_dc"        : "{{env `PACKER_VCENTER_DC`}}",
-    "packer_vcenter_cluster"   : "{{env `PACKER_VCENTER_CLUSTER`}}",
-    "packer_vcenter_datastore" : "{{env `PACKER_VCENTER_DATASTORE`}}",
-    "packer_vcenter_folder"    : "{{env `PACKER_VCENTER_FOLDER`}}",
-    "packer_vcenter_net"       : "{{env `PACKER_VCENTER_NET`}}",
-    "packer_vcenter_insecure"  : "{{env `PACKER_VCENTER_INSECURE`}}",
     "packer_sha"               : "{{env `PACKER_SHA`}}",
     "packer_source_dir"        : "{{env `PACKER_VM_SRC_DIR`}}",
     "packer_output_dir"        : "{{env `PACKER_VM_OUT_DIR`}}",
@@ -157,26 +148,6 @@
     },
     {
       "type": "windows-restart"
-    }
-  ],
-  "post-processors": [
-    {
-      "type": "vsphere",
-      "host": "{{user `packer_vcenter_host`}}",
-      "username": "{{user `packer_vcenter_username`}}",
-      "password": "{{user `packer_vcenter_password`}}",
-      "datacenter": "{{user `packer_vcenter_dc`}}",
-      "cluster": "{{user `packer_vcenter_cluster`}}",
-      "datastore": "{{user `packer_vcenter_datastore`}}",
-      "vm_folder": "{{user `packer_vcenter_folder`}}",
-      "vm_name": "{{user `template_name`}}-{{user `version`}}",
-      "vm_network": "{{user `packer_vcenter_net`}}",
-      "insecure" : "{{user `packer_vcenter_insecure`}}",
-      "overwrite" : "true",
-      "options": [
-        "--X:logLevel=verbose",
-        "--X:logFile={{user `packer_output_dir`}}/ovftool-{{build_name}}.log"
-      ]
     }
   ]
 }

--- a/templates/win/common/vmware.vsphere.cygwin.json
+++ b/templates/win/common/vmware.vsphere.cygwin.json
@@ -16,15 +16,6 @@
     "shutdown_timeout"         : "1h",
 
     "qa_root_passwd"           : "{{env `QA_ROOT_PASSWD_PLAIN`}}",
-    "packer_vcenter_host"      : "{{env `PACKER_VCENTER_HOST`}}",
-    "packer_vcenter_username"  : "{{env `PACKER_VCENTER_USERNAME`}}",
-    "packer_vcenter_password"  : "{{env `PACKER_VCENTER_PASSWORD`}}",
-    "packer_vcenter_dc"        : "{{env `PACKER_VCENTER_DC`}}",
-    "packer_vcenter_cluster"   : "{{env `PACKER_VCENTER_CLUSTER`}}",
-    "packer_vcenter_datastore" : "{{env `PACKER_VCENTER_DATASTORE`}}",
-    "packer_vcenter_folder"    : "{{env `PACKER_VCENTER_FOLDER`}}",
-    "packer_vcenter_net"       : "{{env `PACKER_VCENTER_NET`}}",
-    "packer_vcenter_insecure"  : "{{env `PACKER_VCENTER_INSECURE`}}",
     "packer_sha"               : "{{env `PACKER_SHA`}}",
     "packer_source_dir"        : "{{env `PACKER_VM_SRC_DIR`}}",
     "packer_output_dir"        : "{{env `PACKER_VM_OUT_DIR`}}",
@@ -150,27 +141,5 @@
         "type": "powershell",
         "script" : "../../common/scripts/provisioners/cleanup-host.ps1"
       }
-  ],
-  "post-processors": [
-    {
-      "type": "vsphere",
-      "host": "{{user `packer_vcenter_host`}}",
-      "username": "{{user `packer_vcenter_username`}}",
-      "password": "{{user `packer_vcenter_password`}}",
-      "datacenter": "{{user `packer_vcenter_dc`}}",
-      "cluster": "{{user `packer_vcenter_cluster`}}",
-      "datastore": "{{user `packer_vcenter_datastore`}}",
-      "vm_folder": "{{user `packer_vcenter_folder`}}",
-      "vm_name": "{{user `template_name`}}-{{user `version`}}",
-      "vm_network": "{{user `packer_vcenter_net`}}",
-      "insecure" : "{{user `packer_vcenter_insecure`}}",
-      "overwrite" : "true",
-      "options": [
-        "--X:logLevel=verbose",
-        "--X:logFile={{user `packer_output_dir`}}/ovftool-{{build_name}}.log",
-        "--allowAllExtraConfig",
-        "--allowExtraConfig",
-        "--extraConfig:devices.hotplug=false"      ]
-    }
   ]
 }


### PR DESCRIPTION
With IMAGES-828 merged in, we have now separated the vCenter uploads
from Packer. This commit removes the vSphere post-processor from all the
templates.