### PR TITLE
(IMAGES-985) Update PsWindowsUpdate and other fixes

### DIFF
--- a/templates/win/2008/x86_64/vars.json
+++ b/templates/win/2008/x86_64/vars.json
@@ -11,5 +11,11 @@
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "ab418a455fea422d2582c660ee8cd8f1",
     "firmware"          : "bios",
-    "boot_command"      : "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter>"
+    "boot_command"      : "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter>",
+
+    "CurrentVersion"    : "6.0",
+    "ProductName"       : "Windows Server (R) 2008 Standard",
+    "EditionID"         : "ServerStandard",
+    "InstallationType"  : "Server",
+    "ReleaseID"         : "N/A"
 }

--- a/templates/win/2008/x86_64/vmware.vcenter.cygwin.json
+++ b/templates/win/2008/x86_64/vmware.vcenter.cygwin.json
@@ -55,6 +55,7 @@
       "host"                   : "{{user `packer_vcenter_build_host`}}",
       "convert_to_template"    : "{{user `convert_to_template`}}",
       "folder"                 : "{{user `packer_vcenter_folder`}}",
+      "firmware"               : "{{user `firmware`}}",
       "CPUs"                   : "{{user `numvcpus`}}",
       "CPU_limit"              : -1,
       "RAM"                    : "{{user `memsize`}}",
@@ -86,7 +87,7 @@
       ],
       "iso_paths": [
         "{{user `iso_disk`}}{{user `iso_name`}}",
-        "{{user `iso_disk`}}windows.iso"
+        "{{user `iso_disk`}}windows-10.1.15.iso"
       ],
 
       "communicator"      : "winrm",
@@ -95,7 +96,6 @@
       "winrm_timeout"     : "{{user `winrm_timeout`}}",
 
       "configuration_parameters": {
-        "firmware"                                 : "{{user `firmware`}}",
 
         "gui.fitguestusingnativedisplayresolution" : "FALSE",
         "devices.hotplug"                          : "false",
@@ -119,12 +119,6 @@
     }
   ],
   "provisioners": [
-    {
-      "type": "powershell",
-      "elevated_user": "{{user `winrm_username`}}",
-      "elevated_password": "{{user `winrm_password`}}",
-      "script" : "../../common/scripts/provisioners/test-bootstrap.ps1"
-    },
     {
       "type": "file",
       "source": "../../common/scripts/bootstrap/",
@@ -157,8 +151,30 @@
     },
     {
       "type": "file",
+      "source": "../../common/scripts/acceptance/",
+      "destination": "C:\\Packer\\Acceptance"
+    },
+    {
+      "type": "file",
       "source": "./tmp/post-clone.autounattend.xml",
       "destination": "C:\\Packer\\Config\\post-clone.autounattend.xml"
+    },
+    {
+      "type": "powershell",
+      "elevated_user": "{{user `winrm_username`}}",
+      "elevated_password": "{{user `winrm_password`}}",
+      "inline" : [
+          "C:/Packer/Scripts/test-packerbuild -TestPhase bootstrap-packerbuild"
+        ],
+        "environment_vars" : [
+          "PBTEST_WindowsCurrentVersion={{user `CurrentVersion`}}",
+          "PBTEST_WindowsProductName={{user `ProductName`}}",
+          "PBTEST_WindowsEditionID={{user `EditionID`}}",
+          "PBTEST_WindowsInstallationType={{user `InstallationType`}}",
+          "PBTEST_WindowsReleaseID={{user `ReleaseID`}}",
+          "PBTEST_WindowsMemorySize={{user `memsize`}}"
+        ],
+      "valid_exit_codes" : [ 0 ]
     },
     {
       "type": "powershell",
@@ -178,7 +194,15 @@
       "type": "powershell",
       "elevated_user": "{{user `winrm_username`}}",
       "elevated_password": "{{user `winrm_password`}}",
-      "script" : "../../common/scripts/provisioners/test-windows-update.ps1"
+      "inline" : [
+        "C:/Packer/Scripts/test-packerbuild -TestPhase windows-update"
+      ],
+      "environment_vars" : [
+        "PBTEST_OSName={{user `XXXX`}}",
+        "PBTEST_Edition={{user `XXXX`}}",
+        "PBTEST_Build={{user `XXXX`}}"
+      ],
+      "valid_exit_codes" : [ 0 ]
     },
     {
       "type": "powershell",

--- a/templates/win/2016-core/x86_64/vars.json
+++ b/templates/win/2016-core/x86_64/vars.json
@@ -16,6 +16,6 @@
     "ProductName"       : "Windows Server 2016 Standard",
     "EditionID"         : "ServerStandard",
     "InstallationType"  : "Server Core",
-    "ReleaseID"         : "N/A"
+    "ReleaseID"         : "1607"
 
 }

--- a/templates/win/common/scripts/bootstrap/packer-windows-update.ps1
+++ b/templates/win/common/scripts/bootstrap/packer-windows-update.ps1
@@ -47,18 +47,23 @@ do {
     break
   }
   Write-Output "Windows Update Pass $Attempt"
-  # Note 'KB2267602' is screened out as it doesn't appear to install correctly.
 
   try {
-    # Need to handle Powershell 2 compatibility issue here - Unblock-File is used but not
-    # present in PS2
-    if ($psversiontable.psversion.major -eq 2) {
-      Get-WUInstall -AcceptAll -UpdateType Software -IgnoreReboot -Erroraction SilentlyContinue -NotKBArticleID 'KB2267602'
+    # The format and command for windows update differs across windows versions.
+    # See below.
+    If ($WindowsVersion -like $WindowsServer2016) {
+      # Use Latest (2.0.0.4) for Win-10/2016 only
+      # Note 'KB2267602' is screened out as it doesn't appear to install correctly.
+      Write-Output "Running PSWindows Update - Verbose Mode"
+      Install-WindowsUpdate -Verbose -AcceptAll -UpdateType Software -IgnoreReboot -NotKBArticleID 'KB2267602'
+    } elseif ($psversiontable.psversion.major -eq 2) {
+      # Ignore errors on PS2 (in case of unblock file errors)
       Write-Output "Running PSWindows Update - Ignoring errors (PS2)"
-    }
-    else {
-      Write-Output "Running PSWindows Update"
-      Get-WUInstall -AcceptAll -UpdateType Software -IgnoreReboot -NotKBArticleID 'KB2267602'
+      Get-WUInstall -AcceptAll -UpdateType Software -IgnoreReboot -Erroraction SilentlyContinue
+    } else {
+      # All other versions - mainly 2012r2 use this version
+      Write-Output "Running PSWindows Update - Non Verbose Mode"
+      Install-WindowsUpdate -AcceptAll -UpdateType Software -IgnoreReboot
     }
     if (Test-PendingReboot) { 
       Invoke-Reboot 

--- a/templates/win/common/scripts/bootstrap/packer-windows-update.ps1
+++ b/templates/win/common/scripts/bootstrap/packer-windows-update.ps1
@@ -10,10 +10,16 @@ $ErrorActionPreference = 'Stop'
 $rundate = Get-Date
 write-output "Script: packer-windows-update.ps1 Starting at: $rundate"
 
-# Install latest .Net package prior to any windows updates.
-Install-DotNetLatest
-if (Test-PendingReboot) {
-  Invoke-Reboot
+# Install latest .Net package prior to any windows updates - this NOT done for:
+# Powershell 2.0 builds (win-2008, win-2008R2 and Win-7)
+# Windows 10/2016 - this comes with either the latest, or close to latest.
+if ( ($WindowsVersion -Like $WindowsServer2016) -or (($PSVersionTable.PSVersion.Major) -eq 2) ) {
+  Write-Output "Skipping .Net Installation/Checks"
+} else {
+  Install-DotNetLatest
+  if (Test-PendingReboot) {
+    Invoke-Reboot
+  }
 }
 
 # Run the (Optional) Installation Package File.

--- a/templates/win/common/scripts/common/windows-env.ps1
+++ b/templates/win/common/scripts/common/windows-env.ps1
@@ -22,11 +22,18 @@ Set-Variable -Option Constant -Name WindowsServer2016   -Value "10.*"
 $WindowsVersion = (Get-WmiObject win32_operatingsystem).version
 
 # Collect additional Windows Installation Parameters - useful for various uses including platform verification
-# ReleaseID is tricky as it only appears in later Windows 10 builds.
 $NTVerKeyPath = "Registry::HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion"
 $WindowsProductName = (Get-ItemProperty -Path "$NTVerKeyPath" -Name ProductName).ProductName
 $WindowsEditionID = (Get-ItemProperty -Path "$NTVerKeyPath" -Name EditionID).EditionID
-$WindowsInstallationType = (Get-ItemProperty -Path "$NTVerKeyPath" -Name InstallationType).InstallationType
+
+# InstallationType does not appear in Windows 2008 (Assume Server)
+if ($WindowsVersion -Like $WindowsServer2008) {
+  $global:WindowsInstallationType = "Server"
+} else {
+  $global:WindowsInstallationType = (Get-ItemProperty -Path "$NTVerKeyPath" -Name InstallationType).InstallationType
+}
+
+# ReleaseID is tricky as it only appears in later Windows 10 builds.
 $WindowsReleaseIDObj = Get-ItemProperty -ErrorAction SilentlyContinue -Path "$NTVerKeyPath" -Name ReleaseID
 if ($WindowsReleaseIDObj) {
   $global:WindowsReleaseID = $WindowsReleaseIDObj.ReleaseID

--- a/templates/win/common/scripts/provisioners/initiate-windows-update.ps1
+++ b/templates/win/common/scripts/provisioners/initiate-windows-update.ps1
@@ -19,8 +19,14 @@ Write-Output "Setting up Windows Update"
 
 Install-7ZipPackage
 if (-not (Test-Path "$PackerLogs\PSWindowsUpdate.installed")) {
-  # Download and install PSWindows Update Modules.
-  Download-File "https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/pswindowsupdate/PSWindowsUpdate.1.6.1.1.zip" "$Env:TEMP/pswindowsupdate.zip"
+  # Download and install PSWindows Update Modules 
+  # Use Version 2.0.0.4 (latest) for Win-10/2016 only as it doesn't play nicely with earlier versions
+  If ($WindowsVersion -like $WindowsServer2016) {
+    $Global:PsWindowsUpdateVersion = "2.0.0.4"
+  } else {
+    $Global:PsWindowsUpdateVersion = "1.6.1.1"
+  }
+  Download-File "https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/pswindowsupdate/PSWindowsUpdate.$PsWindowsUpdateVersion.zip" "$Env:TEMP/pswindowsupdate.zip"
   mkdir -Path "$Env:TEMP\PSWindowsUpdate"
   $zproc = Start-Process "$7zip" @SprocParms -ArgumentList "x $Env:TEMP/pswindowsupdate.zip -y -o$PackerPsModules"
   $zproc.WaitForExit()
@@ -38,8 +44,10 @@ Write-Output "========== Initiating Windows Update This will take some time     
 Write-Output "========== A log and update report will be given at the end of the update cycle ========"
 
 # Need to pick up Admin Username/Password from Environment for sched task
+# Also set generous wait time of 50 seconds before task is run to ensure machine is in
+# ready state for update (Win-7-WMF5 seems to need this - (IMAGES-984)
 Write-Output "Create Bootstrap Scheduled Task"
-schtasks /create /tn PackerWinUpdate /rl HIGHEST /ru "$ENV:ADMIN_USERNAME" /RP "$ENV:ADMIN_PASSWORD" /IT /F /SC ONSTART /DELAY 0000:20 /TR 'cmd /c c:\WINDOWS\system32\WindowsPowerShell\v1.0\powershell.exe -sta -WindowStyle Normal -ExecutionPolicy Bypass -NonInteractive -NoProfile -File C:\Packer\Scripts\packer-windows-update.ps1 >> C:\Packer\Logs\windows-update.log'
+schtasks /create /tn PackerWinUpdate /rl HIGHEST /ru "$ENV:ADMIN_USERNAME" /RP "$ENV:ADMIN_PASSWORD" /IT /F /SC ONSTART /DELAY 0000:50 /TR 'cmd /c c:\WINDOWS\system32\WindowsPowerShell\v1.0\powershell.exe -sta -WindowStyle Normal -ExecutionPolicy Bypass -NonInteractive -NoProfile -File C:\Packer\Scripts\packer-windows-update.ps1 >> C:\Packer\Logs\windows-update.log'
 
 # Disable WinRM until further notice.
 Set-Service "WinRM" -StartupType Disabled


### PR DESCRIPTION
Series of fixes in order to progress this (November) refresh of Windows platforms:
1. IMAGES-985 - Upgrade PsWindowsUpdate for PS3+
2. Fix the Windows 2008 Build to adopt recent Pester additions.
3. Don't install .Net 4.7 for Win-2008r2/Win-7 (PS2 only) and Win-10/2016.