### PR TITLE
(MAINT) Fix the ISO Reference for Win-10-pro

### DIFF
--- a/templates/win/10-pro/x86_64/vars.json
+++ b/templates/win/10-pro/x86_64/vars.json
@@ -7,7 +7,7 @@
     "image_name"        : "Windows 10 Pro",
     "product_key"       : "W269N-WFGWX-YVC9B-4J6C9-T83GX",
     "version"           : "20180615_PROD",
-    "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_10_business_editions_version_1803_updated_march_2018_x64_dvd_12063333.iso",
+    "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_10_multi-edition_vl_version_1709_updated_dec_2017_x64_dvd_100406172.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "c6dad7a55f8af7ae5e38b33d1d65805b",
     "boot_command"      : "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait>"


### PR DESCRIPTION
This wasn't changed as part of the rollback for IMAGES-555 work.