### PR TITLE
(IMAGES-905) Bump Fedora 28 template version

### DIFF
--- a/templates/fedora/28/x86_64/vars.json
+++ b/templates/fedora/28/x86_64/vars.json
@@ -2,7 +2,7 @@
     "template_name"                         : "fedora-28-x86_64",
     "template_os"                           : "fedora-64",
     "beakerhost"                            : "fedora28-64",
-    "version"                               : "0.0.3",
+    "version"                               : "0.0.4",
     "iso_url"                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/Fedora-Server-dvd-x86_64-28-1.1.iso",
     "iso_checksum"                          : "8d59a25052e05758c15fe9daa3bc472b5619791b442e752450bba7f1eeca9c1a",
     "iso_checksum_type"                     : "sha256",


### PR DESCRIPTION
We need a new version to run through our CI pipeline to pick up some
fixes that now properly escape setting the root password via environment
variables during the image build.