### PR TITLE
(MAINT) Update CPU/svga build parameters

### DIFF
--- a/templates/win/10-ent/i386/vars.json
+++ b/templates/win/10-ent/i386/vars.json
@@ -4,7 +4,7 @@
     "beakerhost"        : "windows10ent-32",
     "vbox_guest_os"     : "Windows10",
     "vmware_guest_os"   : "windows8",
-    "vsphere_guest_os"  : "windows9_32Guest",
+    "vsphere_guest_os"  : "windows9Guest",
     "windows_version"   : "Windows-10",
     "image_name"        : "Windows 10 Enterprise",
     "product_key"       : "NPPR9-FWDCX-D2C8J-H872K-2YT43",

--- a/templates/win/common/vmware.vcenter.cygwin.json
+++ b/templates/win/common/vmware.vcenter.cygwin.json
@@ -56,6 +56,7 @@
       "convert_to_template"    : "{{user `convert_to_template`}}",
       "folder"                 : "{{user `packer_vcenter_folder`}}",
       "CPUs"                   : "{{user `numvcpus`}}",
+      "CPU_limit"              : -1,
       "RAM"                    : "{{user `memsize`}}",
       "RAM_reserve_all"        : "{{user `RAM_reserve_all`}}",
       "network"                : "{{user `packer_vcenter_net`}}",
@@ -108,7 +109,12 @@
         "time.synchronize.shrink"                  : "FALSE",
         "time.synchronize.tools.startup"           : "FALSE",
         "time.synchronize.tools.enable"            : "FALSE",
-        "time.synchronize.resume.host"             : "FALSE"
+        "time.synchronize.resume.host"             : "FALSE",
+
+        "svga.vramSize"                            : "134217728",
+        "svga.autodetect"                          : "FALSE",
+        "svga.maxWidth"                            : "1680",
+        "svga.maxHeight"                           : "1050"
       }
     }
   ],


### PR DESCRIPTION
The vcenter builds hang either shortly after boot, or in windows-10
during the cumulative update. This appears to be the behaviour noted in
https://github.com/jetbrains-infra/packer-builder-vsphere/issues/119 so applying the recommended fix there.

Also added svga parameters to help correct the console connect issues
associated with the above problem.

Also trivial fix for win-10 32bit Guest ID