### PR TITLE
fix solaris 11.4 dhcp renewal

### DIFF
--- a/manifests/modules/packer/manifests/vsphere/networking.pp
+++ b/manifests/modules/packer/manifests/vsphere/networking.pp
@@ -47,6 +47,6 @@ class packer::vsphere::networking inherits packer::networking::params {
           source => 'puppet:///modules/packer/vsphere/dhcp4.xml',
         }
       }
-    }    
+    }
   }
 }

--- a/manifests/modules/packer/templates/vsphere/rc.local
+++ b/manifests/modules/packer/templates/vsphere/rc.local
@@ -1,5 +1,5 @@
 #!/bin/sh -e
  
-( /etc/vsphere-bootstrap.rb ) 2>&1 | /usr/bin/tee /tmp/vsphere-bootstrap.log
+( /etc/vsphere-bootstrap.rb ) 2>&1 | /usr/bin/tee -a /tmp/vsphere-bootstrap.log
  
 exit 0

--- a/manifests/modules/packer/templates/vsphere/solaris.rb.erb
+++ b/manifests/modules/packer/templates/vsphere/solaris.rb.erb
@@ -19,4 +19,6 @@ Kernel.system("svcadm restart system/identity:node")
 puts '- Re-obtaining DHCP lease...'
 Kernel.system("ifconfig net0 dhcp release && ifconfig net0 dhcp start")
 
-Kernel.system("ipadm delete-addr -r net0/v4a && ipadm create-addr -T dhcp -h #{hostname} net0/v4a")
+Kernel.system("ipadm delete-addr -r net0/v4 || true")
+Kernel.system("ipadm delete-addr -r net0/v4a || true")
+Kernel.system("ipadm create-addr -T dhcp -h #{hostname} net0/v4")

--- a/manifests/modules/packer/templates/vsphere/solaris.rb.erb
+++ b/manifests/modules/packer/templates/vsphere/solaris.rb.erb
@@ -22,3 +22,9 @@ Kernel.system("ifconfig net0 dhcp release && ifconfig net0 dhcp start")
 Kernel.system("ipadm delete-addr -r net0/v4 || true")
 Kernel.system("ipadm delete-addr -r net0/v4a || true")
 Kernel.system("ipadm create-addr -T dhcp -h #{hostname} net0/v4")
+
+# /etc/rc.d/rc.local is what runs this script; Make
+# it a noop after the first run:
+Kernel.system('rm /etc/vsphere-bootstrap.rb')
+Kernel.system('echo "exit 0" > /etc/init.d/rc.local')
+

--- a/templates/solaris/11.4/x86_64/vars.json
+++ b/templates/solaris/11.4/x86_64/vars.json
@@ -2,7 +2,7 @@
     "template_name"                         : "solaris-114-x86_64",
     "template_os"                           : "solaris11-64",
     "beakerhost"                            : "solaris114-32",
-    "version"                               : "0.0.3",
+    "version"                               : "0.0.4",
     "iso_url"                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/sol-11_4-ai-x86.iso",
     "iso_checksum"                          : "e3a29507e583acbc0b912f371c8f328fea7cb6257d587cbc0a651477a52b0a29",
     "iso_checksum_type"                     : "sha256",

--- a/templates/solaris/11.4/x86_64/vars.json
+++ b/templates/solaris/11.4/x86_64/vars.json
@@ -2,7 +2,7 @@
     "template_name"                         : "solaris-114-x86_64",
     "template_os"                           : "solaris11-64",
     "beakerhost"                            : "solaris114-32",
-    "version"                               : "0.0.2",
+    "version"                               : "0.0.3",
     "iso_url"                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/sol-11_4-ai-x86.iso",
     "iso_checksum"                          : "e3a29507e583acbc0b912f371c8f328fea7cb6257d587cbc0a651477a52b0a29",
     "iso_checksum_type"                     : "sha256",


### PR DESCRIPTION
If a new addr is created on Solaris 11.4, the DHCP agent tries to get a new lease that might causes a network outage. 
This PR enables the use of the existing addr for the network interface instead of creating a new one.