### PR TITLE
(IMAGES-890) Fix PE Driver Paths for 2008/7 builds

### DIFF
--- a/templates/win/common/files/AutoUnattendTemplate.xml
+++ b/templates/win/common/files/AutoUnattendTemplate.xml
@@ -11,10 +11,18 @@
     <settings pass="windowsPE">
        <component name="Microsoft-Windows-PnpCustomizationsWinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <DriverPaths>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="A">
+              <PackerDriversVersion OSDriverPlatform="Vista">
+                <PathAndCredentials wcm:action="add" wcm:keyValue="0">
+                    <!-- pvscsi Driver location on vmware tools DVD-->
+                    <Path>E:\Program Files\VMware\VMware Tools\Drivers\pvscsi\Vista</Path>
+                </PathAndCredentials>
+              </PackerDriversVersion>
+              <PackerDriversVersion OSDriverPlatform="Win8">
+                <PathAndCredentials wcm:action="add" wcm:keyValue="0">
                     <!-- pvscsi Driver location on vmware tools DVD-->
                     <Path>E:\Program Files\VMware\VMware Tools\Drivers\pvscsi\Win8</Path>
                 </PathAndCredentials>
+              </PackerDriversVersion>
             </DriverPaths>
         </component>
         <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -323,9 +331,18 @@
         <!-- Added for driver injection. Typically for NICs and Mass Storage -->
         <component name="Microsoft-Windows-PnpCustomizationsNonWinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <DriverPaths>
+              <PackerDriversVersion OSDriverPlatform="Vista">
                 <PathAndCredentials wcm:action="add" wcm:keyValue="0">
+                    <!-- pvscsi Driver location on vmware tools DVD-->
+                    <Path>E:\Program Files\VMware\VMware Tools\Drivers\pvscsi\Vista</Path>
+                </PathAndCredentials>
+              </PackerDriversVersion>
+              <PackerDriversVersion OSDriverPlatform="Win8">
+                <PathAndCredentials wcm:action="add" wcm:keyValue="0">
+                    <!-- pvscsi Driver location on vmware tools DVD-->
                     <Path>E:\Program Files\VMware\VMware Tools\Drivers\pvscsi\Win8</Path>
                 </PathAndCredentials>
+              </PackerDriversVersion>
             </DriverPaths>
         </component>
     </settings>

--- a/templates/win/common/files/Autounattend.xslt
+++ b/templates/win/common/files/Autounattend.xslt
@@ -18,6 +18,19 @@
   <xsl:param name="WinRmPassword" />
   <xsl:param name="Locale" />
 
+
+  <!-- Some logic to set the correct OSDriverPlatform variable so we can choose correct PE drivers to load -->
+  <xsl:variable name="OSDriverPlatform">
+    <xsl:choose>
+      <xsl:when test="$WindowsVersion = 'Windows-2008' or $WindowsVersion = 'Windows-2008r2' or $WindowsVersion = 'Windows-7' " >
+        <xsl:value-of select="'Vista'" />
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'Win8'" />
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:variable>
+
   <!-- General match everything unless matched by more specific rules below -->
   <xsl:template match="@*|node()">
     <xsl:copy>
@@ -34,6 +47,15 @@
       </xsl:attribute>
       <xsl:apply-templates select="node()"/>
     </xsl:copy>
+  </xsl:template>
+
+  <!-- Rule to select correct driver paths for PE phase -->
+  <xsl:template match='u:unattend/u:settings/u:component[@name="Microsoft-Windows-PnpCustomizationsWinPE"]/u:DriverPaths/u:PackerDriversVersion |
+                       u:unattend/u:settings/u:component[@name="Microsoft-Windows-PnpCustomizationsNonWinPE"]/u:DriverPaths/u:PackerDriversVersion'>
+      <xsl:if test="@OSDriverPlatform=$OSDriverPlatform">
+        <!-- Strip out PackerLogonSequence once selected to present valid Unattend.xml -->
+        <xsl:copy-of select="node()" />
+      </xsl:if>
   </xsl:template>
 
   <!-- Rule to select disk configuration -->


### PR DESCRIPTION
Windows builds earlier than Win-8 (i.e. Win-2008, 2008R2 and 7) need to
use Vista Driver paths for the initial PE phase on vsphere-iso so that
the pvcsci drivers are loaded and the hard drive is visible.

Use similar method to what is used for Platform/firmware selection to
make this choice.

DriverPaths are only needed for the initial autounattend file and not
the post-clone one.