### PR TITLE
(IMAGES-747) Use regular Fedora 28 repos

### DIFF
--- a/manifests/modules/packer/manifests/vsphere/repos.pp
+++ b/manifests/modules/packer/manifests/vsphere/repos.pp
@@ -86,17 +86,11 @@ class packer::vsphere::repos inherits packer::vsphere::params {
           '5' => "${os_mirror}/rhel50server-${::architecture}/RPMS.all"
         }
       } else {
-        # When the final release of Fedora 28 drops, our normal mirror url
-        # should work for it and we can remove this special case:
-        if $::operatingsystem == 'Fedora' and $::operatingsystemmajrelease == '28' {
-          $base_url = "${repo_mirror}/rpm__remote_fedora/development/28/Everything/${::architecture}/os"
-        } else {
-          $base_url = $::operatingsystem ? {
-            'Fedora'      => "${repo_mirror}/rpm__remote_fedora/releases/${::operatingsystemmajrelease}/Everything/${::architecture}/os",
-            'CentOS'      => "${repo_mirror}/rpm__remote_centos/${::operatingsystemmajrelease}",
-            'Scientific'  => "${repo_mirror}/rpm__remote_scientific/${::operatingsystemmajrelease}/${::architecture}",
-            'OracleLinux' => "${os_mirror}/${loweros}-${::operatingsystemmajrelease}-${::architecture}/RPMS.all"
-          }
+        $base_url = $::operatingsystem ? {
+          'Fedora'      => "${repo_mirror}/rpm__remote_fedora/releases/${::operatingsystemmajrelease}/Everything/${::architecture}/os",
+          'CentOS'      => "${repo_mirror}/rpm__remote_centos/${::operatingsystemmajrelease}",
+          'Scientific'  => "${repo_mirror}/rpm__remote_scientific/${::operatingsystemmajrelease}/${::architecture}",
+          'OracleLinux' => "${os_mirror}/${loweros}-${::operatingsystemmajrelease}-${::architecture}/RPMS.all"
         }
       }
 


### PR DESCRIPTION
Removes pre-release development repo special case (some dependencies of puppet-agent and pdk aren't available in these development repos)