### PR TITLE
(MAINT) Bump version following deploy

### DIFF
--- a/templates/win/10-1511/x86_64/vars.json
+++ b/templates/win/10-1511/x86_64/vars.json
@@ -6,7 +6,7 @@
     "windows_version"   : "Windows-10",
     "image_name"        : "Windows 10 Enterprise 2015 LTSB",
     "product_key"       : "WNMTR-4C88C-JK8YV-HQ7T2-76DF9",
-    "version"           : "20180615_PROD",
+    "version"           : "20180619_DEV",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_10_enterprise_2015_ltsb_x64_dvd_6848446.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "da938d65c548738900810181a78203f8",

--- a/templates/win/10-1607/x86_64/vars.json
+++ b/templates/win/10-1607/x86_64/vars.json
@@ -6,7 +6,7 @@
     "windows_version"   : "Windows-10",
     "image_name"        : "Windows 10 Enterprise 2016 LTSB",
     "product_key"       : "DCPHK-NFMTC-H88MJ-PFHPY-QJ4BJ",
-    "version"           : "20180615_PROD",
+    "version"           : "20180619_DEV",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_10_enterprise_2016_ltsb_x64_dvd_9059483.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "e39ea2af41b3710682fe3bbdac35ec9a",

--- a/templates/win/10-1709/x86_64/vars.json
+++ b/templates/win/10-1709/x86_64/vars.json
@@ -6,7 +6,7 @@
     "windows_version"   : "Windows-10",
     "image_name"        : "Windows 10 Enterprise",
     "product_key"       : "NPPR9-FWDCX-D2C8J-H872K-2YT43",
-    "version"           : "20180615_PROD",
+    "version"           : "20180619_DEV",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_10_multi-edition_vl_version_1709_updated_dec_2017_x64_dvd_100406172.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "c6dad7a55f8af7ae5e38b33d1d65805b",

--- a/templates/win/10-1803/x86_64/vars.json
+++ b/templates/win/10-1803/x86_64/vars.json
@@ -6,7 +6,7 @@
     "windows_version"   : "Windows-10",
     "image_name"        : "Windows 10 Enterprise",
     "product_key"       : "NPPR9-FWDCX-D2C8J-H872K-2YT43",
-    "version"           : "20180615_PROD",
+    "version"           : "20180619_DEV",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_10_business_editions_version_1803_updated_march_2018_x64_dvd_12063333.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "70ea72fb3ff11771dcc0a36e2850e29e",

--- a/templates/win/10-ent/i386/vars.json
+++ b/templates/win/10-ent/i386/vars.json
@@ -7,7 +7,7 @@
     "windows_version"   : "Windows-10",
     "image_name"        : "Windows 10 Enterprise",
     "product_key"       : "NPPR9-FWDCX-D2C8J-H872K-2YT43",
-    "version"           : "20180615_PROD",
+    "version"           : "20180619_DEV",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_10_multi-edition_vl_version_1709_updated_dec_2017_x86_dvd_100406182.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "e5bd5877a9e7f0e29abc94e4664523c0",

--- a/templates/win/10-ent/x86_64/vars.json
+++ b/templates/win/10-ent/x86_64/vars.json
@@ -6,7 +6,7 @@
     "windows_version"   : "Windows-10",
     "image_name"        : "Windows 10 Enterprise",
     "product_key"       : "NPPR9-FWDCX-D2C8J-H872K-2YT43",
-    "version"           : "20180615_PROD",
+    "version"           : "20180619_DEV",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_10_multi-edition_vl_version_1709_updated_dec_2017_x64_dvd_100406172.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "c6dad7a55f8af7ae5e38b33d1d65805b",

--- a/templates/win/10-pro/x86_64/vars.json
+++ b/templates/win/10-pro/x86_64/vars.json
@@ -6,7 +6,7 @@
     "windows_version"   : "Windows-10",
     "image_name"        : "Windows 10 Pro",
     "product_key"       : "W269N-WFGWX-YVC9B-4J6C9-T83GX",
-    "version"           : "20180615_PROD",
+    "version"           : "20180619_DEV",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_10_multi-edition_vl_version_1709_updated_dec_2017_x64_dvd_100406172.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "c6dad7a55f8af7ae5e38b33d1d65805b",

--- a/templates/win/2008/x86_64/vars.json
+++ b/templates/win/2008/x86_64/vars.json
@@ -6,7 +6,7 @@
     "windows_version"   : "Windows-2008",
     "image_name"        : "Windows Longhorn SERVERSTANDARD",
     "product_key"       : "TM24T-X9RMF-VWXK6-X8JC9-BFGM2",
-    "version"           : "20180615_PROD",
+    "version"           : "20180619_DEV",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_server_2008_with_sp2_x64_dvd_342336_SlipStream_03.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "ab418a455fea422d2582c660ee8cd8f1",

--- a/templates/win/2008r2-wmf2/x86_64/vars.json
+++ b/templates/win/2008r2-wmf2/x86_64/vars.json
@@ -3,5 +3,5 @@
 
     "template_name"             : "win-2008r2-wmf2-x86_64",
     "gce_source_image_family"   : "windows-2008-r2",
-    "version"                   : "20180615_PROD"
+    "version"                   : "20180619_DEV"
 }

--- a/templates/win/2008r2-wmf3/x86_64/vars.json
+++ b/templates/win/2008r2-wmf3/x86_64/vars.json
@@ -3,5 +3,5 @@
     
     "template_name"             : "win-2008r2-wmf3-x86_64",
     "gce_source_image_family"   : "windows-2008-r2",
-    "version"                   : "20180615_PROD"
+    "version"                   : "20180619_DEV"
 }

--- a/templates/win/2008r2-wmf4/x86_64/vars.json
+++ b/templates/win/2008r2-wmf4/x86_64/vars.json
@@ -3,5 +3,5 @@
 
     "template_name"             : "win-2008r2-wmf4-x86_64",
     "gce_source_image_family"   : "windows-2008-r2",
-    "version"                   : "20180615_PROD"
+    "version"                   : "20180619_DEV"
 }

--- a/templates/win/2008r2-wmf5/x86_64/vars.json
+++ b/templates/win/2008r2-wmf5/x86_64/vars.json
@@ -6,7 +6,7 @@
     "windows_version"   : "Windows-2008r2",
     "image_name"        : "Windows Server 2008 R2 SERVERSTANDARD",
     "product_key"       : "YC6KT-GKW9T-YTKYR-T4X34-R7VHC",
-    "version"           : "20180615_PROD",
+    "version"           : "20180619_DEV",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_server_2008_r2_with_sp1_x64_dvd_617601_SlipStream_03.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "f94011cfdc4e0498a01a86a0cafe403e",

--- a/templates/win/2008r2/x86_64/vars.json
+++ b/templates/win/2008r2/x86_64/vars.json
@@ -6,7 +6,7 @@
     "windows_version"           : "Windows-2008r2",
     "image_name"                : "Windows Server 2008 R2 SERVERSTANDARD",
     "product_key"               : "YC6KT-GKW9T-YTKYR-T4X34-R7VHC",
-    "version"                   : "20180615_PROD",
+    "version"                   : "20180619_DEV",
     "iso_url"                   : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_server_2008_r2_with_sp1_x64_dvd_617601_SlipStream_03.iso",
     "iso_checksum_type"         : "md5",
     "iso_checksum"              : "f94011cfdc4e0498a01a86a0cafe403e",

--- a/templates/win/2012/x86_64/vars.json
+++ b/templates/win/2012/x86_64/vars.json
@@ -6,7 +6,7 @@
     "windows_version"   : "Windows-2012",
     "image_name"        : "Windows Server 2012 SERVERSTANDARD",
     "product_key"       : "XC9B7-NBPP2-83J2H-RHMBY-92BT4",
-    "version"           : "20180615_PROD",
+    "version"           : "20180619_DEV",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_server_2012_x64_dvd_915478_SlipStream_03.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "8cc8b3f54bb56dce7936bb1e97e3fc31",

--- a/templates/win/2012r2-core/x86_64/vars.json
+++ b/templates/win/2012r2-core/x86_64/vars.json
@@ -7,7 +7,7 @@
     "image_index"       : "1",
     "image_name"        : "Windows Server 2012 R2 SERVERSTANDARDCORE",
     "product_key"       : "D2N9P-3P6X9-2R39C-7RTCD-MDVJX",
-    "version"           : "20180615_PROD",
+    "version"           : "20180619_DEV",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_server_2012_r2_with_update_x64_dvd_6052708_SlipStream_03.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "8b30b370cfd32e2b90ab4e1b77a31bd3",

--- a/templates/win/2012r2-fr/x86_64/vars.json
+++ b/templates/win/2012r2-fr/x86_64/vars.json
@@ -8,7 +8,7 @@
     "windows_version"   : "Windows-2012r2",
     "image_name"        : "Windows Server 2012 R2 SERVERSTANDARD",
     "product_key"       : "D2N9P-3P6X9-2R39C-7RTCD-MDVJX",
-    "version"           : "20180615_PROD",
+    "version"           : "20180619_DEV",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/fr_windows_server_2012_r2_with_update_x64_dvd_6052713_SlipStream_01.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "2aaeb548f739f417a33439fd6a614090",

--- a/templates/win/2012r2-ja/x86_64/vars.json
+++ b/templates/win/2012r2-ja/x86_64/vars.json
@@ -7,7 +7,7 @@
     "windows_version"   : "Windows-2012r2",
     "image_name"        : "Windows Server 2012 R2 SERVERSTANDARD",
     "product_key"       : "D2N9P-3P6X9-2R39C-7RTCD-MDVJX",
-    "version"           : "20180615_PROD",
+    "version"           : "20180619_DEV",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/ja_windows_server_2012_r2_with_update_x64_dvd_6052738_SlipStream_01.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "d06430e4ddc79330649b4b16d984a3d5",

--- a/templates/win/2012r2-wmf5/x86_64/vars.json
+++ b/templates/win/2012r2-wmf5/x86_64/vars.json
@@ -6,7 +6,7 @@
     "windows_version"   : "Windows-2012r2",
     "image_name"        : "Windows Server 2012 R2 SERVERSTANDARD",
     "product_key"       : "D2N9P-3P6X9-2R39C-7RTCD-MDVJX",
-    "version"           : "20180615_PROD",
+    "version"           : "20180619_DEV",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_server_2012_r2_with_update_x64_dvd_6052708_SlipStream_02.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "3feae58c235f88126a1c099d58abfb8f",

--- a/templates/win/2012r2/x86_64/vars.json
+++ b/templates/win/2012r2/x86_64/vars.json
@@ -7,7 +7,7 @@
     "post_memsize"      : "6144",
     "image_name"        : "Windows Server 2012 R2 SERVERSTANDARD",
     "product_key"       : "D2N9P-3P6X9-2R39C-7RTCD-MDVJX",
-    "version"           : "20180615_PROD",
+    "version"           : "20180619_DEV",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_server_2012_r2_with_update_x64_dvd_6052708_SlipStream_02.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "3feae58c235f88126a1c099d58abfb8f",

--- a/templates/win/2016-core/x86_64/vars.json
+++ b/templates/win/2016-core/x86_64/vars.json
@@ -6,7 +6,7 @@
     "windows_version"   : "Windows-2016",
     "image_name"        : "Windows Server 2016 SERVERSTANDARDCORE",
     "product_key"       : "WC2BQ-8NRM3-FDDYY-2BFGV-KHKQY",
-    "version"           : "20180615_PROD",
+    "version"           : "20180619_DEV",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_server_2016_updated_feb_2018_x64_dvd_11636692.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "e8adeebcd8076702593469e33cc2d092",

--- a/templates/win/2016/x86_64/vars.json
+++ b/templates/win/2016/x86_64/vars.json
@@ -6,7 +6,7 @@
     "windows_version"   : "Windows-2016",
     "image_name"        : "Windows Server 2016 SERVERSTANDARD",
     "product_key"       : "WC2BQ-8NRM3-FDDYY-2BFGV-KHKQY",
-    "version"           : "20180615_PROD",
+    "version"           : "20180619_DEV",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_server_2016_updated_feb_2018_x64_dvd_11636692.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "e8adeebcd8076702593469e33cc2d092",

--- a/templates/win/2019/x86_64/vars.json
+++ b/templates/win/2019/x86_64/vars.json
@@ -7,7 +7,7 @@
     "windows_version"   : "Windows-2019",
     "image_name"        : "Windows Server 2016 SERVERSTANDARD",
     "product_key"       : "MFY9F-XBN2F-TYFMP-CCV49-RMYVH",
-    "version"           : "20180615_PROD",
+    "version"           : "20180619_DEV",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/Windows_2019_InsiderPreview_Server_vNext_en-us_17666.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "4091e78e812765c699acee271efdfc2f",

--- a/templates/win/7-wmf5/x86_64/vars.json
+++ b/templates/win/7-wmf5/x86_64/vars.json
@@ -7,7 +7,7 @@
     "image_name"        : "Windows 7 Enterprise",
     "product_key"       : "33PXH-7Y6KF-2VJC9-XBBR8-HVTHH",
     "hypervisor"        : "VMWare",
-    "version"           : "20180615_PROD",
+    "version"           : "20180619_DEV",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_7_enterprise_with_sp1_x64_dvd_u_677651_SlipStream_03.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "4246cfa663a9a581d2da4ba784554308",

--- a/templates/win/7/x86_64/vars.json
+++ b/templates/win/7/x86_64/vars.json
@@ -7,7 +7,7 @@
     "image_name"        : "Windows 7 Enterprise",
     "product_key"       : "33PXH-7Y6KF-2VJC9-XBBR8-HVTHH",
     "hypervisor"        : "VMWare",
-    "version"           : "20180615_PROD",
+    "version"           : "20180619_DEV",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_7_enterprise_with_sp1_x64_dvd_u_677651_SlipStream_03.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "4246cfa663a9a581d2da4ba784554308",

--- a/templates/win/81/x86_64/vars.json
+++ b/templates/win/81/x86_64/vars.json
@@ -6,7 +6,7 @@
     "windows_version"   : "Windows-8.1",
     "image_name"        : "Windows 8.1 Enterprise",
     "product_key"       : "MHF9N-XY6XB-WVXMC-BTDCT-MKKG7",
-    "version"           : "20180615_PROD",
+    "version"           : "20180619_DEV",
     "iso_url"           : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/windows/en_windows_8.1_enterprise_with_update_x64_dvd_6054382_SlipStream_01.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "ce996fb7136d55314747c5cef2602b27",


### PR DESCRIPTION
Move Windows version on to avoid clash with deployment templates.