### PR TITLE
(IMAGES-975) Add Platform Verification Tests

### DIFF
--- a/templates/win/common/scripts/acceptance/bootstrap-packerbuild/OSVersions.Tests.ps1
+++ b/templates/win/common/scripts/acceptance/bootstrap-packerbuild/OSVersions.Tests.ps1
@@ -10,8 +10,6 @@
     4. ReleaseID - the Windows 10/2016/2019 Build Version
 #>
 
-# Test that the correct OS Version and Edition has been installed.
-
 . C:\Packer\Scripts\windows-env.ps1
 
 describe 'Windows Platform Validation Tests' {

--- a/templates/win/common/scripts/acceptance/bootstrap-packerbuild/PackerDirectories.Tests.ps1
+++ b/templates/win/common/scripts/acceptance/bootstrap-packerbuild/PackerDirectories.Tests.ps1
@@ -1,0 +1,25 @@
+<#
+  .SYNOPSIS
+	Check Packer directories have been created.
+  .DESCRIPTION
+    This is run post-bootstrap to verify that the Packer directory set
+    has been created.
+#>
+
+. C:\Packer\Scripts\windows-env.ps1
+
+describe 'Packer Directory Tests' {
+    $pdirs = @{pdir = "C:\Packer"},
+             @{pdir = "C:\Packer\Logs"},
+             @{pdir = "C:\Packer\Scripts"},
+             @{pdir = "C:\Packer\Config"},
+             @{pdir = "C:\Packer\PsModules"},
+             @{pdir = "C:\Packer\Acceptance"},
+             @{pdir = "C:\Packer\Downloads"},
+             @{pdir = "C:\Packer\SysInternals"}
+
+    it 'Packer Directory <pdir> should exist' -TestCases $pdirs {
+        param ($pdir)
+        $pdir | Should Exist
+    }
+}

--- a/templates/win/common/scripts/acceptance/cygwin/cygwin.Tests.ps1
+++ b/templates/win/common/scripts/acceptance/cygwin/cygwin.Tests.ps1
@@ -1,0 +1,38 @@
+<#
+  .SYNOPSIS
+	Cygwin installation tests
+  .DESCRIPTION
+    A set of tests to verify that Cygwin was installed and completed.
+#>
+
+. C:\Packer\Scripts\windows-env.ps1
+
+
+# Basic set of initial tests - will add more correct verification of cygwin later.
+
+describe 'Cygwin Directory Tests' {
+    $cdirs = @{cdir = "$CygWinDir\bin"},
+                @{cdir = "$CygWinDir\dev"},
+                @{cdir = "$CygWinDir\etc"},
+                @{cdir = "$CygWinDir\home"},
+                @{cdir = "$CygWinDir\lib"},
+                @{cdir = "$CygWinDir\sbin"},
+                @{cdir = "$CygWinDir\tmp"},
+                @{cdir = "$CygWinDir\usr"},
+                @{cdir = "$CygWinDir\var"}
+
+    it 'Cygwin Directory <cdir> should exist' -TestCases $cdirs {
+        param ($cdir)
+        $cdir | Should Exist
+    }
+}
+
+describe 'Cygwin Executable Tests' {
+    $cexes = @{cexe = "$CygWinDir\bin\cygcheck.exe"},
+             @{cexe = "$ENV:WINDIR\system32\setup-$ARCH.exe"}
+
+    it 'Cygwin Executable <cexe> should be installed' -TestCases $cexes {
+        param ($cexe)
+        $cexe | Should Exist
+    }
+}

--- a/templates/win/common/scripts/acceptance/platform/DateTime.Tests.ps1
+++ b/templates/win/common/scripts/acceptance/platform/DateTime.Tests.ps1
@@ -1,0 +1,27 @@
+<#
+  .SYNOPSIS
+	Date Time Tests
+  .DESCRIPTION
+    1. Timezone should be UTC
+    2. Boot time .vs. current time test
+#>
+
+. C:\Packer\Scripts\windows-env.ps1
+
+# Pick up the Timezone from systeminfo
+$Timezone = $(systeminfo | findstr  /L 'Zone:')
+# Note (Get-CimInstance -class Win32_OperatingSystem).LastBootUpTime would be better here, but its not available in PS2.
+# Noting for future.
+$LastBoot = (Get-WmiObject -class Win32_OperatingSystem | Select-Object @{label='LastBootUpTime';expression={$_.ConvertToDateTime($_.LastBootUpTime)}}).LastBootUpTime
+$CurrentTime = Get-Date
+
+describe 'Date/Time Tests' {
+
+    it 'Timezone is UTC' {
+        "$Timezone" | Should Match "\(UTC\)"
+    }
+
+    it 'Last boot is before current time' {
+        $CurrentTime | Should BeGreaterThan $LastBoot
+    }
+}

--- a/templates/win/common/scripts/acceptance/platform/DirectoryCleanup.Tests.ps1
+++ b/templates/win/common/scripts/acceptance/platform/DirectoryCleanup.Tests.ps1
@@ -1,0 +1,28 @@
+<#
+  .SYNOPSIS
+	Directory Cleanup has happened.
+  .DESCRIPTION
+    A set of tests to verify that directory remnants left over
+    after the Puppet run have been removed, so that any CI testing
+    is running on a "Clean System".
+#>
+
+. C:\Packer\Scripts\windows-env.ps1
+
+describe "Directory Cleanup should have happened" {
+
+    it 'Program Data Dir Puppetlabs should not exist' {
+        "$ENV:ProgramData\PuppetLabs" | Should Not Exist
+    }
+
+    it 'Program Dir Puppet Labs should not exist' {
+        "$ENV:ProgramFiles\Puppet Labs" | Should Not Exist
+    }
+
+    # This test is slightly superfluous as if the Puppet Labs directory aren't thiere, this
+    # will also be clear - however, if Puppet Agent is uninstalled, this .dll is kept, so
+    # its useful as a belt and braces test to "prove" that a correct and full cleanup has happened.
+    it 'puppetres.dll Should Not Exist' {
+        "$ENV:PROGRAMFILES\Puppet Labs\Puppet\puppet\bin\puppetres.dll" | Should Not Exist
+    }
+}

--- a/templates/win/common/scripts/acceptance/platform/Services.Tests.ps1
+++ b/templates/win/common/scripts/acceptance/platform/Services.Tests.ps1
@@ -1,0 +1,17 @@
+<#
+  .SYNOPSIS
+	Service Tests
+  .DESCRIPTION
+    E.g. Windows Update Disabled, Google Services Disabled
+#>
+
+. C:\Packer\Scripts\windows-env.ps1
+
+describe 'Services Tests' {
+
+    it 'Windows Update should be Disabled' {
+        # Using Get-WIMIObject here instead Get-Service for Powershell 2 compatibility reasons.
+        $WuaServStartMode = Get-WMIObject win32_service -filter "name='wuauserv'" | select -expand StartMode
+        "$WuaServStartMode" | Should Match "Disabled"
+    }
+}

--- a/templates/win/common/scripts/acceptance/winpackages/sysinternals.Tests.ps1
+++ b/templates/win/common/scripts/acceptance/winpackages/sysinternals.Tests.ps1
@@ -1,0 +1,48 @@
+<#
+  .SYNOPSIS
+	Test that sysinternals executables are installed.
+  .DESCRIPTION
+    Autologon is required to ensure Admin user is logged in
+    BgInfo is required to do the splash screen.
+    The remainder of the utilities are useful diagnostic tools to have.
+#>
+
+. C:\Packer\Scripts\windows-env.ps1
+
+describe 'Sysinternal Executable Tests' {
+    $sysexes = @{sysexe = "$SysInternals\Autologon.exe"},
+               @{sysexe = "$SysInternals\BgInfo.exe"},
+               @{sysexe = "$SysInternals\BgInfo64.exe"},
+               @{sysexe = "$SysInternals\procexp.exe"},
+               @{sysexe = "$SysInternals\procexp64.exe"},
+               @{sysexe = "$SysInternals\Procmon.exe"},
+               @{sysexe = "$SysInternals\PsExec.exe"},
+               @{sysexe = "$SysInternals\PsExec64.exe"},
+               @{sysexe = "$SysInternals\PsFile.exe"},
+               @{sysexe = "$SysInternals\PsFile64.exe"},
+               @{sysexe = "$SysInternals\PsGetSid.exe"},
+               @{sysexe = "$SysInternals\PsGetSid64.exe"},
+               @{sysexe = "$SysInternals\PsInfo.exe"},
+               @{sysexe = "$SysInternals\PsInfo64.exe"},
+               @{sysexe = "$SysInternals\pskill.exe"},
+               @{sysexe = "$SysInternals\pskill64.exe"},
+               @{sysexe = "$SysInternals\pslist.exe"},
+               @{sysexe = "$SysInternals\pslist64.exe"},
+               @{sysexe = "$SysInternals\PsLoggedon.exe"},
+               @{sysexe = "$SysInternals\PsLoggedon64.exe"},
+               @{sysexe = "$SysInternals\psloglist.exe"},
+               @{sysexe = "$SysInternals\pspasswd.exe"},
+               @{sysexe = "$SysInternals\pspasswd64.exe"},
+               @{sysexe = "$SysInternals\psping.exe"},
+               @{sysexe = "$SysInternals\psping64.exe"},
+               @{sysexe = "$SysInternals\PsService.exe"},
+               @{sysexe = "$SysInternals\PsService64.exe"},
+               @{sysexe = "$SysInternals\psshutdown.exe"},
+               @{sysexe = "$SysInternals\pssuspend.exe"},
+               @{sysexe = "$SysInternals\pssuspend64.exe"}
+
+    it 'Sysinternal Executable <sysexe> should be installed' -TestCases $sysexes {
+        param ($sysexe)
+        $sysexe | Should Exist
+    }
+}

--- a/templates/win/common/scripts/acceptance/winpackages/winpackages.Tests.ps1
+++ b/templates/win/common/scripts/acceptance/winpackages/winpackages.Tests.ps1
@@ -1,0 +1,29 @@
+<#
+  .SYNOPSIS
+	Test that Windows Packages are installed.
+  .DESCRIPTION
+    Tests that NotePad++, Git for Windows and Chrome is installed.
+#>
+
+. C:\Packer\Scripts\windows-env.ps1
+
+# Google program directory is a bit strange.
+$GoogleProgDir = (${env:ProgramFiles(x86)}, ${env:ProgramFiles} -ne $null)[0]
+
+describe 'Windows Packages are installed' {
+
+    it 'Git for Windows' {
+        "$ENV:PROGRAMFILES\Git\git-bash.exe" | Should Exist
+        "$ENV:PROGRAMFILES\Git\git-cmd.exe" | Should Exist
+    }
+}
+
+describe -Tag 'DesktopOnly' 'Windows Desktop Packages are installed' {
+    it 'NotePad++ should be installed' {
+        "$ENV:PROGRAMFILES\Notepad++\notepad++.exe" | Should Exist
+    }
+
+    it 'Chrome should be installed' {
+        "$GoogleProgDir\Google\Chrome\Application\chrome.exe" | Should Exist
+    }
+}

--- a/templates/win/common/scripts/common/test-packerbuild.ps1
+++ b/templates/win/common/scripts/common/test-packerbuild.ps1
@@ -21,6 +21,8 @@ $ErrorActionPreference = 'Stop'
 
 . C:\Packer\Scripts\windows-env.ps1
 
+Write-Output "========== Starting Packer Test Phase: $TestPhase ========"
+
 # Adding Validation here to ensure we have a test phase available.
 if (-not (Test-Path "$PackerAcceptance\$TestPhase\")) {
     Write-Error "Test Packages for $TestPhase not available aborting"
@@ -57,7 +59,7 @@ if ($WindowsVersion -NotLike $WindowsServer2016) {
 
 # Print out Log for the phase with a prologue if a log file exists
 if (Test-Path "C:\Packer\Logs\$TestPhase.log") {
-    Write-Output "Printing Log for $TestPhase"
+    Write-Output "========== Printing Log for $TestPhase ========"
 
     Write-Output "==========  Log for: $TestPhase START ========"
     Get-Content -Path "C:\Packer\Logs\$TestPhase.log"
@@ -68,9 +70,14 @@ if (Test-Path "C:\Packer\Logs\$TestPhase.log") {
 
 # Now for the Test Proper - assuming they exist of course
 
-$PesterResults = Invoke-Pester -Script "$PackerAcceptance\$TestPhase\" -PassThru
+If ( $WindowsServerCore ) {
+    $PesterResults = Invoke-Pester -Script "$PackerAcceptance\$TestPhase\" -PassThru -ExcludeTag 'DesktopOnly'
+} else {
+    $PesterResults = Invoke-Pester -Script "$PackerAcceptance\$TestPhase\" -PassThru -ExcludeTag 'CoreOnly'
+}
 
+Write-Output "========== Completed Packer Test Phase: $TestPhase ========"
 if ($PesterResults.FailedCount -gt 0) {
     Write-Output "Failures detected - aborting build"
     Exit 1
-}
+} 

--- a/templates/win/common/scripts/common/windows-env.ps1
+++ b/templates/win/common/scripts/common/windows-env.ps1
@@ -105,6 +105,16 @@ if ($ENV:PROCESSOR_ARCHITECTURE -eq 'x86') {
   $ARCH = 'x86_64'
 }
 
+# Work out what CYGDIR is and set it as a Windows Environment Variable
+# Note - need seperate Prefix var for environment variables due to cygwin/git-for-win idiosyncrasies
+if ($ARCH -eq 'x86') {
+  $CygWinDir = "C:\cygwin"
+  $CygEnvPrefix = "C:/cygwin"
+} else {
+  $CygWinDir = "C:\cygwin64"
+  $CygEnvPrefix = "C:/cygwin64"
+}
+
 # Cleanmgr Registry "SageSet" Value - setting this to "random" value and associated constants
 $CleanMgrSageSet = "5462"
 Set-Variable -Option Constant -Name CleanMgrStateFlags        -Value "StateFlags$CleanMgrSageSet"

--- a/templates/win/common/scripts/provisioners/install-cygwin.ps1
+++ b/templates/win/common/scripts/provisioners/install-cygwin.ps1
@@ -24,16 +24,8 @@ $ErrorActionPreference = 'Stop'
 Write-Output "Loading Windows Environment"
 . C:\Packer\Scripts\windows-env.ps1
 
-# Work out what CYGDIR is and set it as a Windows Environment Variable
-# Note - need seperate Prefix var for environment variables due to cygwin/git-for-win idiosyncrasies
-Write-Output "Setting CYGWINDIR"
-if ($ARCH -eq 'x86') {
-  $CygWinDir = "C:\cygwin"
-  $CygEnvPrefix = "C:/cygwin"
-} else {
-  $CygWinDir = "C:\cygwin64"
-  $CygEnvPrefix = "C:/cygwin64"
-}
+# CygWinDir is platform dependant (moved to windows-env)
+Write-Output "Setting CYGWINDIR to $CygWinDir"
 $RegPath = 'Registry::HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment'
 Set-ItemProperty -Path $RegPath -Name CYGWINDIR -Value $CygWinDir
 Set-ItemProperty -Path $RegPath -Name CYGWINDOWNLOADS -Value $CygwinDownloads

--- a/templates/win/common/vars.json
+++ b/templates/win/common/vars.json
@@ -1,5 +1,5 @@
 {
-  "version"             : "20181129_PROD",
+  "version"             : "20181217_DEV",
 
   "headless"            : "true",
 

--- a/templates/win/common/vmware.vcenter.cygwin.json
+++ b/templates/win/common/vmware.vcenter.cygwin.json
@@ -189,11 +189,6 @@
       "inline" : [
         "C:/Packer/Scripts/test-packerbuild -TestPhase windows-update"
       ],
-      "environment_vars" : [
-        "PBTEST_OSName={{user `XXXX`}}",
-        "PBTEST_Edition={{user `XXXX`}}",
-        "PBTEST_Build={{user `XXXX`}}"
-      ],
       "valid_exit_codes" : [ 0 ]
     },
     {
@@ -204,6 +199,13 @@
       "type": "windows-restart"
     },
     {
+      "type": "powershell",
+      "inline" : [
+        "C:/Packer/Scripts/test-packerbuild -TestPhase winpackages"
+      ],
+      "valid_exit_codes" : [ 0 ]
+    },
+    {
       "type"   : "powershell",
       "script" : "../../common/scripts/provisioners/install-cygwin.ps1",
       "environment_vars" : [
@@ -212,6 +214,13 @@
     },
     {
       "type": "windows-restart"
+    },
+    {
+      "type": "powershell",
+      "inline" : [
+        "C:/Packer/Scripts/test-packerbuild -TestPhase cygwin"
+      ],
+      "valid_exit_codes" : [ 0 ]
     },
     {
       "type": "powershell",
@@ -240,6 +249,13 @@
     },
     {
       "type": "windows-restart"
+    },
+    {
+      "type": "powershell",
+      "inline" : [
+        "C:/Packer/Scripts/test-packerbuild -TestPhase platform"
+      ],
+      "valid_exit_codes" : [ 0 ]
     },
     {
       "type"   : "powershell",


### PR DESCRIPTION
Add additional Pester tests to the image build process for:

1. Windows Packages installation tests
2. Cygwin Installation Tests (not possible to test the full cygwin
   configuration at this stage as the final config is done during
   vmpooler cloner operation.
3. Overall platform tests, and in particular ensure that Puppetlabs
   and other directories are cleaned following the removal of
   puppet agent so as to leave the image in a clean state ready for
   Puppet CI testing in the pooler.

Some additional tests (e.g. Network/Security) still to be added.