### PR TITLE
(IMAGES-907) VMX Paramter changes to reflect recent vcenter upgrade

### DIFF
--- a/templates/win/common/gen-xslt.sh
+++ b/templates/win/common/gen-xslt.sh
@@ -14,7 +14,12 @@ export PACKER_WIN_VERSION=`jq -r .windows_version vars.json`
 
 # Firmware if needed - otherwise default to "efi"
 export PACKER_FIRMWARE=`jq -r '.firmware //empty' vars.json`
-[ -z "${PACKER_FIRMWARE}" ] && export PACKER_FIRMWARE="efi"
+# This is A TEMPORARY HACK to handle an issue with the Esxi 6.7 upgrade
+# that isn't handling the firmware settings correctly on vCenter.
+# So for vmware only - set the firmware to BIOS to ensure non-GPT
+# partitions are built. Virtualbox remains the same.
+[ -z "${PACKER_FIRMWARE}" -a "${IMAGE_PROVISIONER}" = "vmware" ] && export PACKER_FIRMWARE="bios"
+[ -z "${PACKER_FIRMWARE}" -a "${IMAGE_PROVISIONER}" = "virtualbox" ] && export PACKER_FIRMWARE="efi"
 
 # PACKER_WIN_PROC_ARCH defaults to "amd64" unless specified
 # These values are specific to the Autounattend.xml files and differ from

--- a/templates/win/common/scripts/common/windows-env.ps1
+++ b/templates/win/common/scripts/common/windows-env.ps1
@@ -586,7 +586,7 @@ Function Invoke-Reboot {
 Function Clear-RebootFiles {
   Remove-Item -Force -Path "$startup\packer-post-restart.bat"
   if ($WindowsServerCore ) {
-    Remove-Item -Force -Path $PROFILE
+    Remove-Item -Force -Path $PROFILE -ErrorAction SilentlyContinue
   }
 }
 

--- a/templates/win/common/vmware.vcenter.cygwin.json
+++ b/templates/win/common/vmware.vcenter.cygwin.json
@@ -3,7 +3,7 @@
     "template_config"           : "vcenter",
     "provisioner"               : "vmware",
 
-    "vm_version"                : "10",
+    "vm_version"                : "13",
     "disk_size"                 : "61440",
     "memsize"                   : "4096",
     "RAM_reserve_all"           : "true",


### PR DESCRIPTION
vcenter has been upgraded to 6.7 which has caused some vmx changes
especially to the firmware (EFI) selection.

Updates to allow the windows patch tuesday refresh.