### PR TITLE
(IMAGES-916) Fix Path Delete Function

### DIFF
--- a/templates/win/common/scripts/common/windows-env.ps1
+++ b/templates/win/common/scripts/common/windows-env.ps1
@@ -215,18 +215,20 @@ Function ForceFullyDelete-Path {
   [String]$Path,
   [String]$LogFile
   )
-  
-  try {
-    if(Test-Path $Path) {
-        Write-Output "Removing $Path" >> $LogFile 2>&1
-        Takeown /d "$AnswerPromptYes" /R /f $Path >> $LogFile 2>&1
-        Icacls $Path /grant:r "*${WindowsAdminSID}:(OI)(CI)F" /t /c >> $LogFile 2>&1
-        Remove-Item $Path -Recurse -Force >> $LogFile 2>&1
+
+  process {
+    try {
+      if(Test-Path $Path) {
+          Write-Output "Removing $Path" >> $LogFile 2>&1
+          Takeown /d "$AnswerPromptYes" /R /f $Path >> $LogFile 2>&1
+          Icacls $Path /grant:r "*${WindowsAdminSID}:(OI)(CI)F" /t /c >> $LogFile 2>&1
+          Remove-Item $Path -Recurse -Force >> $LogFile 2>&1
+        }
       }
-    }
-    catch {
-        Write-Output "Ignoring Error deleting: $Path - Continue" >> $LogFile 2>&1
-    }
+      catch {
+          Write-Output "Ignoring Error deleting: $Path - Continue" >> $LogFile 2>&1
+      }
+  }
 }
 
 # Helper Function set Windows Update to use the Internal Production WSUS Server


### PR DESCRIPTION
Prior to this change, the ForcefullyDelete-Path function did not have
a `process` block. This caused a bug such that only the last directory
in a list given to the function via the pipeline was actually processed
and deleted. This change ensures that the full collection of directories
piped to the function are processed and deleted.

Manual testing was done to ensure that any errors encountered deleting
a directory would not cause the function to stop processing the
remaining items in a given collection.