### PR TITLE
(IMAGES-898) Switch off WSUS for Win-2012 as well

### DIFF
--- a/templates/win/common/scripts/bootstrap/start-pswindowsupdate.ps1
+++ b/templates/win/common/scripts/bootstrap/start-pswindowsupdate.ps1
@@ -24,7 +24,8 @@ If ( $WindowsServerCore ) {
 # required - this most reliable way to do this is with a reboot so we want to get this out the way first
 # to prevent windows update starting anything.
 # Windows-10/2016 seem to consistenly break on WSUS, so disable WSUS completely for these.
-if ($WindowsVersion -like $WindowsServer2016) {
+# Same seems to apply to win-2012 so disabling for this too.
+if ($WindowsVersion -like $WindowsServer2016 -or $WindowsVersion -like $WindowsServer2012) {
   Write-Output "Bypassing WSUS - Go Direct to Microsoft for updates"
 }
 else {


### PR DESCRIPTION
Having real problems getting windows update for win-2012, so go out to ms update
for this. Takes a while but seems to download a more consistent set of updates.

Need to revisit and parameterise this for later builds, esp. Slipstream.