### PR TITLE
(IMAGES-917) Seperate the bootstrap stage from win update

### DIFF
--- a/templates/win/2008/x86_64/vmware.vcenter.cygwin.json
+++ b/templates/win/2008/x86_64/vmware.vcenter.cygwin.json
@@ -80,7 +80,7 @@
         "./files/platform-packages.ps1",
         "../../common/scripts/common/windows-env.ps1",
         "../../common/scripts/bootstrap/bootstrap-base.bat",
-        "../../common/scripts/bootstrap/start-pswindowsupdate.ps1",
+        "../../common/scripts/bootstrap/bootstrap-packerbuild.ps1",
         "../../common/scripts/bootstrap/shutdown-packerbuild.ps1",
         "../../common/scripts/bootstrap/startup-profile.ps1"
       ],
@@ -121,14 +121,9 @@
   "provisioners": [
     {
       "type": "powershell",
-      "remote_path": "{{user `packer_downloads_dir`}}/print-pswindowslog.ps1",
       "elevated_user": "{{user `winrm_username`}}",
       "elevated_password": "{{user `winrm_password`}}",
-      "inline": [
-        "Write-Output 'Executing Powershell Script: print-pswindowslog.ps1'",
-        "Get-Content C:\\Packer\\Logs\\start-pswindowsupdate.log | foreach {Write-Output $_}",
-        "Start-Sleep -Seconds 10"
-      ]
+      "script" : "../../common/scripts/provisioners/test-bootstrap.ps1"
     },
     {
       "type": "file",
@@ -147,8 +142,8 @@
     },
     {
       "type": "file",
-      "source": "../../common/scripts/bootstrap/shutdown-packerbuild.ps1",
-      "destination": "C:\\Packer\\Scripts\\shutdown-packerbuild.ps1"
+      "source": "../../common/scripts/bootstrap/",
+      "destination": "C:\\Packer\\Scripts"
     },
     {
       "type": "file",
@@ -164,6 +159,22 @@
       "type": "file",
       "source": "./tmp/post-clone.autounattend.xml",
       "destination": "C:\\Packer\\Config\\post-clone.autounattend.xml"
+    },
+    {
+      "type": "powershell",
+      "elevated_user": "{{user `winrm_username`}}",
+      "elevated_password": "{{user `winrm_password`}}",
+      "script" : "../../common/scripts/provisioners/initiate-windows-update.ps1"
+    },
+    {
+      "type" : "windows-restart",
+      "restart_timeout" : "{{user `winupdate_timeout`}}"
+    },
+    {
+      "type": "powershell",
+      "elevated_user": "{{user `winrm_username`}}",
+      "elevated_password": "{{user `winrm_password`}}",
+      "script" : "../../common/scripts/provisioners/test-windows-update.ps1"
     },
     {
       "type": "powershell",

--- a/templates/win/2008r2-wmf5/x86_64/files/platform-packages.ps1
+++ b/templates/win/2008r2-wmf5/x86_64/files/platform-packages.ps1
@@ -4,6 +4,12 @@ $ErrorActionPreference = "Stop"
 
 Write-Output "Running Win-2008r2 WMF5.1 Package Customisation"
 
+# WMF5 requires .Net 4.5.2 as a min, so install latest .dotnet here and now.
+Install-DotNetLatest
+if (Test-PendingReboot) {
+  Invoke-Reboot
+}
+
 if (-not (Test-Path "$PackerLogs\NET35.installed"))
 {
   # Enable .Net 3.5 (needed for Puppet csc compiles)

--- a/templates/win/7-wmf5/x86_64/files/platform-packages.ps1
+++ b/templates/win/7-wmf5/x86_64/files/platform-packages.ps1
@@ -4,6 +4,12 @@ $ErrorActionPreference = "Stop"
 
 Write-Output "Running Win-7 Package Customisation"
 
+# WMF5 requires .Net 4.5.2 as a min, so install latest .dotnet here and now.
+Install-DotNetLatest
+if (Test-PendingReboot) {
+  Invoke-Reboot
+}
+
 if (-not (Test-Path "$PackerLogs\KB2852386.installed"))
 {
   # Install the WinSxS cleanup patch

--- a/templates/win/common/files/AutoUnattendTemplate.xml
+++ b/templates/win/common/files/AutoUnattendTemplate.xml
@@ -274,7 +274,7 @@
                         <Order>5</Order>
                     </SynchronousCommand>
                     <SynchronousCommand wcm:action="add">
-                        <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\start-pswindowsupdate.ps1 -HyperVisor vmware &gt;&gt; C:\Packer\Logs\start-pswindowsupdate.log 2&gt;&amp;1</CommandLine>
+                        <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\bootstrap-packerbuild.ps1 -HyperVisor vmware &gt;&gt; C:\Packer\Logs\bootstrap-packerbuild.log 2&gt;&amp;1</CommandLine>
                         <Description>Start PSWindowsUpdate</Description>
                         <Order>6</Order>
                     </SynchronousCommand>
@@ -305,7 +305,7 @@
                         <Order>5</Order>
                     </SynchronousCommand>
                    <SynchronousCommand wcm:action="add">
-                        <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\start-pswindowsupdate.ps1 -HyperVisor virtualbox &gt;&gt; C:\Packer\Logs\start-pswindowsupdate.log 2&gt;&amp;1</CommandLine>
+                        <CommandLine>cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\bootstrap-packerbuild.ps1 -HyperVisor virtualbox &gt;&gt; C:\Packer\Logs\bootstrap-packerbuild.log 2&gt;&amp;1</CommandLine>
                         <Description>Start PSWindowsUpdate</Description>
                         <Order>6</Order>
                     </SynchronousCommand>

--- a/templates/win/common/scripts/bootstrap/packer-windows-update.ps1
+++ b/templates/win/common/scripts/bootstrap/packer-windows-update.ps1
@@ -1,0 +1,89 @@
+# Continous loop script to execute Windows update.
+# Once completed, cancel the scheduled task and start win-rm
+
+
+$ErrorActionPreference = 'Stop'
+
+. C:\Packer\Scripts\windows-env.ps1
+
+
+$rundate = Get-Date
+write-output "Script: packer-windows-update.ps1 Starting at: $rundate"
+
+# Install latest .Net package prior to any windows updates.
+Install-DotNetLatest
+if (Test-PendingReboot) {
+  Invoke-Reboot
+}
+
+# Run the (Optional) Installation Package File.
+
+if (Test-Path "A:\platform-packages.ps1")
+{
+  & "A:\platform-packages.ps1"
+}
+else {
+  Write-Warning "No additional packages found in $PackageDir"
+}
+
+# Run Windows Update - this will repeat as often as needed through the Invoke-Reboot cycle.
+# When no more reboots are needed, the script falls through to the end.
+Write-Output "Searching for Windows Updates"
+if ($WindowsVersion -like $WindowsServer2016) {
+  Write-Output "Disabling some more Windows Update (10) parameters"
+  Write-Output "Disable seeding of updates to other computers via Group Policies"
+  force-mkdir "HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeliveryOptimization"
+  Set-ItemProperty "HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeliveryOptimization" "DODownloadMode" 0
+}
+
+Write-Output "Using PSWindowsUpdate module"
+Import-Module "$PackerStaging\PSWindowsUpdate\PSWindowsUpdate.psd1"
+
+# Repeat this command twice to ensure any interrupted downloads are re-attempted for install.
+# Windows-10 in particular seems to be affected by intermittency here - so try and improve reliability
+$Attempt = 1
+do {
+  if (Test-Path "$PackerLogs\Mock.Platform" ) {
+    Write-Output "Test Platform Build - exiting"
+    break
+  }
+  Write-Output "Windows Update Pass $Attempt"
+  try {
+    # Need to handle Powershell 2 compatibility issue here - Unblock-File is used but not
+    # present in PS2
+    if ($psversiontable.psversion.major -eq 2) {
+      Get-WUInstall -AcceptAll -UpdateType Software -IgnoreReboot -Erroraction SilentlyContinue
+      Write-Output "Running PSWindows Update - Ignoring errors (PS2)"
+    }
+    else {
+      Write-Output "Running PSWindows Update"
+      Get-WUInstall -AcceptAll -UpdateType Software -IgnoreReboot
+    }
+    if (Test-PendingReboot) { 
+      Invoke-Reboot 
+    }
+  }
+  catch {
+    Write-Warning "ERROR updating Windows"
+    # Code here to trap error and fall out of process dumping log.
+  }
+  $Attempt++
+} while ($Attempt -le 2)
+
+# Run the Application Package Cleaner
+if (Test-Path "$PackerLogs\AppsPackageRemove.Required") {
+  Write-Output "Running Apps Package Cleaner post windows update"
+  Remove-AppsPackages -AppPackageCheckpoint AppsPackageRemove.Pass1
+}
+
+# Windows Update Cycle complete - delete this task.
+Write-Output "Deleting Bootstrap Scheduled Task"
+schtasks /Delete /tn PackerWinUpdate /F
+
+# Enable WinRM so Packer control will resume after reboot.
+Set-Service "WinRM" -StartupType Automatic
+Write-Output "WinRM Enabled - Packer will resume next reboot"
+
+# Restart computer using shutdown command (PS2/3 compatibility)
+Write-Output "Proceeding with Shutdown"
+shutdown /t 0 /r /f

--- a/templates/win/common/scripts/provisioners/initiate-windows-update.ps1
+++ b/templates/win/common/scripts/provisioners/initiate-windows-update.ps1
@@ -1,0 +1,43 @@
+
+# Initiate the Windows Update operation.
+
+$ErrorActionPreference = 'Stop'
+
+. C:\Packer\Scripts\windows-env.ps1
+
+Write-Output "Setting up Windows Update"
+
+# Important Pre-requisite right across the packer  including Windows Update.
+if (-not (Test-Path "$PackerLogs\7zip.installed")) {
+  # Download and install 7za now as its needed here and is useful going forward.
+  $SevenZipInstaller = "7z1604-$ARCH.exe"
+  Write-Output "Installing 7zip $SevenZipInstaller"
+  Download-File "https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/7zip/$SevenZipInstaller"  "$Env:TEMP\$SevenZipInstaller"
+  Start-Process -Wait "$Env:TEMP\$SevenZipInstaller" @SprocParms -ArgumentList "/S"
+  Touch-File "$PackerLogs\7zip.installed"
+  Write-Output "7zip Installed"
+}
+
+if (-not (Test-Path "$PackerLogs\PSWindowsUpdate.installed")) {
+  # Download and install PSWindows Update Modules.
+  Download-File "https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/pswindowsupdate/PSWindowsUpdate.1.6.1.1.zip" "$Env:TEMP/pswindowsupdate.zip"
+  mkdir -Path "$Env:TEMP\PSWindowsUpdate"
+  $zproc = Start-Process "$7zip" @SprocParms -ArgumentList "x $Env:TEMP/pswindowsupdate.zip -y -o$PackerStaging"
+  $zproc.WaitForExit()
+  Touch-File "$PackerLogs\PSWindowsUpdate.installed"
+}
+
+Write-Output "========== Initiating Windows Update ========"
+Write-Output "========== This will take some time  ========"
+Write-Output "========== a log and update report   ========"
+Write-Output "========== will be given at the end  ========"
+Write-Output "========== of the update cycle       ========"
+
+
+$AdminUser = "Administrator"
+$AdminPassword = "PackerAdmin"
+Write-Output "Create Bootstrap Scheduled Task"
+schtasks /create /tn PackerWinUpdate /rl HIGHEST /ru "$AdminUser" /RP "$AdminPassword" /IT /F /SC ONSTART /DELAY 0000:20 /TR 'cmd /c c:\WINDOWS\system32\WindowsPowerShell\v1.0\powershell.exe -sta -WindowStyle Normal -ExecutionPolicy Bypass -NonInteractive -NoProfile -File C:\Packer\Scripts\packer-windows-update.ps1 >> C:\Packer\Logs\windows-update.log'
+
+# Disable WinRM until further notice.
+Set-Service "WinRM" -StartupType Disabled

--- a/templates/win/common/scripts/provisioners/test-bootstrap.ps1
+++ b/templates/win/common/scripts/provisioners/test-bootstrap.ps1
@@ -1,0 +1,6 @@
+# Tests the effectiveness of the bootstrap operation.
+# for the moment just print out the logs.
+
+Get-Content -Path C:\Packer\Logs\bootstrap-packerbuild.log | ForEach-Object {Write-Output $_}
+
+Start-Sleep -Seconds 10

--- a/templates/win/common/scripts/provisioners/test-windows-update.ps1
+++ b/templates/win/common/scripts/provisioners/test-windows-update.ps1
@@ -1,0 +1,9 @@
+# Tests the effectiveness of the bootstrap operation.
+# for the moment just print out the logs.
+
+Write-Output "Windows Update Completed"
+Write-Output "========== Windows Update Log START ========"
+Get-Content -Path C:\Packer\Logs\windows-update.log | ForEach-Object {Write-Output $_}
+Write-Output "========== Windows Update Log END ========"
+
+Start-Sleep -Seconds 10

--- a/templates/win/common/scripts/provisioners/vagrant-arm-host.ps1
+++ b/templates/win/common/scripts/provisioners/vagrant-arm-host.ps1
@@ -102,7 +102,7 @@ Invoke-Expression $CygwinMkpasswd | Out-File $CygwinPasswdFile -Force -Encoding 
 Invoke-Expression $CygwinMkgroup | Out-File $CygwinGroupFile -Force -Encoding "ASCII"
 
 #Snooze for a bit
-sleep -s 10
+Start-Sleep -s 10
 
 #Ensure sshd and WinRM services start after next book
 Write-Output "Starting SSH server!"

--- a/templates/win/common/vars.json
+++ b/templates/win/common/vars.json
@@ -5,7 +5,8 @@
 
   "winrm_username"      : "Administrator",
   "winrm_password"      : "PackerAdmin",
-  "winrm_timeout"       : "4h",
+  "winrm_timeout"       : "1h",
+  "winupdate_timeout"   : "300m",
   "shutdown_timeout"    : "1h",
   "firmware"            : "efi",
 

--- a/templates/win/common/vars.json
+++ b/templates/win/common/vars.json
@@ -1,5 +1,5 @@
 {
-  "version"             : "20180831_PROD",
+  "version"             : "20180910_DEV",
 
   "headless"            : "true",
 

--- a/templates/win/common/virtualbox.base.json
+++ b/templates/win/common/virtualbox.base.json
@@ -57,7 +57,7 @@
         "./files/platform-packages.ps1",
         "../../common/files/virtualbox/oracle-cert-1.cer",
         "../../common/scripts/common/windows-env.ps1",
-        "../../common/scripts/bootstrap/start-pswindowsupdate.ps1",
+        "../../common/scripts/bootstrap/bootstrap-packerbuild.ps1",
         "../../common/scripts/bootstrap/bootstrap-base.bat",
         "../../common/scripts/bootstrap/shutdown-packerbuild.ps1",
         "../../common/scripts/bootstrap/startup-profile.ps1"
@@ -67,12 +67,7 @@
   "provisioners": [
     {
       "type": "powershell",
-      "remote_path": "{{user `packer_downloads_dir`}}/print-pswindowslog.ps1",
-      "inline": [
-        "Write-Output 'Executing Powershell Script: print-pswindowslog.ps1'",
-        "Get-Content C:\\Packer\\Logs\\start-pswindowsupdate.log | foreach {Write-Output $_}",
-        "Start-Sleep -Seconds 10"
-      ]
+      "script" : "../../common/scripts/provisioners/test-bootstrap.ps1"
     },
     {
       "type": "file",

--- a/templates/win/common/virtualbox.slipstream.json
+++ b/templates/win/common/virtualbox.slipstream.json
@@ -62,7 +62,7 @@
         "../../common/files/virtualbox/oracle-cert-1.cer",
         "../../common/scripts/common/windows-env.ps1",
         "../../common/scripts/provisioners/generate-slipstream.ps1",
-        "../../common/scripts/bootstrap/start-pswindowsupdate.ps1",
+        "../../common/scripts/bootstrap/bootstrap-packerbuild.ps1",
         "../../common/scripts/bootstrap/bootstrap-base.bat",
         "../../common/scripts/bootstrap/core-shutdown.ps1",
         "../../common/scripts/bootstrap/startup-profile.ps1"
@@ -72,12 +72,7 @@
   "provisioners": [
     {
       "type": "powershell",
-      "remote_path": "{{user `packer_download_dir`}}/print-pswindowslog.ps1",
-      "inline": [
-        "Write-Output 'Executing Powershell Script: print-pswindowslog.ps1'",
-        "Get-Content C:\\Packer\\Logs\\start-pswindowsupdate.log | foreach {Write-Output $_}",
-        "Start-Sleep -Seconds 10"
-      ]
+      "script" : "../../common/scripts/provisioners/test-bootstrap.ps1"
     },
     {
       "type": "powershell",

--- a/templates/win/common/virtualbox.vagrant.cygwin.json
+++ b/templates/win/common/virtualbox.vagrant.cygwin.json
@@ -56,7 +56,7 @@
         "./files/platform-packages.ps1",
         "../../common/files/virtualbox/oracle-cert-1.cer",
         "../../common/scripts/common/windows-env.ps1",
-        "../../common/scripts/bootstrap/start-pswindowsupdate.ps1",
+        "../../common/scripts/bootstrap/bootstrap-packerbuild.ps1",
         "../../common/scripts/bootstrap/bootstrap-base.bat",
         "../../common/scripts/bootstrap/shutdown-packerbuild.ps1",
         "../../common/scripts/bootstrap/startup-profile.ps1"
@@ -65,13 +65,8 @@
   ],
   "provisioners": [
     {
-      "type": "powershell",
-      "remote_path": "{{user `packer_downloads_dir`}}/print-pswindowslog.ps1",
-      "inline": [
-        "Write-Output 'Executing Powershell Script: print-pswindowslog.ps1'",
-        "Get-Content C:\\Packer\\Logs\\start-pswindowsupdate.log | foreach {Write-Output $_}",
-        "Start-Sleep -Seconds 10"
-      ]
+        "type": "powershell",
+        "script" : "../../common/scripts/provisioners/test-bootstrap.ps1"
     },
     {
         "type": "file",
@@ -99,9 +94,16 @@
         "destination": "C:\\Packer\\scripts"
     },
     {
-        "type": "file",
-        "source": "../../common/scripts/bootstrap/shutdown-packerbuild.ps1",
-        "destination": "C:\\Packer\\Scripts\\shutdown-packerbuild.ps1"
+        "type": "powershell",
+        "script" : "../../common/scripts/provisioners/initiate-windows-update.ps1"
+    },
+    {
+        "type" : "windows-restart",
+        "restart_timeout" : "{{user `winupdate_timeout`}}"
+    },
+    {
+        "type": "powershell",
+        "script" : "../../common/scripts/provisioners/test-windows-update.ps1"
     },
     {
         "type"   : "powershell",

--- a/templates/win/common/vmware.base.json
+++ b/templates/win/common/vmware.base.json
@@ -54,7 +54,7 @@
         "./files/platform-packages.ps1",
         "../../common/scripts/common/windows-env.ps1",
         "../../common/scripts/bootstrap/bootstrap-base.bat",
-        "../../common/scripts/bootstrap/start-pswindowsupdate.ps1",
+        "../../common/scripts/bootstrap/bootstrap-packerbuild.ps1",
         "../../common/scripts/bootstrap/shutdown-packerbuild.ps1",
         "../../common/scripts/bootstrap/startup-profile.ps1"
       ],
@@ -98,12 +98,7 @@
   "provisioners": [
     {
       "type": "powershell",
-      "remote_path": "{{user `packer_download_dir`}}/print-pswindowslog.ps1",
-      "inline": [
-        "Write-Output 'Executing Powershell Script: print-pswindowslog.ps1'",
-        "Get-Content C:\\Packer\\Logs\\start-pswindowsupdate.log | foreach {Write-Output $_}",
-        "Start-Sleep -Seconds 10"
-      ]
+      "script" : "../../common/scripts/provisioners/test-bootstrap.ps1"
     },
     {
       "type": "file",

--- a/templates/win/common/vmware.slipstream.json
+++ b/templates/win/common/vmware.slipstream.json
@@ -52,7 +52,7 @@
         "../../common/scripts/common/windows-env.ps1",
         "../../common/scripts/provisioners/generate-slipstream.ps1",
         "../../common/scripts/bootstrap/bootstrap-base.bat",
-        "../../common/scripts/bootstrap/start-pswindowsupdate.ps1",
+        "../../common/scripts/bootstrap/bootstrap-packerbuild.ps1",
         "../../common/scripts/bootstrap/core-shutdown.ps1",
         "../../common/scripts/bootstrap/startup-profile.ps1"
     ],
@@ -97,12 +97,7 @@
   "provisioners": [
     {
       "type": "powershell",
-      "remote_path": "{{user `packer_download_dir`}}/print-pswindowslog.ps1",
-      "inline": [
-        "Write-Output 'Executing Powershell Script: print-pswindowslog.ps1'",
-        "Get-Content C:\\Packer\\Logs\\start-pswindowsupdate.log | foreach {Write-Output $_}",
-        "Start-Sleep -Seconds 10"
-      ]
+      "script" : "../../common/scripts/provisioners/test-bootstrap.ps1"
     },
     {
       "type": "powershell",

--- a/templates/win/common/vmware.vcenter.cygwin.json
+++ b/templates/win/common/vmware.vcenter.cygwin.json
@@ -80,7 +80,7 @@
         "./files/platform-packages.ps1",
         "../../common/scripts/common/windows-env.ps1",
         "../../common/scripts/bootstrap/bootstrap-base.bat",
-        "../../common/scripts/bootstrap/start-pswindowsupdate.ps1",
+        "../../common/scripts/bootstrap/bootstrap-packerbuild.ps1",
         "../../common/scripts/bootstrap/shutdown-packerbuild.ps1",
         "../../common/scripts/bootstrap/startup-profile.ps1"
       ],
@@ -121,12 +121,7 @@
   "provisioners": [
     {
       "type": "powershell",
-      "remote_path": "{{user `packer_downloads_dir`}}/print-pswindowslog.ps1",
-      "inline": [
-        "Write-Output 'Executing Powershell Script: print-pswindowslog.ps1'",
-        "Get-Content C:\\Packer\\Logs\\start-pswindowsupdate.log | foreach {Write-Output $_}",
-        "Start-Sleep -Seconds 10"
-      ]
+      "script" : "../../common/scripts/provisioners/test-bootstrap.ps1"
     },
     {
       "type": "file",
@@ -146,8 +141,8 @@
     },
     {
       "type": "file",
-      "source": "../../common/scripts/bootstrap/shutdown-packerbuild.ps1",
-      "destination": "C:\\Packer\\Scripts\\shutdown-packerbuild.ps1"
+      "source": "../../common/scripts/bootstrap/",
+      "destination": "C:\\Packer\\Scripts"
     },
     {
       "type": "file",
@@ -163,6 +158,18 @@
       "type": "file",
       "source": "./tmp/post-clone.autounattend.xml",
       "destination": "C:\\Packer\\Config\\post-clone.autounattend.xml"
+    },
+    {
+      "type": "powershell",
+      "script" : "../../common/scripts/provisioners/initiate-windows-update.ps1"
+    },
+    {
+      "type" : "windows-restart",
+      "restart_timeout" : "{{user `winupdate_timeout`}}"
+    },
+    {
+      "type": "powershell",
+      "script" : "../../common/scripts/provisioners/test-windows-update.ps1"
     },
     {
       "type": "powershell",


### PR DESCRIPTION
If a failure happens in the bootstrap phase, it won't get notified until
after a very long timeout period (several hours). So minimise the bootstrap
phase to just installing the hypervisor tools/drivers and any other minimal
network operations so that WinRM can be enabled and control passed back to
packer.

The Windows update phase is initiated later in a seperate phase using the
technique successfully used with the Appveyor build, where WinRm is disabled
just before a packer-reboot provider to allow a further reboot cycle. This
cycle is ended by re-enabling WinRM - thus allowing Windows Update to use as
many reboots as needed.

Also - have changed the startup/reboot sequence to use a Scheduled Task on
Startup to continue the sequence across multiple reboots. This has the
added advantage of being able to run the script elevated, thus getting
round the restriction that WSUS cannot be used across WinRM sessions.

It has also allowed the removal of the $PROFILE Core edition workaround.

This gives a more immediate experience to the jenkins log that the boot sequence
has completed at least.