### PR TITLE
(IMAGES-952) Add Powershell 6

### DIFF
--- a/templates/win/common/puppet/windows_template/manifests/apps/powershell6.pp
+++ b/templates/win/common/puppet/windows_template/manifests/apps/powershell6.pp
@@ -1,0 +1,25 @@
+# Installs and configures Powershell 6 (core)
+
+class windows_template::apps::powershell6()
+{
+  $ps6coredownloadurl = 'https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/powershell6-core'
+
+  # Select package name/install title depending on archictecture
+  if ($::architecture == 'x86') {
+    $ps6coreinstaller = 'PowerShell-6.1.1-win-x86.msi'
+    $ps6corearchtype = 'x86'
+  } else {
+    $ps6coreinstaller = 'PowerShell-6.1.1-win-x64.msi'
+    $ps6corearchtype = 'x64'
+  }
+
+  download_file { "${ps6coreinstaller}" :
+    url                   => "${ps6coredownloadurl}/${ps6coreinstaller}",
+    destination_directory => $::packer_downloads
+  }
+  -> package { "PowerShell 6-${ps6corearchtype}":
+    ensure          => installed,
+    source          => "${::packer_downloads}\\${ps6coreinstaller}",
+    install_options => ['/q']
+  }
+}

--- a/templates/win/common/scripts/acceptance/puppet/winpackages.Tests.ps1
+++ b/templates/win/common/scripts/acceptance/puppet/winpackages.Tests.ps1
@@ -16,6 +16,14 @@ describe 'Windows Packages are installed' {
         "$ENV:PROGRAMFILES\Git\git-bash.exe" | Should Exist
         "$ENV:PROGRAMFILES\Git\git-cmd.exe" | Should Exist
     }
+
+    if ($PSVersionTable.PSVersion.Major -ge 4) {
+        # Powershell 6 is only installed if WMF 4.0 or greater is installed.
+        it 'Powershell 6' {
+            "$ENV:PROGRAMFILES\PowerShell\6\pwsh.exe" | Should Exist
+        }
+    }
+
 }
 
 describe -Tag 'DesktopOnly' 'Windows Desktop Packages are installed' {

--- a/templates/win/common/scripts/config/win-site.pp
+++ b/templates/win/common/scripts/config/win-site.pp
@@ -4,6 +4,10 @@ include windows_template::registry::machine
 include windows_template::registry::user
 include windows_template::apps::sysinternals
 
+if ($psversionmajor >= "4") {
+  # Powershell 6 requires WMF 4.0 or greater for PS6
+  include windows_template::apps::powershell6
+}
 # Conditional for Core checkining
 # only allowed for main installs and non-core
 if ($windows_install_option != 'Core') and ($::operatingsystemrelease != '2008')

--- a/templates/win/common/scripts/provisioners/puppet-configure.ps1
+++ b/templates/win/common/scripts/provisioners/puppet-configure.ps1
@@ -122,6 +122,7 @@ $ENV:FACTER_packer_template_type = $ENV:PackerTemplateType
 # Pick Up user attributes as these could be localised.
 $ENV:FACTER_administrator_sid     =  $WindowsAdminSID
 $ENV:FACTER_administrator_grp_sid = "S-1-5-32-544"
+$ENV:FACTER_psversionmajor        = $PSVersionTable.PSVersion.Major
 
 # Chrome root needs arch detection as under x86 on 64 bit boxen
 if ("$ARCH" -eq "x86") {

--- a/templates/win/common/vars.json
+++ b/templates/win/common/vars.json
@@ -1,5 +1,5 @@
 {
-  "version"             : "20181217_DEV",
+  "version"             : "20190109_DEV",
 
   "headless"            : "true",
 


### PR DESCRIPTION
Add Powershell 6 (Core) to the Windows Templates.

WMF 4.0 is a minimum requirement for the Powershell Core installer, so suppress the installation for windows platforms with WMF 2.0 and 3.0