### PR TITLE
(MAINT) Allow Mock build to Fail Gracefully

### DIFF
--- a/templates/win/2019-mock/x86_64/vars.json
+++ b/templates/win/2019-mock/x86_64/vars.json
@@ -1,5 +1,5 @@
 {
-    "A_Comment"         : "This is preview so not all 2019 defs are available below",
+    "A_Comment"         : "Windows 2019 Mock build for pipeline testing",
     "template_name"     : "win-2019-mock-x86_64",
     "beakerhost"        : "windows2019-64",
     "vbox_guest_os"     : "Windows2016_64",
@@ -7,16 +7,18 @@
     "vsphere_guest_os"  : "windows9Server64Guest",
     "windows_version"   : "Windows-2019",
     "image_name"        : "Windows Server 2019 SERVERSTANDARD",
-    "product_key"       : "MFY9F-XBN2F-TYFMP-CCV49-RMYVH",
-    "iso_name"          : "/Windows_InsiderPreview_Server_vNext_en-us_17723.iso",
+    "product_key"       : "N69G4-B89J2-4G8F4-WWYCC-J464C",
+    "iso_name"          : "en_windows_server_2019_x64_dvd_3c2cf1202.iso",
     "iso_checksum_type" : "md5",
-    "iso_checksum"      : "593ef03364c7cd730f0ec89e322ab4ca",
+    "iso_checksum"      : "37c51cc09182237ae2c30c9d8ce3c41e",
     "boot_command"      : "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter>",
 
-    "CurrentVersion"    : "6.1",
+    "CurrentVersion"    : "6.3",
     "ProductName"       : "Windows Server 2019 Standard",
     "EditionID"         : "ServerStandard",
     "InstallationType"  : "Server",
-    "ReleaseID"         : "N/A"
+    "ReleaseID"         : "1809",
+
+    "valid_exit_codes"  : "0,1"
 
 }

--- a/templates/win/common/gen-xslt.sh
+++ b/templates/win/common/gen-xslt.sh
@@ -14,7 +14,7 @@ export PACKER_WIN_VERSION=`jq -r .windows_version vars.json`
 
 # Firmware is set externally but if not set pick up from vars file, otherwise fail.
 [ -z "${PACKER_FIRMWARE}" ] && export PACKER_FIRMWARE=`jq -r '.firmware //empty' vars.json`
-if [ -z "${PACKER_FIRMWARE}" ]; then echo "PACKER_FIRMWARE not set - exit;" exit 1; fi
+[ -z "${PACKER_FIRMWARE}" ] && export PACKER_FIRMWARE=efi
 
 # PACKER_WIN_PROC_ARCH defaults to "amd64" unless specified
 # These values are specific to the Autounattend.xml files and differ from

--- a/templates/win/common/vmware.vcenter.base.json
+++ b/templates/win/common/vmware.vcenter.base.json
@@ -30,7 +30,9 @@
 
     "boot_wait"                 : "10ms",
     "network_card"              : "vmxnet3",
-    "boot_order"                : "disk,cdrom"
+    "boot_order"                : "disk,cdrom",
+
+    "valid_exit_codes"          : "0"
   },
 
   "description": "Builds a Windows template VM for use in VMware/cygwin directly on vcenter",
@@ -121,7 +123,7 @@
           "PBTEST_WindowsReleaseID={{user `ReleaseID`}}",
           "PBTEST_WindowsMemorySize={{user `memsize`}}"
         ],
-      "valid_exit_codes" : [ 0 ]
+      "valid_exit_codes" : "{{user `valid_exit_codes`}}"
     },
     {
       "type"         : "powershell",
@@ -140,7 +142,7 @@
       "inline" : [
         "C:/Packer/Scripts/test-packerbuild -TestPhase windows-update"
       ],
-      "valid_exit_codes" : [ 0 ]
+      "valid_exit_codes" : "{{user `valid_exit_codes`}}"
     },
     {
       "type"   : "powershell",

--- a/templates/win/common/vmware.vcenter.cygwin.json
+++ b/templates/win/common/vmware.vcenter.cygwin.json
@@ -34,7 +34,9 @@
     "boot_wait"                 : "10ms",
     "convert_to_template"       : "false",
     "network_card"              : "vmxnet3",
-    "boot_order"                : "disk,cdrom"
+    "boot_order"                : "disk,cdrom",
+
+    "valid_exit_codes"          : "0"
   },
 
   "description": "Builds a Windows template VM for use in VMware/cygwin directly on vcenter",
@@ -173,7 +175,7 @@
           "PBTEST_WindowsReleaseID={{user `ReleaseID`}}",
           "PBTEST_WindowsMemorySize={{user `memsize`}}"
         ],
-      "valid_exit_codes" : [ 0 ]
+      "valid_exit_codes" : "{{user `valid_exit_codes`}}"
     },
     {
       "type": "powershell",
@@ -192,7 +194,7 @@
       "inline" : [
         "C:/Packer/Scripts/test-packerbuild -TestPhase windows-update"
       ],
-      "valid_exit_codes" : [ 0 ]
+      "valid_exit_codes" : "{{user `valid_exit_codes`}}"
     },
     {
       "type"   : "powershell",
@@ -209,7 +211,7 @@
       "inline" : [
         "C:/Packer/Scripts/test-packerbuild -TestPhase cygwin"
       ],
-      "valid_exit_codes" : [ 0 ]
+      "valid_exit_codes" : "{{user `valid_exit_codes`}}"
     },
     {
       "type": "powershell",
@@ -226,7 +228,7 @@
       "inline" : [
         "C:/Packer/Scripts/test-packerbuild -TestPhase puppet"
       ],
-      "valid_exit_codes" : [ 0 ]
+      "valid_exit_codes" : "{{user `valid_exit_codes`}}"
     },
     {
       "type": "windows-restart"
@@ -251,7 +253,7 @@
       "inline" : [
         "C:/Packer/Scripts/test-packerbuild -TestPhase platform"
       ],
-      "valid_exit_codes" : [ 0 ]
+      "valid_exit_codes" : "{{user `valid_exit_codes`}}"
     },
     {
       "type"   : "powershell",

--- a/templates/win/common/vmware.vcenter.platform9.json
+++ b/templates/win/common/vmware.vcenter.platform9.json
@@ -22,7 +22,9 @@
     "packer_sha"                : null,
 
     "boot_wait"                 : "10ms",
-    "boot_order"                : "disk,cdrom"
+    "boot_order"                : "disk,cdrom",
+
+    "valid_exit_codes"          : "0"
   },
 
   "description": "Builds a Windows template VM for use in VMware/cygwin directly on vcenter",
@@ -115,7 +117,7 @@
       "inline" : [
         "C:/Packer/Scripts/test-packerbuild -TestPhase puppet"
       ],
-      "valid_exit_codes" : [ 0 ]
+      "valid_exit_codes" : "{{user `valid_exit_codes`}}"
     },
     {
       "type": "windows-restart"
@@ -140,7 +142,7 @@
       "inline" : [
         "C:/Packer/Scripts/test-packerbuild -TestPhase platform"
       ],
-      "valid_exit_codes" : [ 0 ]
+      "valid_exit_codes" : "{{user `valid_exit_codes`}}"
     },
     {
       "type"   : "powershell",


### PR DESCRIPTION
Use the new packer array variables to vary the valid_exit codes from the
default fail for acceptance tests for the Mock build. This allows the
windows update validation (and other Pester tests) to fail gracefully
without aborting the build.

The Mock build is a very useful build for pipeline througput testing
with a shortened build cycle.

**Breaking** Have also fixed a late-breaking error with the firmware settings that was affecting general windows builds.