### PR TITLE
(RE-11841) Update RHEL6 mirrors

### DIFF
--- a/manifests/modules/packer/manifests/repos.pp
+++ b/manifests/modules/packer/manifests/repos.pp
@@ -42,29 +42,50 @@ class packer::repos {
         gpgcheck => "1",
         gpgkey   => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
       }
-    } else {
-
+    } elsif $::operatingsystemmajrelease =="6" {
       yumrepo { "localmirror-os":
         descr    => "localmirror-os",
-        baseurl  => "${base_url}/os",
+        baseurl  => "${base_url}-os",
         gpgcheck => "1",
         gpgkey   => "file:///etc/pki/rpm-gpg/${gpgkey}"
       }
 
       yumrepo { "localmirror-optional":
         descr    => "localmirror-optional",
-        baseurl  => "${base_url}/optional",
+        baseurl  => "${base_url}-optional",
         gpgcheck => "1",
         gpgkey   => "file:///etc/pki/rpm-gpg/${gpgkey}"
       }
 
       yumrepo { "localmirror-extras":
         descr    => "localmirror-extras",
-        baseurl  => "${base_url}/extras",
+        baseurl  => "${base_url}-extras",
         gpgcheck => "1",
         gpgkey   => "file:///etc/pki/rpm-gpg/${gpgkey}"
-      }
-    }
+     }
+   } else {
+
+     yumrepo { "localmirror-os":
+       descr    => "localmirror-os",
+       baseurl  => "${base_url}/os",
+       gpgcheck => "1",
+       gpgkey   => "file:///etc/pki/rpm-gpg/${gpgkey}"
+     }
+
+     yumrepo { "localmirror-optional":
+       descr    => "localmirror-optional",
+       baseurl  => "${base_url}/optional",
+       gpgcheck => "1",
+       gpgkey   => "file:///etc/pki/rpm-gpg/${gpgkey}"
+     }
+
+     yumrepo { "localmirror-extras":
+       descr    => "localmirror-extras",
+       baseurl  => "${base_url}/extras",
+       gpgcheck => "1",
+       gpgkey   => "file:///etc/pki/rpm-gpg/${gpgkey}"
+     }
+   }
 
     # We add the lb (load balancer) repo for redhat-6-x86_64 which is
     # used in puppet modules testing

--- a/manifests/modules/packer/manifests/repos.pp
+++ b/manifests/modules/packer/manifests/repos.pp
@@ -87,15 +87,5 @@ class packer::repos {
      }
    }
 
-    # We add the lb (load balancer) repo for redhat-6-x86_64 which is
-    # used in puppet modules testing
-    if $::operatingsystemmajrelease == "6" and $::architecture == "x86_64" {
-      yumrepo { "localmirror-lb":
-        descr    => "localmirror-lb",
-        baseurl  => "${base_url}/lb",
-        gpgcheck => "1",
-        gpgkey   => "file:///etc/pki/rpm-gpg/${gpgkey}"
-      }
-    }
   }
 }

--- a/manifests/modules/packer/manifests/vsphere/repos.pp
+++ b/manifests/modules/packer/manifests/vsphere/repos.pp
@@ -169,16 +169,6 @@ class packer::vsphere::repos inherits packer::vsphere::params {
           }
         }
 
-        # We add the lb (load balancer) repo for redhat-6-x86_64 which is
-        # used in puppet modules testing
-        if $::operatingsystemmajrelease == "6" and $::architecture == "x86_64" {
-          yumrepo { "localmirror-lb":
-            descr    => "localmirror-lb",
-            baseurl  => "${base_url}/lb",
-            gpgcheck => "1",
-            gpgkey   => "file:///etc/pki/rpm-gpg/${gpgkey}"
-          }
-        }
       }
 
       if $::operatingsystem == 'CentOS' {

--- a/manifests/modules/packer/manifests/vsphere/repos.pp
+++ b/manifests/modules/packer/manifests/vsphere/repos.pp
@@ -124,6 +124,27 @@ class packer::vsphere::repos inherits packer::vsphere::params {
             gpgcheck => "1",
             gpgkey   => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
           }
+        } elsif $::operatingsystemmajrelease == "6" {
+          yumrepo { "localmirror-os":
+            descr    => "localmirror-os",
+            baseurl  => "${base_url}-os",
+            gpgcheck => "1",
+            gpgkey   => "file:///etc/pki/rpm-gpg/${gpgkey}"
+          }
+
+          yumrepo { "localmirror-optional":
+            descr    => "localmirror-optional",
+            baseurl  => "${base_url}-optional",
+            gpgcheck => "1",
+            gpgkey   => "file:///etc/pki/rpm-gpg/${gpgkey}"
+          }
+
+          yumrepo { "localmirror-extras":
+            descr    => "localmirror-extras",
+            baseurl  => "${base_url}-extras",
+            gpgcheck => "1",
+            gpgkey   => "file:///etc/pki/rpm-gpg/${gpgkey}"
+          }
         } else {
 
           yumrepo { "localmirror-os":


### PR DESCRIPTION
This updates the RHEL 6 images to use the artifactory RHEL mirrors.

This also removes configuration of the `lb` repo as our subscription seems to not have access to that. Working to figure out if this is OK for haproxy module testing. If we need to re-add it it can probably happen in a separate PR, the existing cache of the lb repo seems to have very recently expired/corrupted so we can't install any packages from there currently anyways.