### PR TITLE
(MAINT) Fix /mode:vm for sysprep

### DIFF
--- a/templates/win/common/scripts/common/init-sysprep.ps1
+++ b/templates/win/common/scripts/common/init-sysprep.ps1
@@ -79,7 +79,7 @@ $SysPrepArgs = "/generalize /oobe /quit /unattend:C:\Packer\Config\post-clone.au
 if ( ($ImageProvisioner -eq "vmware") -and ($WindowsVersion -notlike $WindowsServer2008R2) -and ($WindowsVersion -notlike $WindowsServer2008)) {
     # /mode:vm was only introduced from win-2012 onwards
     Write-Output "Using /mode:vm"
-    $SysPrepArgs += "/mode:vm"
+    $SysPrepArgs += " /mode:vm"
 }
 Write-Output "Starting the Sysprep Process"
 $zproc = Start-Process "$SysPrepDir\sysprep.exe" @SprocParms -ArgumentList "$SysPrepArgs"


### PR DESCRIPTION
This command is missing a critical space which barfs the sysprep.