### PR TITLE
(IMAGES-974) WindowsUpdate Tests

### DIFF
--- a/templates/win/10-1511/x86_64/vars.json
+++ b/templates/win/10-1511/x86_64/vars.json
@@ -13,9 +13,9 @@
     "boot_command"      : "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait>",
 
     "CurrentVersion"    : "6.3",
-    "ProductName"       : "Windows 10 Enterprise",
-    "EditionID"         : "Enterprise",
+    "ProductName"       : "Windows 10 Enterprise 2015 LTSB",
+    "EditionID"         : "EnterpriseS",
     "InstallationType"  : "Client",
-    "ReleaseID"         : "1511"
+    "ReleaseID"         : "N/A"
 
 }

--- a/templates/win/10-1607/x86_64/vars.json
+++ b/templates/win/10-1607/x86_64/vars.json
@@ -13,8 +13,8 @@
     "boot_command"      : "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait>",
 
     "CurrentVersion"    : "6.3",
-    "ProductName"       : "Windows 10 Enterprise",
-    "EditionID"         : "Enterprise",
+    "ProductName"       : "Windows 10 Enterprise 2016 LTSB",
+    "EditionID"         : "EnterpriseS",
     "InstallationType"  : "Client",
     "ReleaseID"         : "1607"
 

--- a/templates/win/2012r2-core/x86_64/vars.json
+++ b/templates/win/2012r2-core/x86_64/vars.json
@@ -16,7 +16,7 @@
     "CurrentVersion"    : "6.3",
     "ProductName"       : "Windows Server 2012 R2 Standard",
     "EditionID"         : "ServerStandard",
-    "InstallationType"  : "ServerCore",
+    "InstallationType"  : "Server Core",
     "ReleaseID"         : "N/A"
 
 }

--- a/templates/win/2016-core/x86_64/vars.json
+++ b/templates/win/2016-core/x86_64/vars.json
@@ -15,7 +15,7 @@
     "CurrentVersion"    : "6.3",
     "ProductName"       : "Windows Server 2016 Standard",
     "EditionID"         : "ServerStandard",
-    "InstallationType"  : "ServerCore",
-    "ReleaseID"         : "1607"
+    "InstallationType"  : "Server Core",
+    "ReleaseID"         : "N/A"
 
 }

--- a/templates/win/common/scripts/acceptance/windows-update/WindowsUpdate.Tests.ps1
+++ b/templates/win/common/scripts/acceptance/windows-update/WindowsUpdate.Tests.ps1
@@ -1,0 +1,37 @@
+<#
+  .SYNOPSIS
+    Windows Update Tests
+  .DESCRIPTION
+    A set of tests that PsWindowsUpdate has run and actual
+    windows updates are installed.
+#>
+. C:\Packer\Scripts\windows-env.ps1
+
+Import-PsWindowsUpdateModule
+
+# Pull information from Windows Update operations.
+# Updates in last 12 hours (for very long update process)
+$WUHistory = get-wuhistory -Erroraction SilentlyContinue | Where-Object { [int]($(Get-Date) - $_.Date).TotalHours -le 12 }
+
+# Pending Update List.
+$WUUpdateList = get-WULIST -UpdateType Software -Erroraction SilentlyContinue -NotKBArticleID 'KB2267602'
+# Following to handle Win-2008r2/Win-7 which returns $null if no updates.
+If ([string]::IsNullOrEmpty($WUUpdateList)) { $WUUpdateList = @() }
+
+# Use "our" pending reboot check as the PSWU doesn't work under winrm
+$WinRebootStatus = Test-PendingReboot 
+
+describe 'Windows Update Validation Tests' {
+
+    it 'Should Have at least One recent Windows Update installed' {
+        $WUHistory.Count | Should BeGreaterThan 0
+    }
+
+    it 'Should not have any Windows Updates Pending' {
+        $WUUpdateList.Count | Should be 0
+    }
+
+    it 'Reboot Status should not be pending' {
+        $WinRebootStatus | Should be $false
+    }
+}

--- a/templates/win/common/scripts/common/windows-env.ps1
+++ b/templates/win/common/scripts/common/windows-env.ps1
@@ -593,10 +593,13 @@ Function Test-PendingReboot {
 
 # Helper Function to perform a reboot and continue the windows update process.
 Function Invoke-Reboot {
-  Write-Output "Proceeding with Shutdown"
+  $shutdate = Get-Date
+  Write-Output "Proceeding with Shutdown at: $shutdate"
   shutdown /t 0 /r /f
   # Sleep here to stop any further command execution.
   Start-Sleep -Seconds 20
+  Write-Output "Ok - we havent shutdown lets exit gracefully."
+  Exit 0
 }
 
 # Helper Function (from Boxstarter) to enable remote desktop
@@ -671,21 +674,16 @@ Function Install-PSWindowsUpdate {
   Write-Output "Ended PSWindowsUpdate Installation`n"
 }
 
-# Helper to install Windows Updates.
-Function Install-WindowsUpdates {
-  Write-Output "Starting Windows updates installation. This may takes a lot of time..."
+# Helper to import PsWindowsUpdate Module.
+Function Import-PsWindowsUpdateModule {
+  Write-Output "Importing PSWindowsUpdate module"
 
-  Import-Module PSWindowsUpdate
-  if ($psversiontable.psversion.major -eq 2) {
-    Write-Output "Running PSWindows Update - Ignoring errors (PS2)"
-    Get-WUInstall -AcceptAll -UpdateType Software -IgnoreReboot -Erroraction SilentlyContinue
+  if ($psversiontable.psversion.major -eq 2)
+  {
+    # Setting this alias for PS2 removes a benign error that causes Pester to barf.
+    Set-Alias -Name Unblock-File -Scope Global -Value Get-ChildItem
   }
-  else {
-    Write-Output "Running PSWindows Update"
-    Get-WUInstall -AcceptAll -UpdateType Software -IgnoreReboot
-  }
-
-  Write-Output "Ended Windows updates installation."
+  Import-Module -Global -Name "$PackerPsModules\PSWindowsUpdate\PSWindowsUpdate.psd1"
 }
 
 #Helper Function to handle the various OS dependant shutdown conditions.

--- a/templates/win/common/scripts/provisioners/initiate-windows-update.ps1
+++ b/templates/win/common/scripts/provisioners/initiate-windows-update.ps1
@@ -9,7 +9,6 @@
 
 #>
 
-
 # Initiate the Windows Update operation.
 
 $ErrorActionPreference = 'Stop'
@@ -28,11 +27,15 @@ if (-not (Test-Path "$PackerLogs\PSWindowsUpdate.installed")) {
   Touch-File "$PackerLogs\PSWindowsUpdate.installed"
 }
 
-Write-Output "========== Initiating Windows Update ========"
-Write-Output "========== This will take some time  ========"
-Write-Output "========== a log and update report   ========"
-Write-Output "========== will be given at the end  ========"
-Write-Output "========== of the update cycle       ========"
+if ($WindowsVersion -like $WindowsServer2016) {
+  Write-Output "Disabling some more Windows Update (10) parameters"
+  Write-Output "Disable seeding of updates to other computers via Group Policies"
+  force-mkdir "HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeliveryOptimization"
+  Set-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeliveryOptimization" -Name "DODownloadMode" -Value 0
+}
+
+Write-Output "========== Initiating Windows Update This will take some time                   ========"
+Write-Output "========== A log and update report will be given at the end of the update cycle ========"
 
 # Need to pick up Admin Username/Password from Environment for sched task
 Write-Output "Create Bootstrap Scheduled Task"

--- a/templates/win/common/vmware.vcenter.cygwin.json
+++ b/templates/win/common/vmware.vcenter.cygwin.json
@@ -165,13 +165,14 @@
           "C:/Packer/Scripts/test-packerbuild -TestPhase bootstrap-packerbuild"
         ],
         "environment_vars" : [
-            "PBTEST_WindowsCurrentVersion={{user `CurrentVersion`}}",
-            "PBTEST_WindowsProductName={{user `ProductName`}}",
-            "PBTEST_WindowsEditionID={{user `EditionID`}}",
-            "PBTEST_WindowsInstallationType={{user `InstallationType`}}",
-            "PBTEST_WindowsReleaseID={{user `ReleaseID`}}",
-            "PBTEST_WindowsMemorySize={{user `memsize`}}"
-          ]
+          "PBTEST_WindowsCurrentVersion={{user `CurrentVersion`}}",
+          "PBTEST_WindowsProductName={{user `ProductName`}}",
+          "PBTEST_WindowsEditionID={{user `EditionID`}}",
+          "PBTEST_WindowsInstallationType={{user `InstallationType`}}",
+          "PBTEST_WindowsReleaseID={{user `ReleaseID`}}",
+          "PBTEST_WindowsMemorySize={{user `memsize`}}"
+        ],
+      "valid_exit_codes" : [ 0 ]
     },
     {
       "type": "powershell",
@@ -191,10 +192,11 @@
         "C:/Packer/Scripts/test-packerbuild -TestPhase windows-update"
       ],
       "environment_vars" : [
-          "PBTEST_OSName={{user `XXXX`}}",
-          "PBTEST_Edition={{user `XXXX`}}",
-          "PBTEST_Build={{user `XXXX`}}"
-      ]
+        "PBTEST_OSName={{user `XXXX`}}",
+        "PBTEST_Edition={{user `XXXX`}}",
+        "PBTEST_Build={{user `XXXX`}}"
+      ],
+      "valid_exit_codes" : [ 0 ]
     },
     {
       "type": "powershell",


### PR DESCRIPTION
Add Smoke tests to verify that WindowsUpdate has happened including
1. Updates have been installed in the last 12 hours.
2. There are no pending updates.
3. There are no pending reboots

This update also resolves a serious issue with the windows update during the shutdown sequence (Invoke-Reboot) which allowed a second Get-WuInstall to run and interfere with the shutdown sequence.

Some cosmetic changes were also made to the Windows Update scripts associated with this work as well as minor fixes to the Windows Core builders for the ```Server Core``` type.