### PR TITLE
(IMAGES-1017) Localise TZ Test

### DIFF
--- a/templates/win/common/scripts/acceptance/platform/DateTime.Tests.ps1
+++ b/templates/win/common/scripts/acceptance/platform/DateTime.Tests.ps1
@@ -8,8 +8,8 @@
 
 . C:\Packer\Scripts\windows-env.ps1
 
-# Pick up the Timezone from systeminfo
-$Timezone = $(systeminfo | findstr  /L 'Zone:')
+# Pick up the Timezone from systeminfo - with Localised Timezone Title
+$Timezone = $(systeminfo | findstr  /L $TZTitle)
 # Note (Get-CimInstance -class Win32_OperatingSystem).LastBootUpTime would be better here, but its not available in PS2.
 # Noting for future.
 $LastBoot = (Get-WmiObject -class Win32_OperatingSystem | Select-Object @{label='LastBootUpTime';expression={$_.ConvertToDateTime($_.LastBootUpTime)}}).LastBootUpTime

--- a/templates/win/common/scripts/common/windows-env.ps1
+++ b/templates/win/common/scripts/common/windows-env.ps1
@@ -46,8 +46,16 @@ $WindowsAdminSID =  (Get-WmiObject win32_useraccount -Filter "Sid like 'S-1-5-21
 # Crude Code to chose appropriate resonse for YesNo
 $PrimaryLanguage = (Get-Culture).TwoLetterISOLanguageName
 Switch ($PrimaryLanguage) {
-  "fr"  {$AnswerPromptYes = "O"; break}
-  default {$AnswerPromptYes = "Y"; break}
+  "fr"  {
+    $global:AnswerPromptYes = "O"
+    $global:TZTitle = "Fuseau horaire:"
+    break
+  }
+  default {
+    $global:AnswerPromptYes = "Y"
+    $global:TZTitle = "Zone:"
+    break 
+  }
 }
 
 # Test to see if we are Core Version or not.


### PR DESCRIPTION
French uses a different timezone title in the systeminfo output so add
localisation support to enable Pester tests to work correctly.