### PR TITLE
(MAINT) Fix win-10-1803 template name

### DIFF
--- a/templates/win/10-1803/x86_64/vars.json
+++ b/templates/win/10-1803/x86_64/vars.json
@@ -1,5 +1,5 @@
 {
-    "template_name"     : "win-10-ent-x86_64",
+    "template_name"     : "win-10-1803-x86_64",
     "beakerhost"        : "windows10ent-64",
     "vbox_guest_os"     : "Windows81_64",
     "vmware_guest_os"   : "windows8-64",


### PR DESCRIPTION
The template name for this image was incorrect and duplicating
win-10-ent. Correct it to allow the new template to be created.