### PR TITLE
(maint) Bump the RHEL 7 template version

### DIFF
--- a/templates/redhat/7.2/x86_64/vars.json
+++ b/templates/redhat/7.2/x86_64/vars.json
@@ -2,7 +2,7 @@
     "template_name"                         : "redhat-7.2-x86_64",
     "template_os"                           : "rhel7-64",
     "beakerhost"                            : "redhat7-64",
-    "version"                               : "0.0.4",
+    "version"                               : "0.0.5",
     "iso_url"                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/rhel-server-7.2-x86_64-dvd.iso",
     "iso_checksum"                          : "03f3a0291634335f6995534d829bd21ffaa0d000004dfeb1b2fb81052d64a4d5",
     "iso_checksum_type"                     : "sha256",


### PR DESCRIPTION
This is needed to pick up the recent repo configuration changes for this
platform.