### PR TITLE
(maint) Add Solaris to bypass default case in repos.pp

### DIFF
--- a/manifests/modules/packer/manifests/vsphere/repos.pp
+++ b/manifests/modules/packer/manifests/vsphere/repos.pp
@@ -224,7 +224,11 @@ class packer::vsphere::repos inherits packer::vsphere::params {
         }
       }
     }
-    
+
+    solaris: {
+      # Solaris repo: http://solaris-11-reposync.delivery.puppetlabs.net:81 
+      # Added Solaris case so it wont execute default one & added solaris repo link in case we need it in the future.
+    }
   default: {
     fail( "Unsupported platform: ${::osfamily}/${::operatingsystem}" )
     }


### PR DESCRIPTION
This is needed to pass nocm and to not enter the default statement.