### PR TITLE
(maint) Set tools_upload_flavor to linux in top-level vmware.base.json

### DIFF
--- a/templates/common/vmware.base.json
+++ b/templates/common/vmware.base.json
@@ -39,7 +39,9 @@
     "inject_http_seed_in_boot_command"             : "false",
     "ssh_username"                                 : "root",
     "ssh_password"                                 : "puppet",
-    "vmware_base_provisioning_scripts"             : "../../../../scripts/bootstrap-aio.sh"
+    "vmware_base_provisioning_scripts"             : "../../../../scripts/bootstrap-aio.sh",
+
+    "tools_upload_flavor"                          : "linux"
   },
 
   "description"                                    : "Builds a Linux base template VM for use in VMWare",


### PR DESCRIPTION
Without this variable, any Linux images built from the top-level
vmware.base.json template will error in the vmtools setup step because
the linux.iso file will not be uploaded onto the image.