### PR TITLE
(IMAGES-962) Updated templates not to use ENV vars

### DIFF
--- a/templates/common/vmware.vcenter.json
+++ b/templates/common/vmware.vcenter.json
@@ -25,14 +25,14 @@
       "packer_vcenter_net"                           : null,
       "packer_vcenter_insecure"                      : null,
 
-      "packer_sha"                                   : "{{env `PACKER_SHA`}}",
+      "packer_sha"                                   : "{{user `packer_sha`}}",
 
       "convert_to_template"                          : "false",
       "boot_order"                                   : "disk,cdrom",
       "communicator_protocol"                        : "ssh",
 
       "vmware_base_required_modules"                 : "saz-ssh puppetlabs-stdlib",
-  
+
       "vmware_base_vmx_data_memsize"                 : "512",
       "vmware_base_vmx_data_cpuid_coresPerSocket"    : "1",
       "vmware_base_vmx_data_numvcpus"                : "1",
@@ -41,7 +41,7 @@
       "vmware_base_vm_scsi0_present"                 : "TRUE",
       "vmware_base_vm_smc_present"                   : "",
       "vmware_base_vm_hpet0_present"                 : "",
-      "vmware_base_vm_ich7m_present"                 : "",                     
+      "vmware_base_vm_ich7m_present"                 : "",
       "vmware_base_vm_firmware"                      : "",
       "vmware_base_vmx_keyboard_and_mouse_profile"   : "",
       "vmware_base_vm_disk_adapter_type"             : "pvscsi",
@@ -50,11 +50,11 @@
       "vmware_base_vmx_data_ethernet0_pciSlotNumber" : "33",
 
       "vmware_vsphere_nocm_required_modules"         : null,
-    
+
       "qa_root_passwd"                               : "{{env `QA_ROOT_PASSWD`}}",
       "qa_root_passwd_plain"                         : "{{env `QA_ROOT_PASSWD_PLAIN`}}",
 
-    
+
       "ssh_username"                                 : "root",
       "ssh_password"                                 : "puppet",
       "inject_http_seed_in_boot_command"             : "false",
@@ -72,7 +72,7 @@
       "communicator"                                 : "{{user `communicator_protocol`}}",
       "ssh_username"                                 : "{{user `ssh_username`}}",
       "ssh_password"                                 : "{{user `ssh_password`}}",
-     
+
 
       "name"                                         : "vcenter-iso",
       "vm_name"                                      : "{{user `template_name`}}-{{user `version`}}",
@@ -157,8 +157,8 @@
                                                           "PC_REPO={{user `pc_repo`}}"
                                                        ],
       "scripts"                                      : "{{user `vmware_base_provisioning_scripts`}}"
-    },  
-  
+    },
+
     {
       "type"                                         : "puppet-masterless",
       "execute_command"                              : "{{.FacterVars}} PATH=$PATH:/opt/puppetlabs/bin puppet apply --verbose --detailed-exitcodes --modulepath='/tmp/packer-puppet-masterless/manifests/modules' {{.ManifestFile}}",

--- a/templates/common/vmware.vsphere.nocm.json
+++ b/templates/common/vmware.vsphere.nocm.json
@@ -18,11 +18,11 @@
     "provisioner"                           : "vmware",
     "shutdown_command"                      : "/sbin/halt -h -p",
 
-    "qa_root_passwd"                        : "{{env `QA_ROOT_PASSWD`}}",
-    "qa_root_passwd_plain"                  : "{{env `QA_ROOT_PASSWD_PLAIN`}}",
-    "packer_sha"                            : "{{env `PACKER_SHA`}}",
-    "packer_source_dir"                     : "{{env `PACKER_VM_SRC_DIR`}}",
-    "packer_output_dir"                     : "{{env `PACKER_VM_OUT_DIR`}}"
+    "qa_root_passwd"                        : "{{user `qa_root_passwd`}}",
+    "qa_root_passwd_plain"                  : "{{user `qa_root_passwd_plain`}}",
+    "packer_sha"                            : "{{user `packer_sha`}}",
+    "packer_source_dir"                     : "{{user `packer_vm_src_dir`}}",
+    "packer_output_dir"                     : "{{user `packer_vm_out_dir`}}"
   },
 
   "builders": [

--- a/templates/vro/common/vmware.vsphere.nocm.json
+++ b/templates/vro/common/vmware.vsphere.nocm.json
@@ -16,10 +16,10 @@
 
     "raw_vmx_file"              : "{{env `VRO_RAW_VMX_PATH` }}",
 
-    "qa_root_passwd_plain"      : "{{env `QA_ROOT_PASSWD_PLAIN`}}",
-    "packer_sha"                : "{{env `PACKER_SHA`}}",
-    "packer_source_dir"         : "{{env `PACKER_VM_SRC_DIR`}}",
-    "packer_output_dir"         : "{{env `PACKER_VM_OUT_DIR`}}"
+    "qa_root_passwd_plain"      : "{{user `qa_root_passwd_plain`}}",
+    "packer_sha"                : "{{user `packer_sha`}}",
+    "packer_source_dir"         : "{{user `packer_vm_src_dir`}}",
+    "packer_output_dir"         : "{{user `packer_vm_out_dir`}}"
   },
 
   "builders": [


### PR DESCRIPTION
I've updated the templates to use user vars instead of env vars

This works along and needs to be merged with:
https://github.com/puppetlabs/platform-ci-utils/pull/58