### PR TITLE
(IMAGES-1004) Platform9 BIOS Base Build

### DIFF
--- a/templates/win/common/scripts/platform9/platform9-config.ps1
+++ b/templates/win/common/scripts/platform9/platform9-config.ps1
@@ -1,0 +1,11 @@
+# Platform9 Configuration Script.
+# Placeholder for Platform 9 scripts.
+
+. C:\Packer\Scripts\windows-env.ps1
+
+$rundate = date
+write-output "Script: platform9-config.ps1 Starting at: $rundate"
+
+
+
+Write-Output "Bye"

--- a/templates/win/common/vars.json
+++ b/templates/win/common/vars.json
@@ -1,5 +1,5 @@
 {
-  "version"             : "20190111_PROD",
+  "version"             : "20190118_DEV",
 
   "headless"            : "true",
 

--- a/templates/win/common/vmware.vcenter.base.json
+++ b/templates/win/common/vmware.vcenter.base.json
@@ -1,0 +1,180 @@
+{
+  "variables": {
+
+    "vm_version"                : "14",
+    "disk_size"                 : "61440",
+    "memsize"                   : "4096",
+    "RAM_reserve_all"           : "true",
+    "numvcpus"                  : "2",
+    "disk_controller_type"      : "pvscsi",
+    "disk_thin_provisioned"     : "true",
+    "shutdown_command"          : "powershell -executionpolicy bypass -File C:\\Packer\\Scripts\\init-sysprep.ps1 -ArumentList \"-Shutdown\" >> C:\\Packer\\Logs\\Init-Sysprep.log 2>&1",
+    "iso_disk"                  : "[AI_Insurgency_Test_Images] iso/",
+
+    "vsphere_guest_os"          : null,
+    "iso_name"                  : null,
+
+    "packer_vcenter_host"       : null,
+    "packer_vcenter_username"   : null,
+    "packer_vcenter_password"   : null,
+    "packer_vcenter_dc"         : null,
+    "packer_vcenter_cluster"    : null,
+    "packer_vcenter_datastore"  : null,
+    "packer_vcenter_folder"     : null,
+    "packer_vcenter_net"        : null,
+    "packer_vcenter_insecure"   : null,
+
+    "qa_root_passwd_plain"      : null,
+    "packer_sha"                : null,
+
+    "firmware"                  : null,
+
+    "boot_wait"                 : "10ms",
+    "network_card"              : "vmxnet3",
+    "boot_order"                : "disk,cdrom"
+  },
+
+  "description": "Builds a Windows template VM for use in VMware/cygwin directly on vcenter",
+
+  "builders": [
+    {
+      "type"                   : "vsphere-23-iso",
+
+      "name"                   : "vcenter-base",
+      "vm_name"                : "{{user `template_name`}}-{{user `version`}}.{{user `firmware`}}.base",
+      "vm_version"             : "{{user `vm_version`}}",
+      "notes"                  : "Packer build: {{user `template_name`}}-{{user `version`}} built {{isotime}} SHA: {{user `packer_sha`}}",
+
+      "vcenter_server"         : "{{user `packer_vcenter_host`}}",
+      "insecure_connection"    : "{{user `packer_vcenter_insecure`}}",
+      "username"               : "{{user `packer_vcenter_username`}}",
+      "password"               : "{{user `packer_vcenter_password`}}",
+      "datacenter"             : "{{user `packer_vcenter_dc`}}",
+      "cluster"                : "{{user `packer_vcenter_cluster`}}",
+      "convert_to_template"    : "false",
+      "folder"                 : "{{user `packer_vcenter_folder`}}",
+
+      "firmware"               : "{{user `firmware`}}",
+      "CPUs"                   : "{{user `numvcpus`}}",
+      "CPU_limit"              : -1,
+      "RAM"                    : "{{user `memsize`}}",
+      "RAM_reserve_all"        : "{{user `RAM_reserve_all`}}",
+      "network"                : "{{user `packer_vcenter_net`}}",
+      "network_card"           : "{{user `network_card`}}",
+      "guest_os_type"          : "{{user `vsphere_guest_os`}}",
+      "datastore"              : "{{user `packer_vcenter_datastore`}}",
+      "disk_controller_type"   : "{{user `disk_controller_type`}}",
+      "disk_thin_provisioned"  : "{{user `disk_thin_provisioned`}}",
+      "disk_size"              : "{{user `disk_size`}}",
+      "boot_order"             : "{{user `boot_order`}}",
+      "boot_wait"              : "{{user `boot_wait`}}",
+      "host"                   : "",
+      "boot_command" : [
+        "<spacebar><wait><spacebar><wait><enter><wait><enter><wait><enter><wait><enter>"
+      ],
+
+      "shutdown_command"  : "{{user `shutdown_command`}}",
+      "shutdown_timeout"  : "{{user `shutdown_timeout`}}",
+
+      "floppy_files": [
+        "./tmp/autounattend.xml",
+        "./files/platform-packages.ps1",
+        "../../common/scripts/common/windows-env.ps1",
+        "../../common/scripts/bootstrap/bootstrap-base.bat",
+        "../../common/scripts/bootstrap/bootstrap-packerbuild.ps1",
+        "../../common/scripts/bootstrap/shutdown-packerbuild.ps1",
+        "../../common/scripts/bootstrap/startup-profile.ps1"
+      ],
+      "iso_paths": [
+        "{{user `iso_disk`}}{{user `iso_name`}}",
+        "{{user `iso_disk`}}windows.iso"
+      ],
+
+      "communicator"      : "winrm",
+      "winrm_username"    : "{{user `winrm_username`}}",
+      "winrm_password"    : "{{user `winrm_password`}}",
+      "winrm_timeout"     : "{{user `winrm_timeout`}}"
+    }
+  ],
+  "provisioners": [
+    {
+      "type"        : "file",
+      "source"      : "../../common/scripts/bootstrap/shutdown-packerbuild.ps1",
+      "destination" : "C:\\Packer\\Scripts\\shutdown-packerbuild.ps1"
+    },
+    {
+      "type"        : "file",
+      "source": "../../common/scripts/common/",
+      "destination": "C:\\Packer\\Scripts"
+    },
+    {
+      "type"        : "file",
+      "source": "../../common/scripts/bootstrap/",
+      "destination": "C:\\Packer\\Scripts"
+    },
+    {
+      "type"        : "file",
+      "source": "../../common/scripts/config/",
+      "destination": "C:\\Packer\\Config"
+    },
+    {
+      "type"        : "file",
+      "source": "../../common/scripts/acceptance/",
+      "destination": "C:\\Packer\\Acceptance"
+    },
+    {
+      "type"        : "file",
+      "source": "./tmp/post-clone.autounattend.xml",
+      "destination": "C:\\Packer\\Config\\post-clone.autounattend.xml"
+    },
+    {
+      "type"        : "powershell",
+      "inline"      : [
+          "C:/Packer/Scripts/test-packerbuild -TestPhase bootstrap-packerbuild"
+        ],
+        "environment_vars" : [
+          "PBTEST_WindowsCurrentVersion={{user `CurrentVersion`}}",
+          "PBTEST_WindowsProductName={{user `ProductName`}}",
+          "PBTEST_WindowsEditionID={{user `EditionID`}}",
+          "PBTEST_WindowsInstallationType={{user `InstallationType`}}",
+          "PBTEST_WindowsReleaseID={{user `ReleaseID`}}",
+          "PBTEST_WindowsMemorySize={{user `memsize`}}"
+        ],
+      "valid_exit_codes" : [ 0 ]
+    },
+    {
+      "type"         : "powershell",
+      "script"       : "../../common/scripts/provisioners/initiate-windows-update.ps1",
+      "environment_vars" : [
+        "ADMIN_USERNAME={{user `winrm_username`}}",
+        "ADMIN_PASSWORD={{user `winrm_password`}}"
+      ]
+    },
+    {
+      "type" : "windows-restart",
+      "restart_timeout" : "{{user `winupdate_timeout`}}"
+    },
+    {
+      "type": "powershell",
+      "inline" : [
+        "C:/Packer/Scripts/test-packerbuild -TestPhase windows-update"
+      ],
+      "valid_exit_codes" : [ 0 ]
+    },
+    {
+      "type"   : "powershell",
+      "script" : "../../common/scripts/provisioners/clean-disk-dism.ps1"
+    },
+    {
+      "type": "powershell",
+      "script" : "../../common/scripts/provisioners/cleanup-host.ps1"
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type"   : "powershell",
+      "script" : "../../common/scripts/provisioners/clean-disk-sdelete.ps1"
+    }
+  ]
+}

--- a/templates/win/common/vmware.vcenter.platform9.json
+++ b/templates/win/common/vmware.vcenter.platform9.json
@@ -1,0 +1,146 @@
+{
+  "variables": {
+    "disk_size"                 : "61440",
+    "memsize"                   : "4096",
+    "RAM_reserve_all"           : "true",
+    "numvcpus"                  : "2",
+    "shutdown_command"          : "powershell -executionpolicy bypass -File C:\\Packer\\Scripts\\init-sysprep.ps1 -ArumentList \"-Shutdown\" >> C:\\Packer\\Logs\\Init-Sysprep.log 2>&1",
+
+    "packer_vcenter_host"       : null,
+    "packer_vcenter_username"   : null,
+    "packer_vcenter_password"   : null,
+    "packer_vcenter_dc"         : null,
+    "packer_vcenter_cluster"    : null,
+    "packer_vcenter_datastore"  : null,
+    "packer_vcenter_folder"     : null,
+    "packer_vcenter_net"        : null,
+    "packer_vcenter_insecure"   : null,
+
+    "base_template_name"        : null,
+
+    "qa_root_passwd_plain"      : null,
+    "packer_sha"                : null,
+
+    "boot_wait"                 : "10ms",
+    "boot_order"                : "disk,cdrom"
+  },
+
+  "description": "Builds a Windows template VM for use in VMware/cygwin directly on vcenter",
+
+  "builders": [
+    {
+      "type"                   : "vsphere-23-clone",
+
+      "name"                   : "vcenter-clone",
+      "template"               : "{{user `base_template_name`}}",
+      "vm_name"                : "{{user `template_name`}}-{{user `version`}}.platform9",
+      "notes"                  : "Packer build: {{user `template_name`}}-{{user `version`}} built {{isotime}} SHA: {{user `packer_sha`}}",
+
+      "vcenter_server"         : "{{user `packer_vcenter_host`}}",
+      "insecure_connection"    : "{{user `packer_vcenter_insecure`}}",
+      "username"               : "{{user `packer_vcenter_username`}}",
+      "password"               : "{{user `packer_vcenter_password`}}",
+      "datacenter"             : "{{user `packer_vcenter_dc`}}",
+      "cluster"                : "{{user `packer_vcenter_cluster`}}",
+      "convert_to_template"    : "false",
+      "folder"                 : "{{user `packer_vcenter_folder`}}",
+
+      "CPUs"                   : "{{user `numvcpus`}}",
+      "CPU_limit"              : -1,
+      "RAM"                    : "{{user `memsize`}}",
+      "RAM_reserve_all"        : "{{user `RAM_reserve_all`}}",
+      "datastore"              : "{{user `packer_vcenter_datastore`}}",
+      "disk_size"              : "{{user `disk_size`}}",
+      "host"                   : "",
+
+      "linked_clone"           : "false",
+
+      "shutdown_command"  : "{{user `shutdown_command`}}",
+      "shutdown_timeout"  : "{{user `shutdown_timeout`}}",
+
+      "communicator"      : "winrm",
+      "winrm_username"    : "{{user `winrm_username`}}",
+      "winrm_password"    : "{{user `winrm_password`}}",
+      "winrm_timeout"     : "{{user `winrm_timeout`}}"
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "file",
+      "source": "../../common/scripts/bootstrap/shutdown-packerbuild.ps1",
+      "destination": "C:\\Packer\\Scripts\\shutdown-packerbuild.ps1"
+    },
+    {
+      "type": "file",
+      "source": "../../common/puppet/",
+      "destination": "C:\\Packer\\puppet\\modules"
+    },
+    {
+      "type": "file",
+      "source": "../../common/scripts/common/",
+      "destination": "C:\\Packer\\Scripts"
+    },
+    {
+      "type": "file",
+      "source": "../../common/scripts/platform9/",
+      "destination": "C:\\Packer\\Scripts"
+    },
+    {
+      "type": "file",
+      "source": "../../common/scripts/config/",
+      "destination": "C:\\Packer\\Config"
+    },
+    {
+      "type": "file",
+      "source": "../../common/scripts/acceptance/",
+      "destination": "C:\\Packer\\Acceptance"
+    },
+    {
+      "type": "file",
+      "source": "./tmp/post-clone.autounattend.xml",
+      "destination": "C:\\Packer\\Config\\post-clone.autounattend.xml"
+    },
+    {
+      "type": "powershell",
+      "script" : "../../common/scripts/provisioners/puppet-configure.ps1",
+      "environment_vars" : [
+        "QA_ROOT_PASSWD_PLAIN={{user `qa_root_passwd_plain`}}",
+        "PackerTemplateName={{user `template_name`}}-{{user `version`}}",
+        "PackerSHA={{user `packer_sha`}}",
+        "PackerTemplateType=vmpooler"
+      ]
+    },
+    {
+      "type": "powershell",
+      "inline" : [
+        "C:/Packer/Scripts/test-packerbuild -TestPhase puppet"
+      ],
+      "valid_exit_codes" : [ 0 ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "powershell",
+      "script" : "../../common/scripts/provisioners/config-winsettings.ps1"
+    },
+    {
+      "type": "powershell",
+      "script" : "../../common/scripts/provisioners/cleanup-host.ps1"
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "powershell",
+      "inline" : [
+        "C:/Packer/Scripts/test-packerbuild -TestPhase platform"
+      ],
+      "valid_exit_codes" : [ 0 ]
+    },
+    {
+      "type"   : "powershell",
+      "script" : "../../common/scripts/provisioners/clean-disk-sdelete.ps1"
+    }
+  ]
+}


### PR DESCRIPTION
Create two separate vcenter build files initially for Platform9. 

Although platform9 is a bios build, the base file should be generic enough to build either UEFI or BIOS files (little packer difference between them once the disk format is setup in the autounattend.xml file).

The base file creates an up to date windows base image, whereas the platform9 file performs the necessary base configuration. Further work will be done in later tickets to add the correct drivers and sysprep stage for platform9.

Provide placeholder platform9 script file to verify the build.