### PR TITLE
Split out yum repos for rhel 7 for yum group support

### DIFF
--- a/manifests/modules/packer/manifests/repos.pp
+++ b/manifests/modules/packer/manifests/repos.pp
@@ -23,7 +23,7 @@ class packer::repos {
     $base_url = $::operatingsystemmajrelease ? {
       # TODO: RHEL 8 is beta atm, we need to update with some local mirros when available
       '8' => "https://downloads.redhat.com/redhat/rhel/rhel-8-beta",
-      '7' => "${repo_mirror}/rpm-rhel-7-${::architecture}",
+      '7' => "${repo_mirror}/rpm__remote_rhel-7",
       '6' => "${repo_mirror}/rpm__remote_rhel-68-${::architecture}",
       '5' => "${os_mirror}/rhel50server-${::architecture}/RPMS.all"
     }
@@ -41,13 +41,6 @@ class packer::repos {
         baseurl  => "${base_url}/appstream/${::architecture}",
         gpgcheck => "1",
         gpgkey   => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
-      }
-    } elsif $::operatingsystemmajrelease == "7" {
-      yumrepo { "localmirror-everything":
-        descr    => "localmirror-everything",
-        baseurl  => "${base_url}",
-        gpgcheck => "1",
-        gpgkey   => "file:///etc/pki/rpm-gpg/${gpgkey}"
       }
     } elsif $::operatingsystemmajrelease == "5" {
       yumrepo { "localmirror-os":

--- a/templates/redhat/7.2-fips/x86_64/vars.json
+++ b/templates/redhat/7.2-fips/x86_64/vars.json
@@ -2,7 +2,7 @@
     "template_name"                         : "redhat-fips-7.2-x86_64",
     "template_os"                           : "rhel7-64",
     "beakerhost"                            : "redhatfips7-64",
-    "version"                               : "0.0.3",
+    "version"                               : "0.0.4",
     "iso_url"                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/rhel-server-7.2-x86_64-dvd.iso",
     "iso_checksum"                          : "03f3a0291634335f6995534d829bd21ffaa0d000004dfeb1b2fb81052d64a4d5",
     "iso_checksum_type"                     : "sha256",

--- a/templates/redhat/7.2/x86_64/vars.json
+++ b/templates/redhat/7.2/x86_64/vars.json
@@ -2,7 +2,7 @@
     "template_name"                         : "redhat-7.2-x86_64",
     "template_os"                           : "rhel7-64",
     "beakerhost"                            : "redhat7-64",
-    "version"                               : "0.0.5",
+    "version"                               : "0.0.6",
     "iso_url"                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/rhel-server-7.2-x86_64-dvd.iso",
     "iso_checksum"                          : "03f3a0291634335f6995534d829bd21ffaa0d000004dfeb1b2fb81052d64a4d5",
     "iso_checksum_type"                     : "sha256",


### PR DESCRIPTION
Artifactory does not merge yum groups in a virtual repo (https://www.jfrog.com/jira/browse/RTFACT-14058), this PR breaks out the os, extras and optional repos to individual yum configs so the systems can use yum groups.