### PR TITLE
(WIP) (IMAGES-1017) Win-2012 Update Fixes

### DIFF
--- a/templates/win/2012/x86_64/files/platform-packages.ps1
+++ b/templates/win/2012/x86_64/files/platform-packages.ps1
@@ -14,15 +14,67 @@ if (-not (Test-Path "$PackerLogs\DesktopExperience.installed"))
 }
 
 # Servicing Stack Patches that don't get slipstreamed properly to be installed.
-if (-not (Test-Path "$PackerLogs\Win2012.Patches"))
-{
-  $patches = @(
-    'http://download.windowsupdate.com/c/msdownload/update/software/updt/2015/04/windows8-rt-kb3003729-x64_e95e2c0534a7f3e8f51dd9bdb7d59e32f6d65612.msu',
-    'http://download.windowsupdate.com/d/msdownload/update/software/updt/2015/09/windows8-rt-kb3096053-x64_930f557083e97c7e22e7da133e802afca4963d4f.msu',
-    'http://download.windowsupdate.com/d/msdownload/update/software/crup/2016/06/windows8-rt-kb3173426-x64_ecf1b38d9e3cdf1eace07b9ddbf6f57c1c9d9309.msu'
-  )
-  $patches | % { Install_Win_Patch -PatchUrl $_ }
+# Force reboot after each.
 
-  Touch-File "$PackerLogs\Win2012.Patches"
-  if (Test-PendingReboot) { Invoke-Reboot }
+if (-not (Test-Path "$PackerLogs\Win2012-1.Patches"))
+{
+  Install_Win_Patch -PatchUrl "http://download.windowsupdate.com/c/msdownload/update/software/updt/2015/04/windows8-rt-kb3003729-x64_e95e2c0534a7f3e8f51dd9bdb7d59e32f6d65612.msu"
+  Touch-File "$PackerLogs\Win2012-1.Patches"
+  Invoke-Reboot
 }
+
+if (-not (Test-Path "$PackerLogs\Win2012-2.Patches"))
+{
+  Install_Win_Patch -PatchUrl "http://download.windowsupdate.com/d/msdownload/update/software/updt/2015/09/windows8-rt-kb3096053-x64_930f557083e97c7e22e7da133e802afca4963d4f.msu"
+  Touch-File "$PackerLogs\Win2012-2.Patches"
+  Invoke-Reboot
+}
+
+if (-not (Test-Path "$PackerLogs\Win2012-3.Patches"))
+{
+  Install_Win_Patch -PatchUrl "http://download.windowsupdate.com/d/msdownload/update/software/crup/2016/06/windows8-rt-kb3173426-x64_ecf1b38d9e3cdf1eace07b9ddbf6f57c1c9d9309.msu"
+  Touch-File "$PackerLogs\Win2012-3.Patches"
+  Invoke-Reboot
+}
+
+  # Note may also need this update: https://www.catalog.update.microsoft.com/Search.aspx?q=KB2919355
+  # http://download.windowsupdate.com/d/msdownload/update/software/secu/2014/04/clearcompressionflag_3104315db9d84f6a2a56b9621e89ea66a8c27604.exe
+  # http://download.windowsupdate.com/c/msdownload/update/software/crup/2014/02/windows8.1-kb2937592-x64_4abc0a39c9e500c0fbe9c41282169c92315cafc2.msu
+  # http://download.windowsupdate.com/c/msdownload/update/software/secu/2014/04/windows8.1-kb2959977-x64_574ba2d60baa13645b764f55069b74b2de866975.msu
+  # http://download.windowsupdate.com/c/msdownload/update/software/secu/2014/04/windows8.1-kb2934018-x64_234a5fc4955f81541f5bfc0d447e4fc4934efc38.msu
+  # http://download.windowsupdate.com/c/msdownload/update/software/crup/2014/03/windows8.1-kb2938439-x64_3ed1574369e36b11f37af41aa3a875a115a3eac1.msu
+  # http://download.windowsupdate.com/d/msdownload/update/software/crup/2014/02/windows8.1-kb2919355-x64_e6f4da4d33564419065a7370865faacf9b40ff72.msu
+  # http://download.windowsupdate.com/d/msdownload/update/software/crup/2014/02/windows8.1-kb2932046-x64_6aee5fda6e2a6729d1fbae6eac08693acd70d985.msu
+
+  if (-not (Test-Path "$PackerLogs\Win2012-4.Patches"))
+  {
+    # August 2016
+    # https://social.technet.microsoft.com/Forums/en-US/36fb0752-d4a0-48ec-b5e1-217eec18ac20/stuck-checking-for-updates-server-2012-never-completes-the-operation?forum=winserver8gen
+    # https://www.experts-exchange.com/questions/29019987/Windows-Server-2012-Standard-stuck-on-Checking-for-Updates.html
+  
+    Install_Win_Patch -PatchUrl "http://download.windowsupdate.com/c/msdownload/update/software/updt/2016/07/windows8-rt-kb3179575-x64_76e44428b65d806c446638cf340db9d3da452063.msu"
+    Touch-File "$PackerLogs\Win2012-4.Patches"
+    Invoke-Reboot
+  }
+  
+ # [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\WindowsUpdate\UX]
+ # "IsConvergedUpdateStackEnabled"=dword:00000000
+ 
+#  [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\WindowsUpdate\UX\Settings]
+#  "UxOption"=dword:00000000
+  
+if (-not (Test-Path "$PackerLogs\Win2012-5.Patches"))
+{
+  # The April 11, 2017—KB4015551 (Monthly Rollup) is also needed as it contains
+  # a critical patch that is unavailable separetly - see workaround discussion below. 
+  # https://social.technet.microsoft.com/Forums/en-US/af1b44f6-02e7-4baa-99e3-da38d5e9b30d/server-2012-std-non-r2-windows-update-stuck-at-quotchecking-for-updatesquot?forum=winserver8gen
+  # https://social.technet.microsoft.com/Forums/windowsserver/en-US/eff2be4b-120c-4f7c-b649-c7df2512b611/windows-update-checking-for-updates-kb3102810-windows-server-2012-not-r2?forum=winservergen
+
+  Install_Win_Patch -PatchUrl "http://download.windowsupdate.com/d/msdownload/update/software/secu/2017/04/windows8-rt-kb4015551-x64_8e3457ab5a3108ede25df0240463ba16de7f87f8.msu"
+  Touch-File "$PackerLogs\Win2012-5.Patches"
+  Invoke-Reboot
+}
+
+
+
+

--- a/templates/win/common/scripts/bootstrap/bootstrap-packerbuild.ps1
+++ b/templates/win/common/scripts/bootstrap/bootstrap-packerbuild.ps1
@@ -46,6 +46,7 @@ if (-not (Test-Path "$PackerLogs\BootstrapSchedTask.installed")) {
 # Same seems to apply to win-2012 so disabling for this too.
 if ($WindowsVersion -like $WindowsServer2016 -or $WindowsVersion -like $WindowsServer2012) {
   Write-Output "Bypassing WSUS - Go Direct to Microsoft for updates"
+  Disable-WindowsAutoUpdate
 }
 else {
   Enable-UpdatesFromInternalWSUS

--- a/templates/win/common/scripts/common/windows-env.ps1
+++ b/templates/win/common/scripts/common/windows-env.ps1
@@ -291,6 +291,22 @@ Function Enable-UpdatesFromInternalWSUS {
   }
 }
 
+# Helper Function set Windows Update to use the Internal Production WSUS Server
+Function Disable-WindowsAutoUpdate {
+  if (-not (Test-Path "$PackerLogs\DisableWinAutoUpdate.installed")) {
+
+    Write-Output "Disabling Windows AutoUpdate"
+
+    reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" /v "NoAutoUpdate" /t REG_DWORD /d 1 /f
+    reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" /v "AUOptions" /t REG_DWORD /d 2 /f
+    reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" /v "ScheduledInstallDay" /t REG_DWORD /d 0 /f
+    reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" /v "ScheduledInstallTime" /t REG_DWORD /d 3 /f
+
+    Touch-File "$PackerLogs/DisableWinAutoUpdate.installed"
+  }
+}
+
+
 # Helper Function to install 7zip as a key package
 Function Install-7ZipPackage {
   if (-not (Test-Path "$PackerLogs\7zip.installed")) {


### PR DESCRIPTION
Disable AutoUpdate for Windows 2012 and Windows 10/2016.
This means that the PsWindowsUpdate process has a chance to "get in
first" as it appears the Win-2012 is failing to check for updates.

Experimental.