### PR TITLE
Adds CentOS 7.5 template

### DIFF
--- a/manifests/modules/packer/manifests/networking/params.pp
+++ b/manifests/modules/packer/manifests/networking/params.pp
@@ -8,7 +8,7 @@ class packer::networking::params {
 
     redhat: {
       case $::operatingsystemrelease {
-        '7.0', '7.0.1406', '7.1.1503', '7.2.1511', '7.2', '7.3.1611', '7.4.1708': {
+        '7.0', '7.0.1406', '7.1.1503', '7.2.1511', '7.2', '7.3.1611', '7.4.1708', '7.5.1804': {
           case $::provisioner {
             'virtualbox': { $interface_script = '/etc/sysconfig/network-scripts/ifcfg-enp0s3' }
             'vmware':     { $interface_script = '/etc/sysconfig/network-scripts/ifcfg-ens33' }

--- a/templates/centos/7.5/common/files/ks.cfg
+++ b/templates/centos/7.5/common/files/ks.cfg
@@ -1,0 +1,42 @@
+install
+cdrom
+lang en_US.UTF-8
+keyboard us
+network --bootproto=dhcp --device=eth0
+rootpw --iscrypted $1$v4K9E8Wj$gZIHJ5JtQL5ZGZXeqSSsd0
+firewall --disabled
+authconfig --enableshadow --passalgo=sha512
+selinux --disabled
+timezone UTC
+bootloader --location=mbr --append=kpti
+
+text
+skipx
+zerombr
+
+clearpart --all --initlabel
+autopart
+
+auth  --useshadow  --enablemd5
+firstboot --disabled
+reboot --eject
+
+%packages --ignoremissing
+@core
+bzip2
+kernel-devel
+kernel-headers
+gcc
+make
+net-tools
+patch
+perl
+curl
+wget
+nfs-utils
+yum-autoupdate
+-ipw2100-firmware
+-ipw2200-firmware
+-ivtv-firmware
+%end
+

--- a/templates/centos/7.5/x86_64/vars.json
+++ b/templates/centos/7.5/x86_64/vars.json
@@ -1,0 +1,14 @@
+{
+    "template_name"                         : "centos-7.5-x86_64",
+    "template_os"                           : "rhel7-64",
+    "beakerhost"                            : "centos7-64",
+    "version"                               : "0.0.1",
+    "iso_url"                               : "http://centos.mirror.nucleus.be/7.5.1804/isos/x86_64/CentOS-7-x86_64-DVD-1804.iso",
+    "iso_checksum"                          : "506e4e06abf778c3435b4e5745df13e79ebfc86565d7ea1e128067ef6b5a6345",
+    "iso_checksum_type"                     : "sha256",
+    "docker_base_image"                     : "centos:7.5.1804",
+    "virtualbox_base_template_os"           : "RedHat_64",
+    "vmware_vsphere_nocm_vmx_data_memsize"  : "4096",
+    "vmware_vsphere_nocm_vmx_data_numvcpus" : "2",
+    "puppet_aio"                            : "http://yum.puppetlabs.com/el/7/PC1/x86_64/puppet-agent-1.10.9-1.el7.x86_64.rpm"
+}


### PR DESCRIPTION
I looked at the release notes for CentOS 7.5 to confirm any changes that might cause issues.

1. I added the kpti kernel flag so that images are secure by default. I'm not sure if that matters as much for VMs or not.