### PR TITLE
(IMAGES-909) Set firmware for vCenter builds to efi

### DIFF
--- a/templates/win/common/vars.json
+++ b/templates/win/common/vars.json
@@ -1,5 +1,5 @@
 {
-  "version"             : "20180920_DEV",
+  "version"             : "20181003_DEV",
 
   "headless"            : "true",
 

--- a/templates/win/common/vmware.vcenter.cygwin.json
+++ b/templates/win/common/vmware.vcenter.cygwin.json
@@ -40,7 +40,7 @@
 
   "builders": [
     {
-      "type": "vsphere-iso",
+      "type": "vsphere-puppet-iso",
 
       "name"                   : "{{user `template_name`}}-{{user `provisioner`}}-{{user `template_config`}}",
       "vm_name"                : "{{user `template_name`}}-{{user `version`}}",
@@ -55,6 +55,7 @@
       "host"                   : "{{user `packer_vcenter_build_host`}}",
       "convert_to_template"    : "{{user `convert_to_template`}}",
       "folder"                 : "{{user `packer_vcenter_folder`}}",
+      "firmware"               : "{{user `firmware`}}",
       "CPUs"                   : "{{user `numvcpus`}}",
       "CPU_limit"              : -1,
       "RAM"                    : "{{user `memsize`}}",
@@ -95,7 +96,6 @@
       "winrm_timeout"     : "{{user `winrm_timeout`}}",
 
       "configuration_parameters": {
-        "firmware"                                 : "{{user `firmware`}}",
 
         "gui.fitguestusingnativedisplayresolution" : "FALSE",
         "devices.hotplug"                          : "false",


### PR DESCRIPTION
Point the builder to use the new "puppet" build of the
packer-build-vsphere-iso plugin (which is deliberately
named as packer-build-vsphere-plugin-iso to disinguish that
we are using a custom puppet built one until such time as
jetbrains release a revised plugin.

Having the new plugin in place means that we can now direct
the firmware for vcenter builds to efi (except for win-2008
of course). The firmware setting is also removed from the
vmx parameters, where it appeared to cause problems with
ovftool and esxi 6.7