### PR TITLE
(IMAGES-915) Add Mock-Platform build for JJB testing

### DIFF
--- a/templates/win/2019-mock/x86_64/files/platform-packages.ps1
+++ b/templates/win/2019-mock/x86_64/files/platform-packages.ps1
@@ -1,0 +1,9 @@
+$ErrorActionPreference = "Stop"
+
+. C:\Packer\Scripts\windows-env.ps1
+
+Write-Output "Running Win-2019 Mock Platform Generation"
+
+# Create the Mock Platform File.
+
+Touch-File "$PackerLogs\Mock.Platform"

--- a/templates/win/2019-mock/x86_64/vars.json
+++ b/templates/win/2019-mock/x86_64/vars.json
@@ -1,0 +1,15 @@
+{
+    "A_Comment"         : "This is preview so not all 2019 defs are available below",
+    "template_name"     : "win-2019-mock-x86_64",
+    "beakerhost"        : "windows2019-64",
+    "vbox_guest_os"     : "Windows2016_64",
+    "vmware_guest_os"   : "windows8srv-64",
+    "vsphere_guest_os"  : "windows9Server64Guest",
+    "windows_version"   : "Windows-2019",
+    "image_name"        : "Windows Server 2019 SERVERSTANDARD",
+    "product_key"       : "MFY9F-XBN2F-TYFMP-CCV49-RMYVH",
+    "iso_name"          : "/Windows_InsiderPreview_Server_vNext_en-us_17723.iso",
+    "iso_checksum_type" : "md5",
+    "iso_checksum"      : "593ef03364c7cd730f0ec89e322ab4ca",
+    "boot_command"      : "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter>"
+}

--- a/templates/win/common/scripts/bootstrap/start-pswindowsupdate.ps1
+++ b/templates/win/common/scripts/bootstrap/start-pswindowsupdate.ps1
@@ -168,6 +168,10 @@ Import-Module "$PackerStaging\PSWindowsUpdate\PSWindowsUpdate.psd1"
 # Windows-10 in particular seems to be affected by intermittency here - so try and improve reliability
 $Attempt = 1
 do {
+  if (Test-Path "$PackerLogs\Mock.Platform" ) {
+    Write-Output "Test Platform Build - exiting"
+    break
+  }
   Write-Output "Windows Update Pass $Attempt"
   try {
     # Need to handle Powershell 2 compatibility issue here - Unblock-File is used but not

--- a/templates/win/common/scripts/provisioners/clean-disk-dism.ps1
+++ b/templates/win/common/scripts/provisioners/clean-disk-dism.ps1
@@ -2,6 +2,11 @@ $ErrorActionPreference = 'Stop'
 
 . C:\Packer\Scripts\windows-env.ps1
 
+if (Test-Path "$PackerLogs\Mock.Platform" ) {
+  Write-Output "Test Platform Build - exiting"
+  exit 0
+}
+
 $SpaceAtStart = [Math]::Round( ((Get-WmiObject win32_logicaldisk | where { $_.DeviceID -eq $env:SystemDrive }).FreeSpace)/1GB, 2)
 
 #Set all CleanMgr VolumeCache keys to StateFlags = 0 to prevent cleanup. After, set the proper keys to 2 to allow cleanup.

--- a/templates/win/common/scripts/provisioners/clean-disk-sdelete.ps1
+++ b/templates/win/common/scripts/provisioners/clean-disk-sdelete.ps1
@@ -2,9 +2,13 @@ $ErrorActionPreference = 'Stop'
 
 . C:\Packer\Scripts\windows-env.ps1
 
+if (Test-Path "$PackerLogs\Mock.Platform" ) {
+    Write-Output "Test Platform Build - exiting"
+    exit 0
+}
+
 # This is using a revised Disk Zero script instead of sdelete.
 # Script obtained and modified from: http://www.hurryupandwait.io/blog/how-can-we-most-optimally-shrink-a-windows-base-image
-
 
 # Add in Optimize-Volume if this is present.
 if (Get-Command -ErrorAction SilentlyContinue Optimize-Volume ) {

--- a/templates/win/common/scripts/provisioners/cleanup-host.ps1
+++ b/templates/win/common/scripts/provisioners/cleanup-host.ps1
@@ -4,6 +4,11 @@ $ErrorActionPreference = 'Stop'
 
 . C:\Packer\Scripts\windows-env.ps1
 
+if (Test-Path "$PackerLogs\Mock.Platform" ) {
+  Write-Output "Test Platform Build - exiting"
+  exit 0
+}
+
 $SpaceAtStart = [Math]::Round( ((Get-WmiObject win32_logicaldisk | where { $_.DeviceID -eq $env:SystemDrive }).FreeSpace)/1GB, 2)
 
 Write-Output "Uninstalling Puppet Agent..."

--- a/templates/win/common/scripts/provisioners/puppet-configure.ps1
+++ b/templates/win/common/scripts/provisioners/puppet-configure.ps1
@@ -6,6 +6,11 @@ $ErrorActionPreference = "Stop"
 
 . C:\Packer\Scripts\windows-env.ps1
 
+if (Test-Path "$PackerLogs\Mock.Platform" ) {
+  Write-Output "Test Platform Build - exiting"
+  exit 0
+}
+
 Write-Output "Installing Puppet Agent..."
 if ("$ARCH" -eq "x86") {
   $PuppetMSIUrl = "https://downloads.puppetlabs.com/windows/puppet-agent-x86-latest.msi"


### PR DESCRIPTION
This is a partial "quick" windows platform build with enough
components, i.e. Cygwin and ssh settings but nothing else to
provide a fast build template for JJB testing.