### PR TITLE
(IMAGES-855) Add libtool to the cygwin packages

### DIFF
--- a/templates/win/common/scripts/config/cygwin-packages
+++ b/templates/win/common/scripts/config/cygwin-packages
@@ -84,6 +84,7 @@ libssh2_1            1.5.0-1            OK
 libssp0              4.9.3-1            OK
 libstdc++6           4.9.3-1            OK
 libtasn1_6           4.5-1              OK
+libtool              2.4.6              OK
 libuuid-devel        2.25.2-2           OK
 libuuid1             2.25.2-2           OK
 libwind0             1.5.2-4            OK

--- a/templates/win/common/scripts/provisioners/install-cygwin.ps1
+++ b/templates/win/common/scripts/provisioners/install-cygwin.ps1
@@ -62,7 +62,7 @@ $ENV:QA_ROOT_PASSWD | Out-File "$CygwinDownloads\qapasswd"
 
 Write-Output "Downloading Cygwin Setup"
 $CygWinSetup = "$CygwinDownloads\setup-$ARCH.exe"
-Download-File "https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/cygwin/setup-$ARCH.exe" $CygWinSetup
+Download-File "https://cygwin.com/setup-$ARCH.exe" $CygWinSetup
 # Install Cygwin directly from the Cygwin site - so using latest version.
 # Start-Process -wait needed to address Win-2008 where the setup appears to run async and script exits before install has completed
 Write-Output "Installing Cygwin"

--- a/templates/win/common/scripts/provisioners/install-cygwin.ps1
+++ b/templates/win/common/scripts/provisioners/install-cygwin.ps1
@@ -38,6 +38,8 @@ if ($ARCH -eq 'x86') {
 $RegPath = 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment'
 Set-ItemProperty -Path $RegPath -Name CYGWINDIR -Value $CygWinDir
 Set-ItemProperty -Path $RegPath -Name CYGWINDOWNLOADS -Value $CygwinDownloads
+# Fix for IMAGES-855 - Defining NM as env var resolves the libool "syntax error near unexpected token `|`" eval error
+Set-ItemProperty -Path $RegPath -Name NM -Value "/usr/bin/nm"
 
 # Read list of packages to be installed.
 # This is a plain-text list of packages, where the first word on each line must be a single package name.


### PR DESCRIPTION
Libtool is installed/configured by libcurl and appears to be having
issues, so try installing this directly from cygwin to see if it
performs better.

The cygwin setup.exe is also well out of date, so grab this from cygwin
directly instead of our own artifactory.