### PR TITLE
(MAINT) Fix to un-terminated string

### DIFF
--- a/templates/win/common/vmware.vcenter.cygwin.json
+++ b/templates/win/common/vmware.vcenter.cygwin.json
@@ -48,7 +48,7 @@
       "type": "vsphere-23-iso",
 
       "name"                   : "vcenter-iso",
-      "vm_name"                : "{{user `template_name`}}-{{user `version`}}{{user `template_suffix}}",
+      "vm_name"                : "{{user `template_name`}}-{{user `version`}}{{user `template_suffix`}}",
       "vm_version"             : "{{user `vm_version`}}",
       "notes"                  : "Packer build: {{user `template_name`}}-{{user `version`}} built {{isotime}} SHA: {{user `packer_sha`}}",
 


### PR DESCRIPTION
This is breaking the main packer windows build.
Add the missing `