### PR TITLE
(maint) Update SLES 15 agent to use official released version

### DIFF
--- a/templates/sles/15/x86_64/vars.json
+++ b/templates/sles/15/x86_64/vars.json
@@ -8,5 +8,5 @@
     "iso_checksum_type"                     : "sha256",
     "vmware_vsphere_nocm_vmx_data_memsize"  : "6144",
     "vmware_vsphere_nocm_vmx_data_numvcpus" : "2",
-    "puppet_aio"                            : "http://buildsources.delivery.puppetlabs.net/sles-15-agent/puppet-agent-5.5.3.15.g3c4ced28-1.sles12.x86_64.rpm"
+    "puppet_aio"                            : "http://yum.puppetlabs.com/puppet5/sles/15/x86_64/puppet-agent-5.5.7-1.sles15.x86_64.rpm"
 }


### PR DESCRIPTION
During image development for SLES 15, I had to create a temporary agent
package that included important fixes in facter to detect SLES 15
correctly. Now that we've released our first official puppet5 package
for SLES 15, this updates the image build to use that package instead.