### PR TITLE
(IMAGES-1001) Kill Pupper 3 deprecations

### DIFF
--- a/templates/win/common/puppet/windows_group_policy/manifests/gpupdate.pp
+++ b/templates/win/common/puppet/windows_group_policy/manifests/gpupdate.pp
@@ -1,22 +1,21 @@
+# for a GPO update.
 define windows_group_policy::gpupdate(
-  $target = 'All',
-  $force = true,
-  $logoutput = false,
-  $timeout = 30,
+  Optional[Pattern[/^(All|Machine|User)$/]] $target = 'All',
+  Optional[Boolean] $force                          = true,
+  Optional[Boolean] $logoutput                      = false,
+  Optional[Integer] $timeout                        = 30,
 )
 {
-  validate_re($target, '^(All|Machine|User)$', 'target must be one of \'All\', \'Machine\' or \'User\'')
-
   # TODO Support not forcing
   # TODO Support different target types
   # TODO watch out of for prompts.  Need to pipe in 'N'
   # TODO Need to figure out how to do RefreshOnly stuff
 
   exec { "GPO-GPUPDATE-$name":
-    command => "& cmd /c gpupdate /force /Wait:$timeout",
-    provider => powershell,
-    logoutput => $logoutput,
-    timeout => $timeout,
+    command     => "& cmd /c gpupdate /force /Wait:$timeout",
+    provider    => powershell,
+    logoutput   => $logoutput,
+    timeout     => $timeout,
     refreshonly => true,
   }
 }

--- a/templates/win/common/puppet/windows_group_policy/manifests/local/machine.pp
+++ b/templates/win/common/puppet/windows_group_policy/manifests/local/machine.pp
@@ -1,32 +1,30 @@
+# Update a local machine policy 
 define windows_group_policy::local::machine(
-  $ensure    = 'present',
-  $key       = '',
-  $value     = '',
-  $type      = 'REG_SZ',
-  $data      = '',
-  $logoutput = false,
+  Pattern[/^(present|absent)$/] $ensure = 'present',
+  String $key                           = '',
+  String $value                         = '',
+  Pattern[/^(REG_SZ|REG_DWORD)$/] $type = 'REG_SZ',
+  Variant[String,Integer] $data         = '',
+  Optional[Boolean] $logoutput          = false,
 )
 {
-  validate_re($ensure, '^(present|absent)$', 'ensure must be one of \'present\' or \'absent\'')
-  validate_re($type, '^(REG_SZ|REG_DWORD)$', 'type must be one of \'REG_SZ\' or \'REG_DWORD\'')
-
   $policy_type = 'Machine'
 
   if $ensure in ['present'] {
-    exec { "GPO-Local-Machine-$name":
-      command => template('windows_group_policy/script_header.ps1',
-                          'windows_group_policy/PolFileEditor.ps1',
-                          'windows_group_policy/local_gpo.ps1',
-                          'windows_group_policy/command-set.ps1'),
-      unless => template('windows_group_policy/script_header.ps1',
-                         'windows_group_policy/PolFileEditor.ps1',
-                         'windows_group_policy/local_gpo.ps1',
-                         'windows_group_policy/command-unless.ps1'),
-      provider => powershell,
+    exec { "GPO-Local-Machine-${name}":
+      command   => template('windows_group_policy/script_header.ps1',
+                            'windows_group_policy/PolFileEditor.ps1',
+                            'windows_group_policy/local_gpo.ps1',
+                            'windows_group_policy/command-set.ps1'),
+      unless    => template('windows_group_policy/script_header.ps1',
+                            'windows_group_policy/PolFileEditor.ps1',
+                            'windows_group_policy/local_gpo.ps1',
+                            'windows_group_policy/command-unless.ps1'),
+      provider  => powershell,
       logoutput => $logoutput,
     }
   } else {
     # Do stuff to remove it
     Notify{ '***** Removing GPOs is NOT IMPLEMENTED': }
-  }   
+  }
 }

--- a/templates/win/common/puppet/windows_group_policy/manifests/local/user.pp
+++ b/templates/win/common/puppet/windows_group_policy/manifests/local/user.pp
@@ -1,28 +1,26 @@
+# Update a local user policy 
 define windows_group_policy::local::user(
-  $ensure    = 'present',
-  $key       = '',
-  $value     = '',
-  $type      = 'REG_SZ',
-  $data      = '',
-  $logoutput = false,
+  Pattern[/^(present|absent)$/] $ensure = 'present',
+  String $key                           = '',
+  String $value                         = '',
+  Pattern[/^(REG_SZ|REG_DWORD)$/] $type = 'REG_SZ',
+  Variant[String,Integer] $data         = '',
+  Optional[Boolean] $logoutput          = false,
 )
 {
-  validate_re($ensure, '^(present|absent)$', 'ensure must be one of \'present\' or \'absent\'')
-  validate_re($type, '^(REG_SZ|REG_DWORD)$', 'type must be one of \'REG_SZ\' or \'REG_DWORD\'')
-
   $policy_type = 'User'
 
   if $ensure in ['present'] {
     exec { "GPO-Local-User-$name":
-      command => template('windows_group_policy/script_header.ps1',
-                          'windows_group_policy/PolFileEditor.ps1',
-                          'windows_group_policy/local_gpo.ps1',
-                          'windows_group_policy/command-set.ps1'),
-      unless => template('windows_group_policy/script_header.ps1',
-                         'windows_group_policy/PolFileEditor.ps1',
-                         'windows_group_policy/local_gpo.ps1',
-                         'windows_group_policy/command-unless.ps1'),
-      provider => powershell,
+      command   => template('windows_group_policy/script_header.ps1',
+                            'windows_group_policy/PolFileEditor.ps1',
+                            'windows_group_policy/local_gpo.ps1',
+                            'windows_group_policy/command-set.ps1'),
+      unless    => template('windows_group_policy/script_header.ps1',
+                            'windows_group_policy/PolFileEditor.ps1',
+                            'windows_group_policy/local_gpo.ps1',
+                            'windows_group_policy/command-unless.ps1'),
+      provider  => powershell,
       logoutput => $logoutput,
     }
   } else {

--- a/templates/win/common/puppet/windows_template/manifests/apps/chrome.pp
+++ b/templates/win/common/puppet/windows_template/manifests/apps/chrome.pp
@@ -5,7 +5,6 @@ class windows_template::apps::chrome()
   file { "${::chrome_root}\\Application\\master_preferences":
     owner  => "${::administrator_sid}",
     group  => "${::administrator_grp_sid}",
-    mode   => '0775',
     source => "${::modules_path}\\windows_template\\files\\master_preferences",
   }
 


### PR DESCRIPTION
The validate_re helper function is deprecated, so use Puppet 4 types with
validation instead.

Also remove the mode setting from the google config file as this causes an
issue with Win-10 Build 1809 - the recommendation is to the acl anyways for
permission settings.