### PR TITLE
Ubuntu 14.04 should use vmware-tools instande of openvmtools

### DIFF
--- a/manifests/modules/packer/manifests/vmtools.pp
+++ b/manifests/modules/packer/manifests/vmtools.pp
@@ -2,7 +2,7 @@ class packer::vmtools inherits packer::vmtools::params {
 
   # At some point it's going to become more worthwhile to flip this so
   # installing open-vm-tools is the default.
-  if ( ($::osfamily == 'debian' and $::operatingsystemmajrelease in ['7', '8', '9', '16.04', '14.04', '18.04', '18.10']) or
+  if ( ($::osfamily == 'debian' and $::operatingsystemmajrelease in ['7', '8', '9', '16.04', '18.04', '18.10']) or
         ($::osfamily == 'redhat' and $::operatingsystemmajrelease in ['7', '25', '26', '27', '28']) or
         ($::osfamily == 'suse' and $::operatingsystemmajrelease in ['15'])
     ) {

--- a/templates/common/vmware.vsphere.nocm.json
+++ b/templates/common/vmware.vsphere.nocm.json
@@ -4,7 +4,6 @@
     "beakerhost"                                           : null,
     "version"                                              : null,
     "puppet_aio"                                           : null,
-    "pc_repo"                                              : null,
 
     "vmware_vsphere_nocm_required_modules"                 : null,
     "vmware_vsphere_nocm_vmx_data_memsize"                 : null,

--- a/templates/ubuntu/14.04/i386/vars.json
+++ b/templates/ubuntu/14.04/i386/vars.json
@@ -1,8 +1,8 @@
 {
-    "template_name"                         : "ubuntu-14.04-i386",
+    "template_name"                         : "ubuntu-1404-i386",
     "template_os"                           : "ubuntu",
     "beakerhost"                            : "ubuntu1404-32",
-    "version"                               : "0.0.6",
+    "version"                               : "0.0.7",
     "iso_url"                               : "http://osmirror.delivery.puppetlabs.net/iso/ubuntu-14.04.2-server-i386.iso",
     "iso_checksum"                          : "76524ab9502a34b983ed56af2d5a72835ce41aec1e2b4c0cb7788ef596958ed6",
     "iso_checksum_type"                     : "sha256",

--- a/templates/ubuntu/14.04/x86_64/vars.json
+++ b/templates/ubuntu/14.04/x86_64/vars.json
@@ -1,8 +1,8 @@
 {
-    "template_name"                         : "ubuntu-14.04-x86_64",
+    "template_name"                         : "ubuntu-1404-x86_64",
     "template_os"                           : "ubuntu-64",
     "beakerhost"                            : "ubuntu1404-64",
-    "version"                               : "0.0.6",
+    "version"                               : "0.0.7",
     "iso_url"                               : "http://osmirror.delivery.puppetlabs.net/iso/ubuntu-14.04.2-server-amd64.iso",
     "iso_checksum"                          : "8acd2f56bfcba2f7ac74a7e4a5e565ce68c024c38525c0285573e41c86ae90c0",
     "iso_checksum_type"                     : "sha256",

--- a/templates/ubuntu/common/vars.json
+++ b/templates/ubuntu/common/vars.json
@@ -1,5 +1,6 @@
 {
     "floppy_dirs"                          : "",
     "floppy_files"                         : "../common/files/preseed.cfg",
-    "vmware_vsphere_nocm_required_modules" : "puppetlabs-stdlib example42-network puppetlabs-apt"
+    "vmware_vsphere_nocm_required_modules" : "puppetlabs-stdlib example42-network puppetlabs-apt",
+    "tools_upload_flavor"                  : "linux"
 }


### PR DESCRIPTION
It seems that open-vm-tools causes Ubuntu 14.04 to error out in vmpooler. This PR removes the dependency on open-vm-tools and enables VMWare tools