### PR TITLE
(IMAGES-907) Fix vagrant output location

### DIFF
--- a/templates/win/common/virtualbox.base.vagrant.cygwin.json
+++ b/templates/win/common/virtualbox.base.vagrant.cygwin.json
@@ -8,10 +8,11 @@
     "memory_size"          : "2048",
     "cpu_count"            : "2",
 
-    "qa_root_passwd_plain"       : null,
+    "qa_root_passwd_plain" : null,
     "packer_sha"           : null,
     "packer_vm_src_dir"    : null,
-    "packer_vm_out_dir"    : null
+    "packer_vm_out_dir"    : null,
+    "packer_shared_dir"    : "/srv/packer/output"
   },
 
   "description": "Builds a Windows template VM for use in VirtualBox with Vagrant",
@@ -126,7 +127,7 @@
   ],
     "post-processors": [{
         "type"                : "vagrant",
-        "output"              : "{{user `packer_vm_out_dir`}}/output-{{build_name}}/{{user `template_name`}}-{{user `provisioner`}}-{{user `template_config`}}.box",
+        "output"              : "{{user `packer_shared_dir`}}/output-{{build_name}}/{{user `template_name`}}-{{user `provisioner`}}-{{user `template_config`}}.box",
         "vagrantfile_template": "tmp/vagrantfile-windows.template"
     }
   ]

--- a/templates/win/common/virtualbox.vagrant.cygwin.json
+++ b/templates/win/common/virtualbox.vagrant.cygwin.json
@@ -18,7 +18,8 @@
     "qa_root_passwd_plain" : null,
     "packer_sha"           : null,
     "packer_vm_src_dir"    : null,
-    "packer_vm_out_dir"    : null
+    "packer_vm_out_dir"    : null,
+    "packer_shared_dir"    : "/srv/packer/output" 
   },
 
   "description": "Builds a Windows template VM for use in VirtualBox with Vagrant",
@@ -177,7 +178,7 @@
   ],
     "post-processors": [{
         "type"                : "vagrant",
-        "output"              : "{{user `packer_vm_out_dir`}}/output-{{build_name}}/{{user `template_name`}}-{{user `provisioner`}}-{{user `template_config`}}.box",
+        "output"              : "{{user `packer_shared_dir`}}/output-{{build_name}}/{{user `template_name`}}-{{user `provisioner`}}-{{user `template_config`}}.box",
         "vagrantfile_template": "tmp/vagrantfile-windows.template"
     }
   ]


### PR DESCRIPTION
This broke somewhere along the new ci-platform-utils change - the
final .box file needs to be placed in the shared directory.

A proper fix will involve changes to ci-job-configs, but for the
moment, put in a default value to get the jobs through for August.