### PR TITLE
(IMAGES-976) Improve build parameter injection

### DIFF
--- a/templates/win/2008/x86_64/vmware.vcenter.cygwin.json
+++ b/templates/win/2008/x86_64/vmware.vcenter.cygwin.json
@@ -36,7 +36,9 @@
     "boot_wait"                 : "10ms",
     "convert_to_template"       : "false",
     "network_card"              : "vmxnet3",
-    "boot_order"                : "disk,cdrom"
+    "boot_order"                : "disk,cdrom",
+
+    "valid_exit_codes"          : "0"
   },
 
   "description": "Builds a Windows Server 2008 SP2 template VM for use in VMware. Custom spec needed for this platform",
@@ -125,21 +127,37 @@
     {
       "type": "shell-local",
       "inline" : [
-        "rm -f ./tmp/build.yaml",
-        "echo '---' > tmp/build.yaml",
-        "echo \"packer::template_name: '{{user `template_name`}}'\" >> ./tmp/build.yaml",
-        "echo \"packer::packer_sha: '{{user `packer_sha`}}'\" >> ./tmp/build.yaml",
-        "echo \"packer::version: '{{user `version`}}'\" >> ./tmp/build.yaml",
-        "echo \"packer::build_date: '{{isotime}}'\" >> ./tmp/build.yaml",
-        "echo \"packer::template_type: '{{user `packer_template_type`}}'\" >> ./tmp/build.yaml",
-        "echo \"packer::packer_sha: '{{user `packer_sha`}}'\" >> ./tmp/build.yaml"
+        "rm -f ./tmp/build.json",
+        "echo '{' > tmp/build.json",
+
+        "echo '  \"packer\" : {' >> ./tmp/build.json",
+        "echo '    \"template_name\": \"{{user `template_name`}}\",' >> ./tmp/build.json",
+        "echo '    \"packer_sha\": \"{{user `packer_sha`}}\",' >> ./tmp/build.json",
+        "echo '    \"version\": \"{{user `version`}}\",' >> ./tmp/build.json",
+        "echo '    \"build_date\": \"{{isotime}}\",' >> ./tmp/build.json",
+        "echo '    \"template_type\": \"{{user `packer_template_type`}}\",' >> ./tmp/build.json",
+        "echo '    \"memsize\": \"{{user `memsize`}}\",' >> ./tmp/build.json",
+        "echo '    \"admin_username\": \"{{user `winrm_username`}}\",' >> ./tmp/build.json",
+        "echo '    \"admin_password\": \"{{user `winrm_password`}}\",' >> ./tmp/build.json",
+        "echo '    \"qa_root_passwd_plain\": \"{{user `qa_root_passwd_plain`}}\",' >> ./tmp/build.json",
+
+        "echo '    \"windows\" : {' >> ./tmp/build.json",
+        "echo '       \"currentversion\": \"{{user `CurrentVersion`}}\",' >> ./tmp/build.json",
+        "echo '       \"productname\": \"{{user `ProductName`}}\",' >> ./tmp/build.json",
+        "echo '       \"editionid\": \"{{user `EditionID`}}\",' >> ./tmp/build.json",
+        "echo '       \"installationtype\": \"{{user `InstallationType`}}\",' >> ./tmp/build.json",
+        "echo '       \"releaseid\": \"{{user `ReleaseID`}}\"' >> ./tmp/build.json",
+
+        "echo '    }' >> ./tmp/build.json",
+        "echo '  }' >> ./tmp/build.json",
+        "echo '}' >> ./tmp/build.json"
       ]
     },
     {
       "type": "file",
       "generated" : true,
-      "source": "./tmp/build.yaml",
-      "destination": "C:\\Packer\\puppet\\data\\build.yaml"
+      "source": "./tmp/build.json",
+      "destination": "C:\\Packer\\puppet\\data\\build.json"
     },
     {
       "type": "file",
@@ -188,24 +206,14 @@
       "inline" : [
           "C:/Packer/Scripts/test-packerbuild -TestPhase bootstrap-packerbuild"
         ],
-        "environment_vars" : [
-          "PBTEST_WindowsCurrentVersion={{user `CurrentVersion`}}",
-          "PBTEST_WindowsProductName={{user `ProductName`}}",
-          "PBTEST_WindowsEditionID={{user `EditionID`}}",
-          "PBTEST_WindowsInstallationType={{user `InstallationType`}}",
-          "PBTEST_WindowsReleaseID={{user `ReleaseID`}}",
-          "PBTEST_WindowsMemorySize={{user `memsize`}}"
-        ]
+        "valid_exit_codes" : "{{user `valid_exit_codes`}}"
     },
     {
       "type": "powershell",
       "elevated_user": "{{user `winrm_username`}}",
       "elevated_password": "{{user `winrm_password`}}",
       "script" : "../../common/scripts/provisioners/initiate-windows-update.ps1",
-      "environment_vars" : [
-        "ADMIN_USERNAME={{user `winrm_username`}}",
-        "ADMIN_PASSWORD={{user `winrm_password`}}"
-      ]
+      "valid_exit_codes" : "{{user `valid_exit_codes`}}"
     },
     {
       "type" : "windows-restart",
@@ -217,16 +225,15 @@
       "elevated_password": "{{user `winrm_password`}}",
       "inline" : [
         "C:/Packer/Scripts/test-packerbuild -TestPhase windows-update"
-      ]
+      ],
+      "valid_exit_codes" : "{{user `valid_exit_codes`}}"
     },
     {
       "type": "powershell",
       "elevated_user": "{{user `winrm_username`}}",
       "elevated_password": "{{user `winrm_password`}}",
       "script" : "../../common/scripts/provisioners/install-cygwin.ps1",
-      "environment_vars" : [
-        "QA_ROOT_PASSWD_PLAIN={{user `qa_root_passwd_plain`}}"
-      ]
+      "valid_exit_codes" : "{{user `valid_exit_codes`}}"
     },
     {
       "type": "windows-restart"
@@ -236,11 +243,7 @@
       "elevated_user": "{{user `winrm_username`}}",
       "elevated_password": "{{user `winrm_password`}}",
       "script"       : "../../common/scripts/provisioners/initiate-puppet-configure.ps1",
-      "environment_vars" : [
-        "ADMIN_USERNAME={{user `winrm_username`}}",
-        "ADMIN_PASSWORD={{user `winrm_password`}}",
-        "QA_ROOT_PASSWD_PLAIN={{user `qa_root_passwd_plain`}}"
-      ]
+      "valid_exit_codes" : "{{user `valid_exit_codes`}}"
     },
     {
       "type": "windows-restart",
@@ -252,25 +255,29 @@
       "elevated_password": "{{user `winrm_password`}}",
       "inline" : [
         "C:/Packer/Scripts/test-packerbuild -TestPhase puppet"
-      ]
+      ],
+      "valid_exit_codes" : "{{user `valid_exit_codes`}}"
     },
     {
       "type": "powershell",
       "elevated_user": "{{user `winrm_username`}}",
       "elevated_password": "{{user `winrm_password`}}",
-      "script" : "../../common/scripts/provisioners/config-winsettings.ps1"
+      "script" : "../../common/scripts/provisioners/config-winsettings.ps1",
+      "valid_exit_codes" : "{{user `valid_exit_codes`}}"
     },
     {
       "type": "powershell",
       "elevated_user": "{{user `winrm_username`}}",
       "elevated_password": "{{user `winrm_password`}}",
-      "script" : "../../common/scripts/provisioners/cleanup-host.ps1"
+      "script" : "../../common/scripts/provisioners/cleanup-host.ps1",
+      "valid_exit_codes" : "{{user `valid_exit_codes`}}"
     },
     {
       "type"   : "powershell",
       "elevated_user": "{{user `winrm_username`}}",
       "elevated_password": "{{user `winrm_password`}}",
-      "script" : "../../common/scripts/provisioners/clean-disk-dism.ps1"
+      "script" : "../../common/scripts/provisioners/clean-disk-dism.ps1",
+      "valid_exit_codes" : "{{user `valid_exit_codes`}}"
     },
     {
       "type": "windows-restart"
@@ -279,7 +286,8 @@
       "type"   : "powershell",
       "elevated_user": "{{user `winrm_username`}}",
       "elevated_password": "{{user `winrm_password`}}",
-      "script" : "../../common/scripts/provisioners/clean-disk-sdelete.ps1"
+      "script" : "../../common/scripts/provisioners/clean-disk-sdelete.ps1",
+      "valid_exit_codes" : "{{user `valid_exit_codes`}}"
     }
   ]
 }

--- a/templates/win/common/puppet/hiera.yaml
+++ b/templates/win/common/puppet/hiera.yaml
@@ -2,11 +2,11 @@
 version: 5
 defaults:
   datadir: C:\Packer\puppet\data
-  data_hash: yaml_data
+  data_hash: json_data 
 
 hierarchy:
   - name: "Build data"
-    path: "build.yaml"
+    path: "build.json"
 
   - name: "Common data"
-    path: "common.yaml"
+    path: "common.json"

--- a/templates/win/common/puppet/windows_template/data/common.json
+++ b/templates/win/common/puppet/windows_template/data/common.json
@@ -1,0 +1,20 @@
+{
+  "packer": {
+    "template_name": "Template-Undef",
+    "packer_sha": "XXXXXXXXXXXX",
+    "version": "YYYYMMDD",
+    "build_date": "YYYY-MM-DD",
+    "template_type": "Undefined",
+    "memsize": "0000",
+    "admin_username": "Administrator",
+    "admin_password": "PackerAdmin",
+    "qa_password_plain": "XXXXXXX",
+    "windows": {
+      "currentversion": "X.Y",
+      "productname": "Windows Edition Name",
+      "editionid": "EditionID",
+      "installationtype": "Installation Type",
+      "releaseid": "N/A"
+    }
+  }
+}

--- a/templates/win/common/puppet/windows_template/data/common.yaml
+++ b/templates/win/common/puppet/windows_template/data/common.yaml
@@ -1,8 +1,0 @@
----
-# Common or Default data definitions for Packer/Puppet
-packer::template_name: 'Undefined'
-packer::packer_sha: 'Undefined'
-packer::version: 'Undefined'
-packer::build_date: 'Undefined'
-packer::template_type: 'Undefined'
-packer::packer_sha: 'Undefined'

--- a/templates/win/common/puppet/windows_template/manifests/registry/machine.pp
+++ b/templates/win/common/puppet/windows_template/manifests/registry/machine.pp
@@ -73,25 +73,25 @@ class windows_template::registry::machine ()
     registry::value { 'VMPOOLER_Build_Date':
         key   => 'HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment',
         value => 'VMPOOLER_Build_Date',
-        data  => lookup('packer::build_date'),
+        data  => lookup('packer.build_date'),
         type  => 'string'
     }
     registry::value { 'VMPOOLER_Packer_SHA':
         key   => 'HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment',
         value => 'VMPOOLER_Packer_SHA',
-        data  => lookup('packer::packer_sha'),
+        data  => lookup('packer.packer_sha'),
         type  => 'string'
     }
     registry::value { 'VMPOOLER_Packer_Template':
         key   => 'HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment',
         value => 'VMPOOLER_Packer_Template',
-        data  => lookup('packer::template_name'),
+        data  => lookup('packer.template_name'),
         type  => 'string'
     }
     registry::value { 'VMPOOLER_Packer_Template_Type':
         key   => 'HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment',
         value => 'VMPOOLER_Packer_Template_Type',
-        data  => lookup('packer::template_type'),
+        data  => lookup('packer.template_type'),
         type  => 'string'
     }
 

--- a/templates/win/common/scripts/acceptance/bootstrap-packerbuild/OSVersions.Tests.ps1
+++ b/templates/win/common/scripts/acceptance/bootstrap-packerbuild/OSVersions.Tests.ps1
@@ -15,19 +15,18 @@
 describe 'Windows Platform Validation Tests' {
 
     it 'Should be the Correct Operating System name' {
-        $WindowsProductName | Should Be $ENV:PBTEST_WindowsProductName
+        $WindowsProductName | Should Be $($PackerBuildParams.packer.windows.productname)
     }
 
     it 'Should be the correct Edition' {
-        $WindowsEditionID | Should Be $ENV:PBTEST_WindowsEditionID
+        $WindowsEditionID | Should Be $($PackerBuildParams.packer.windows.editionid)
     }
 
     it 'Should be the correct Installation Type' {
-        $WindowsInstallationType | Should Be  $ENV:PBTEST_WindowsInstallationType
+        $WindowsInstallationType | Should Be $($PackerBuildParams.packer.windows.installationtype)
     }
 
     it 'Should be the correct Release ID' {
-        $WindowsReleaseID | Should Be  $ENV:PBTEST_WindowsReleaseID
+        $WindowsReleaseID | Should Be $($PackerBuildParams.packer.windows.releaseid)
     }
-
 }

--- a/templates/win/common/scripts/bootstrap/bootstrap-packerbuild.ps1
+++ b/templates/win/common/scripts/bootstrap/bootstrap-packerbuild.ps1
@@ -136,6 +136,16 @@ if (-not (Test-Path "$PackerLogs\PrivatiseNetAdapters.installed")) {
   Touch-File "$PackerLogs\PrivatiseNetAdapters.installed"
 }
 
+# Run the (Optional) Installation Package File.
+
+if (Test-Path "A:\platform-packages.ps1")
+{
+  & "A:\platform-packages.ps1"
+}
+else {
+  Write-Warning "No additional packages found in $PackageDir"
+}
+
 # Need to guard against system going into standby for long updates
 Write-Output "Disabling Sleep timers"
 Disable-PC-Sleep

--- a/templates/win/common/scripts/bootstrap/packer-windows-update.ps1
+++ b/templates/win/common/scripts/bootstrap/packer-windows-update.ps1
@@ -22,16 +22,6 @@ if ( ($WindowsVersion -Like $WindowsServer2016) -or (($PSVersionTable.PSVersion.
   }
 }
 
-# Run the (Optional) Installation Package File.
-
-if (Test-Path "A:\platform-packages.ps1")
-{
-  & "A:\platform-packages.ps1"
-}
-else {
-  Write-Warning "No additional packages found in $PackageDir"
-}
-
 Import-PsWindowsUpdateModule
 
 # Run Windows Update - this will repeat as often as needed through the Invoke-Reboot cycle.

--- a/templates/win/common/scripts/common/windows-env.ps1
+++ b/templates/win/common/scripts/common/windows-env.ps1
@@ -93,8 +93,8 @@ $startup = "$env:appdata\Microsoft\Windows\Start Menu\Programs\Startup"
 $PackerStaging = "C:\Packer"
 $PackerDownloads = "$PackerStaging\Downloads"
 $PackerPuppet = "$PackerStaging\puppet"
-$PuppetModulesPath = "$PackerStaging\puppet\modules"
-$PuppetHieradata = "$PackerStaging\puppet\data"
+$PuppetModulesPath = "$PackerPuppet\modules"
+$PuppetHieradata = "$PackerPuppet\data"
 $PackerScripts = "$PackerStaging\Scripts"
 $SysInternals = "$PackerStaging\SysInternals"
 $PackerLogs = "$PackerStaging\Logs"
@@ -102,6 +102,16 @@ $PackerConfig = "$PackerStaging\Config"
 $CygwinDownloads = "$PackerDownloads\Cygwin"
 $PackerPsModules = "$PackerStaging\PsModules"
 $PackerAcceptance = "$PackerStaging\Acceptance"
+
+# Load in the build parameters injected from the Packer Build.
+$PackerBuildFile = "$PuppetHieradata\build.json"
+if (Test-Path "$PuppetHieradata\build.json") {
+  $PackerBuildData = Get-Content -Path "$PuppetHieradata\build.json"
+
+  [System.Reflection.Assembly]::LoadWithPartialName("System.Web.Extensions")
+  $ser = New-Object System.Web.Script.Serialization.JavaScriptSerializer
+  $Global:PackerBuildParams = $ser.DeserializeObject($PackerBuildData)
+}
 
 # For Puppet modules configuration
 $ModulesPath = ''

--- a/templates/win/common/scripts/platform9/platform9-post-clone-configuration.ps1
+++ b/templates/win/common/scripts/platform9/platform9-post-clone-configuration.ps1
@@ -17,10 +17,9 @@ Write-Output "Starting Cloud-Init"
 Write-Output "Cloudbase-Init Ended"
 
 # Update machine password (and reset autologin)
-$qa_root_passwd_plain = Get-Content "$PackerDownloads\qapasswd"
 Write-Output "Setting $AdminUsername Password"
-net user $AdminUsername "$qa_root_passwd_plain"
-autologon -AcceptEula $AdminUsername . "$qa_root_passwd_plain"
+net user $AdminUsername "$($PackerBuildParams.packer.qa_root_passwd_plain)"
+autologon -AcceptEula $AdminUsername . "$($PackerBuildParams.packer.qa_root_passwd_plain)"
 
 # Use BGInfo to paint the screen
 if (-not $WindowsServerCore) {

--- a/templates/win/common/scripts/provisioners/config-platform9.ps1
+++ b/templates/win/common/scripts/provisioners/config-platform9.ps1
@@ -59,9 +59,4 @@ Download-File "https://artifactory.delivery.puppetlabs.net/artifactory/generic/b
 $zproc = Start-Process "msiexec" @SprocParms -ArgumentList "/i $PackerDownloads\$CloudbaseInstaller /qn /l*v $PackerLogs\CloudbaseInstaller.log"
 $zproc.WaitForExit()
 
-# Setup Password for later use
-if ($ENV:QA_ROOT_PASSWD_PLAIN.length -le 0 ) {throw "QA_ROOT_PASSWD_PLAIN is not defined"}
-$ENV:QA_ROOT_PASSWD_PLAIN | Out-File "$PackerDownloads\qapasswd"
-
-
 Write-Output "Bye"

--- a/templates/win/common/scripts/provisioners/initiate-puppet-configure.ps1
+++ b/templates/win/common/scripts/provisioners/initiate-puppet-configure.ps1
@@ -108,8 +108,8 @@ Write-Output "========== A log and update report will be given at the end of the
 
 # Need to pick up Admin Username/Password from Environment for sched task
 
-Write-Output "Create Bootstrap Scheduled Task"
-schtasks /create /tn PuppetConfigure /rl HIGHEST /ru "$ENV:ADMIN_USERNAME" /RP "$ENV:ADMIN_PASSWORD" /IT /F /SC ONSTART /DELAY 0000:50 /TR 'cmd /c c:\WINDOWS\system32\WindowsPowerShell\v1.0\powershell.exe -sta -WindowStyle Normal -ExecutionPolicy Bypass -NonInteractive -NoProfile -File C:\Packer\Scripts\puppet-configure.ps1 >> C:\Packer\Logs\puppet.log 2>&1'
+Write-Output "Create Bootstrap Scheduled Task with $($PackerBuildParams.packer.admin_username)"
+schtasks /create /tn PuppetConfigure /rl HIGHEST /ru "$($PackerBuildParams.packer.admin_username)" /RP "$($PackerBuildParams.packer.admin_password)" /IT /F /SC ONSTART /DELAY 0000:50 /TR 'cmd /c c:\WINDOWS\system32\WindowsPowerShell\v1.0\powershell.exe -sta -WindowStyle Normal -ExecutionPolicy Bypass -NonInteractive -NoProfile -File C:\Packer\Scripts\puppet-configure.ps1 >> C:\Packer\Logs\puppet.log 2>&1'
 
 # Disable WinRM until further notice.
 Set-Service "WinRM" -StartupType Disabled

--- a/templates/win/common/scripts/provisioners/initiate-windows-update.ps1
+++ b/templates/win/common/scripts/provisioners/initiate-windows-update.ps1
@@ -46,8 +46,8 @@ Write-Output "========== A log and update report will be given at the end of the
 # Need to pick up Admin Username/Password from Environment for sched task
 # Also set generous wait time of 50 seconds before task is run to ensure machine is in
 # ready state for update (Win-7-WMF5 seems to need this - (IMAGES-984)
-Write-Output "Create Bootstrap Scheduled Task"
-schtasks /create /tn PackerWinUpdate /rl HIGHEST /ru "$ENV:ADMIN_USERNAME" /RP "$ENV:ADMIN_PASSWORD" /IT /F /SC ONSTART /DELAY 0000:50 /TR 'cmd /c c:\WINDOWS\system32\WindowsPowerShell\v1.0\powershell.exe -sta -WindowStyle Normal -ExecutionPolicy Bypass -NonInteractive -NoProfile -File C:\Packer\Scripts\packer-windows-update.ps1 >> C:\Packer\Logs\windows-update.log 2>&1'
+Write-Output "Create Windows Update Scheduled Task"
+schtasks /create /tn PackerWinUpdate /rl HIGHEST /ru "$($PackerBuildParams.packer.admin_username)" /RP "$($PackerBuildParams.packer.admin_password)" /IT /F /SC ONSTART /DELAY 0000:50 /TR 'cmd /c c:\WINDOWS\system32\WindowsPowerShell\v1.0\powershell.exe -sta -WindowStyle Normal -ExecutionPolicy Bypass -NonInteractive -NoProfile -File C:\Packer\Scripts\packer-windows-update.ps1 >> C:\Packer\Logs\windows-update.log 2>&1'
 
 # Disable WinRM until further notice.
 Set-Service "WinRM" -StartupType Disabled

--- a/templates/win/common/scripts/provisioners/install-cygwin.ps1
+++ b/templates/win/common/scripts/provisioners/install-cygwin.ps1
@@ -47,10 +47,6 @@ foreach ($line in $content)
 }
 Write-Output "Package list is: $CygWinPackageList"
 
-# Setup Password for later use
-if ($ENV:QA_ROOT_PASSWD_PLAIN.length -le 0 ) {throw "QA_ROOT_PASSWD_PLAIN is not defined"}
-$ENV:QA_ROOT_PASSWD_PLAIN | Out-File "$CygwinDownloads\qapasswd"
-
 Write-Output "Downloading Cygwin Packages"
 Download-File "https://artifactory.delivery.puppetlabs.net/artifactory/generic/buildsources/windows/cygwin/packages-$ARCH.zip" "$CygwinDownloads\packages_$ARCH.zip"
 Write-Output "Extracting $CygwinDownloads\packages_$ARCH.zip"

--- a/templates/win/common/scripts/provisioners/vagrant-arm-host.ps1
+++ b/templates/win/common/scripts/provisioners/vagrant-arm-host.ps1
@@ -3,6 +3,8 @@
 
 $ErrorActionPreference = 'Stop'
 
+. C:\Packer\Scripts\windows-env.ps1
+
 # If we are Windows-10/2016 need to set network adapters private.
 # Note - need longhand test as windows_env isn't available here.
 if ($WindowsVersion -like "10.*") {
@@ -65,8 +67,7 @@ Invoke-Expression $CygwinMkgroup | Out-File $CygwinGroupFile -Force -Encoding "A
 
 # Set up cygserv Username
 Write-Output "Setting SSH Host Configuration"
-$qa_root_passwd_plain = Get-Content "$ENV:CYGWINDOWNLOADS\qapasswd"
-& $CygWinShell --login -c `'ssh-host-config --yes --privileged --user cyg_server --pwd $qa_root_passwd_plain`'
+& $CygWinShell --login -c `'ssh-host-config --yes --privileged --user cyg_server --pwd $($PackerBuildParams.packer.qa_root_passwd_plain)`'
 
 # Generate ssh keys for both Administrator and vagrant
 Write-Output "Generate SSH Keys"

--- a/templates/win/common/virtualbox.base.json
+++ b/templates/win/common/virtualbox.base.json
@@ -17,6 +17,8 @@
 
     "qa_root_passwd_plain"    : null,
     "packer_sha"              : null,
+    "packer_template_type"    : "vagrant",
+
     "packer_vm_src_dir"       : null,
     "packer_vm_out_dir"       : null
   },
@@ -65,6 +67,41 @@
   ],
   "provisioners": [
     {
+      "type": "shell-local",
+      "inline" : [
+        "rm -f ./tmp/build.json",
+        "echo '{' > tmp/build.json",
+
+        "echo '  \"packer\" : {' >> ./tmp/build.json",
+        "echo '    \"template_name\": \"{{user `template_name`}}\",' >> ./tmp/build.json",
+        "echo '    \"packer_sha\": \"{{user `packer_sha`}}\",' >> ./tmp/build.json",
+        "echo '    \"version\": \"{{user `version`}}\",' >> ./tmp/build.json",
+        "echo '    \"build_date\": \"{{isotime}}\",' >> ./tmp/build.json",
+        "echo '    \"template_type\": \"{{user `packer_template_type`}}\",' >> ./tmp/build.json",
+        "echo '    \"memsize\": \"{{user `memsize`}}\",' >> ./tmp/build.json",
+        "echo '    \"admin_username\": \"{{user `winrm_username`}}\",' >> ./tmp/build.json",
+        "echo '    \"admin_password\": \"{{user `winrm_password`}}\",' >> ./tmp/build.json",
+        "echo '    \"qa_root_passwd_plain\": \"{{user `qa_root_passwd_plain`}}\",' >> ./tmp/build.json",
+
+        "echo '    \"windows\" : {' >> ./tmp/build.json",
+        "echo '       \"currentversion\": \"{{user `CurrentVersion`}}\",' >> ./tmp/build.json",
+        "echo '       \"productname\": \"{{user `ProductName`}}\",' >> ./tmp/build.json",
+        "echo '       \"editionid\": \"{{user `EditionID`}}\",' >> ./tmp/build.json",
+        "echo '       \"installationtype\": \"{{user `InstallationType`}}\",' >> ./tmp/build.json",
+        "echo '       \"releaseid\": \"{{user `ReleaseID`}}\"' >> ./tmp/build.json",
+
+        "echo '    }' >> ./tmp/build.json",
+        "echo '  }' >> ./tmp/build.json",
+        "echo '}' >> ./tmp/build.json"
+      ]
+    },
+    {
+      "type": "file",
+      "generated" : true,
+      "source": "./tmp/build.json",
+      "destination": "C:\\Packer\\puppet\\data\\build.json"
+    },
+    {
       "type": "file",
       "source": "../../common/scripts/common/",
       "destination": "C:\\Packer\\Scripts"
@@ -87,11 +124,7 @@
     },
     {
       "type": "powershell",
-      "script" : "../../common/scripts/provisioners/initiate-windows-update.ps1",
-      "environment_vars" : [
-        "ADMIN_USERNAME={{user `winrm_username`}}",
-        "ADMIN_PASSWORD={{user `winrm_password`}}"
-      ]
+      "script" : "../../common/scripts/provisioners/initiate-windows-update.ps1"
     },
     {
       "type" : "windows-restart",

--- a/templates/win/common/virtualbox.base.vagrant.cygwin.json
+++ b/templates/win/common/virtualbox.base.vagrant.cygwin.json
@@ -1,126 +1,161 @@
 {
   "variables": {
-    "template_config"      : "vagrant.cygwin",
-    "provisioner"          : "virtualbox",
-
-    "shutdown_command"     : "powershell -executionpolicy bypass -File C:\\Packer\\Scripts\\shutdown-packerbuild.ps1",
-    "disk_size"            : "61440",
-    "memory_size"          : "2048",
-    "cpu_count"            : "2",
-
-    "qa_root_passwd_plain"       : null,
-    "packer_sha"           : null,
-    "packer_vm_src_dir"    : null,
-    "packer_vm_out_dir"    : null
+    "template_config": "vagrant.cygwin",
+    "provisioner": "virtualbox",
+    "shutdown_command": "powershell -executionpolicy bypass -File C:\\Packer\\Scripts\\shutdown-packerbuild.ps1",
+    "disk_size": "61440",
+    "memory_size": "2048",
+    "cpu_count": "2",
+    "qa_root_passwd_plain": null,
+    "packer_sha": null,
+    "packer_vm_src_dir": null,
+    "packer_vm_out_dir": null
   },
-
   "description": "Builds a Windows template VM for use in VirtualBox with Vagrant",
   "builders": [
     {
-      "type"                 : "virtualbox-ovf",
-      "name"                 : "{{user `template_name`}}-{{user `provisioner`}}-{{user `template_config`}}",
-      "source_path"          : "{{user `packer_vm_src_dir`}}/output-{{user `template_name`}}-{{user `provisioner`}}-base/packer-{{user `template_name`}}-{{user `provisioner`}}-base.ovf",
-      "output_directory"     : "{{user `packer_vm_out_dir`}}/output-{{build_name}}",
-      "headless"             : "{{user `headless`}}",
-
-      "communicator"         : "winrm",
-      "winrm_username"       : "{{user `winrm_username`}}",
-      "winrm_password"       : "{{user `winrm_password`}}",
-      "winrm_timeout"        : "{{user `winrm_timeout`}}",
-      
-      "shutdown_command"     : "{{user `shutdown_command`}}",
-      "shutdown_timeout"     : "{{user `shutdown_timeout`}}",
-      "guest_additions_mode" : "attach",
+      "type": "virtualbox-ovf",
+      "name": "{{user `template_name`}}-{{user `provisioner`}}-{{user `template_config`}}",
+      "source_path": "{{user `packer_vm_src_dir`}}/output-{{user `template_name`}}-{{user `provisioner`}}-base/packer-{{user `template_name`}}-{{user `provisioner`}}-base.ovf",
+      "output_directory": "{{user `packer_vm_out_dir`}}/output-{{build_name}}",
+      "headless": "{{user `headless`}}",
+      "communicator": "winrm",
+      "winrm_username": "{{user `winrm_username`}}",
+      "winrm_password": "{{user `winrm_password`}}",
+      "winrm_timeout": "{{user `winrm_timeout`}}",
+      "shutdown_command": "{{user `shutdown_command`}}",
+      "shutdown_timeout": "{{user `shutdown_timeout`}}",
+      "guest_additions_mode": "attach",
       "vboxmanage": [
-        ["modifyvm","{{.Name}}","--memory","2048"],
-        ["modifyvm","{{.Name}}","--vram","128"],
-        ["modifyvm","{{.Name}}","--cpus","2"]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "2048"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--vram",
+          "128"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "2"
+        ]
       ]
     }
   ],
   "provisioners": [
     {
-        "type": "file",
-        "source": "../../common/scripts/config/",
-        "destination": "C:\\Packer\\Config"
+      "type": "shell-local",
+      "inline": [
+        "rm -f ./tmp/build.json",
+        "echo '{' > tmp/build.json",
+        "echo '  \"packer\" : {' >> ./tmp/build.json",
+        "echo '    \"template_name\": \"{{user `template_name`}}\",' >> ./tmp/build.json",
+        "echo '    \"packer_sha\": \"{{user `packer_sha`}}\",' >> ./tmp/build.json",
+        "echo '    \"version\": \"{{user `version`}}\",' >> ./tmp/build.json",
+        "echo '    \"build_date\": \"{{isotime}}\",' >> ./tmp/build.json",
+        "echo '    \"template_type\": \"{{user `packer_template_type`}}\",' >> ./tmp/build.json",
+        "echo '    \"memsize\": \"{{user `memsize`}}\",' >> ./tmp/build.json",
+        "echo '    \"admin_username\": \"{{user `winrm_username`}}\",' >> ./tmp/build.json",
+        "echo '    \"admin_password\": \"{{user `winrm_password`}}\",' >> ./tmp/build.json",
+        "echo '    \"qa_root_passwd_plain\": \"{{user `qa_root_passwd_plain`}}\",' >> ./tmp/build.json",
+        "echo '    \"windows\" : {' >> ./tmp/build.json",
+        "echo '       \"currentversion\": \"{{user `CurrentVersion`}}\",' >> ./tmp/build.json",
+        "echo '       \"productname\": \"{{user `ProductName`}}\",' >> ./tmp/build.json",
+        "echo '       \"editionid\": \"{{user `EditionID`}}\",' >> ./tmp/build.json",
+        "echo '       \"installationtype\": \"{{user `InstallationType`}}\",' >> ./tmp/build.json",
+        "echo '       \"releaseid\": \"{{user `ReleaseID`}}\"' >> ./tmp/build.json",
+        "echo '    }' >> ./tmp/build.json",
+        "echo '  }' >> ./tmp/build.json",
+        "echo '}' >> ./tmp/build.json"
+      ]
     },
     {
-        "type": "file",
-        "source": "./tmp/post-clone.autounattend.xml",
-        "destination": "C:\\Packer\\Config\\post-clone.autounattend.xml"
+      "type": "file",
+      "generated": true,
+      "source": "./tmp/build.json",
+      "destination": "C:\\Packer\\puppet\\data\\build.json"
     },
     {
-        "type": "file",
-        "source": "../../common/puppet/",
-        "destination": "C:\\Packer\\puppet\\modules"
+      "type": "file",
+      "source": "../../common/scripts/config/",
+      "destination": "C:\\Packer\\Config"
     },
     {
-        "type": "file",
-        "source": "../../common/scripts/common/",
-        "destination": "C:\\Packer\\scripts"
+      "type": "file",
+      "source": "./tmp/post-clone.autounattend.xml",
+      "destination": "C:\\Packer\\Config\\post-clone.autounattend.xml"
     },
     {
-        "type": "file",
-        "source": "../../common/scripts/bootstrap/",
-        "destination": "C:\\Packer\\scripts"
+      "type": "file",
+      "source": "../../common/puppet/",
+      "destination": "C:\\Packer\\puppet\\modules"
     },
     {
-        "type": "file",
-        "source": "../../common/scripts/bootstrap/shutdown-packerbuild.ps1",
-        "destination": "C:\\Packer\\Scripts\\shutdown-packerbuild.ps1"
+      "type": "file",
+      "source": "../../common/scripts/common/",
+      "destination": "C:\\Packer\\scripts"
     },
     {
-        "type"   : "powershell",
-        "script" : "../../common/scripts/provisioners/install-cygwin.ps1",
-        "environment_vars": [
-            "QA_ROOT_PASSWD_PLAIN={{user `qa_root_passwd_plain`}}"
-        ]
+      "type": "file",
+      "source": "../../common/scripts/bootstrap/",
+      "destination": "C:\\Packer\\scripts"
     },
     {
-        "type": "windows-restart"
+      "type": "file",
+      "source": "../../common/scripts/bootstrap/shutdown-packerbuild.ps1",
+      "destination": "C:\\Packer\\Scripts\\shutdown-packerbuild.ps1"
     },
     {
-        "type": "powershell",
-        "script" : "../../common/scripts/provisioners/puppet-configure.ps1",
-        "environment_vars" : [
-          "PackerTemplateName={{user `template_name`}}-{{user `version`}}",
-          "PackerSHA={{user `packer_sha`}}",
-          "PackerTemplateType=vagrant"
-        ]
+      "type": "powershell",
+      "script": "../../common/scripts/provisioners/install-cygwin.ps1"
     },
     {
-        "type": "windows-restart"
+      "type": "windows-restart"
     },
     {
-        "type"   : "powershell",
-        "script" : "../../common/scripts/provisioners/config-winsettings.ps1"
+      "type": "powershell",
+      "script": "../../common/scripts/provisioners/puppet-configure.ps1"
     },
     {
-        "type"   : "powershell",
-        "script" : "../../common/scripts/provisioners/cleanup-host.ps1"
+      "type": "windows-restart"
     },
     {
-        "type": "windows-restart",
-        "restart_command": "powershell -executionpolicy bypass -File C:\\Packer\\Scripts\\init-sysprep.ps1 -ArumentList \"-Restart\" >> C:\\Packer\\Logs\\Init-Sysprep.log 2>&1",
-        "restart_timeout": "15m"
+      "type": "powershell",
+      "script": "../../common/scripts/provisioners/config-winsettings.ps1"
     },
     {
-        "type": "powershell",
-        "inline": [
+      "type": "powershell",
+      "script": "../../common/scripts/provisioners/cleanup-host.ps1"
+    },
+    {
+      "type": "windows-restart",
+      "restart_command": "powershell -executionpolicy bypass -File C:\\Packer\\Scripts\\init-sysprep.ps1 -ArumentList \"-Restart\" >> C:\\Packer\\Logs\\Init-Sysprep.log 2>&1",
+      "restart_timeout": "15m"
+    },
+    {
+      "type": "powershell",
+      "inline": [
         "Write-Output 'SYSPREP Log output'",
         "Get-Content C:\\Packer\\Logs\\Init-Sysprep.log",
         "Start-Sleep -Seconds 10"
-        ]
+      ]
     },
     {
-        "type"   : "powershell",
-        "script" : "../../common/scripts/provisioners/vagrant-arm-host.ps1"
+      "type": "powershell",
+      "script": "../../common/scripts/provisioners/vagrant-arm-host.ps1"
     }
   ],
-    "post-processors": [{
-        "type"                : "vagrant",
-        "output"              : "{{user `packer_vm_out_dir`}}/output-{{build_name}}/{{user `template_name`}}-{{user `provisioner`}}-{{user `template_config`}}.box",
-        "vagrantfile_template": "tmp/vagrantfile-windows.template"
+  "post-processors": [
+    {
+      "type": "vagrant",
+      "output": "{{user `packer_vm_out_dir`}}/output-{{build_name}}/{{user `template_name`}}-{{user `provisioner`}}-{{user `template_config`}}.box",
+      "vagrantfile_template": "tmp/vagrantfile-windows.template"
     }
   ]
 }

--- a/templates/win/common/virtualbox.slipstream.json
+++ b/templates/win/common/virtualbox.slipstream.json
@@ -70,6 +70,41 @@
   ],
   "provisioners": [
     {
+      "type": "shell-local",
+      "inline" : [
+        "rm -f ./tmp/build.json",
+        "echo '{' > tmp/build.json",
+
+        "echo '  \"packer\" : {' >> ./tmp/build.json",
+        "echo '    \"template_name\": \"{{user `template_name`}}\",' >> ./tmp/build.json",
+        "echo '    \"packer_sha\": \"{{user `packer_sha`}}\",' >> ./tmp/build.json",
+        "echo '    \"version\": \"{{user `version`}}\",' >> ./tmp/build.json",
+        "echo '    \"build_date\": \"{{isotime}}\",' >> ./tmp/build.json",
+        "echo '    \"template_type\": \"{{user `packer_template_type`}}\",' >> ./tmp/build.json",
+        "echo '    \"memsize\": \"{{user `memsize`}}\",' >> ./tmp/build.json",
+        "echo '    \"admin_username\": \"{{user `winrm_username`}}\",' >> ./tmp/build.json",
+        "echo '    \"admin_password\": \"{{user `winrm_password`}}\",' >> ./tmp/build.json",
+        "echo '    \"qa_root_passwd_plain\": \"{{user `qa_root_passwd_plain`}}\",' >> ./tmp/build.json",
+
+        "echo '    \"windows\" : {' >> ./tmp/build.json",
+        "echo '       \"currentversion\": \"{{user `CurrentVersion`}}\",' >> ./tmp/build.json",
+        "echo '       \"productname\": \"{{user `ProductName`}}\",' >> ./tmp/build.json",
+        "echo '       \"editionid\": \"{{user `EditionID`}}\",' >> ./tmp/build.json",
+        "echo '       \"installationtype\": \"{{user `InstallationType`}}\",' >> ./tmp/build.json",
+        "echo '       \"releaseid\": \"{{user `ReleaseID`}}\"' >> ./tmp/build.json",
+
+        "echo '    }' >> ./tmp/build.json",
+        "echo '  }' >> ./tmp/build.json",
+        "echo '}' >> ./tmp/build.json"
+      ]
+    },
+    {
+      "type": "file",
+      "generated" : true,
+      "source": "./tmp/build.json",
+      "destination": "C:\\Packer\\puppet\\data\\build.json"
+    },
+    {
       "type": "powershell",
       "script" : "../../common/scripts/provisioners/test-bootstrap.ps1"
     },

--- a/templates/win/common/virtualbox.vagrant.cygwin.json
+++ b/templates/win/common/virtualbox.vagrant.cygwin.json
@@ -17,6 +17,8 @@
 
     "qa_root_passwd_plain" : null,
     "packer_sha"           : null,
+    "packer_template_type" : "vagrant",
+
     "packer_vm_src_dir"    : null,
     "packer_vm_out_dir"    : null
   },
@@ -64,6 +66,41 @@
   ],
   "provisioners": [
     {
+      "type": "shell-local",
+      "inline" : [
+        "rm -f ./tmp/build.json",
+        "echo '{' > tmp/build.json",
+
+        "echo '  \"packer\" : {' >> ./tmp/build.json",
+        "echo '    \"template_name\": \"{{user `template_name`}}\",' >> ./tmp/build.json",
+        "echo '    \"packer_sha\": \"{{user `packer_sha`}}\",' >> ./tmp/build.json",
+        "echo '    \"version\": \"{{user `version`}}\",' >> ./tmp/build.json",
+        "echo '    \"build_date\": \"{{isotime}}\",' >> ./tmp/build.json",
+        "echo '    \"template_type\": \"{{user `packer_template_type`}}\",' >> ./tmp/build.json",
+        "echo '    \"memsize\": \"{{user `memsize`}}\",' >> ./tmp/build.json",
+        "echo '    \"admin_username\": \"{{user `winrm_username`}}\",' >> ./tmp/build.json",
+        "echo '    \"admin_password\": \"{{user `winrm_password`}}\",' >> ./tmp/build.json",
+        "echo '    \"qa_root_passwd_plain\": \"{{user `qa_root_passwd_plain`}}\",' >> ./tmp/build.json",
+
+        "echo '    \"windows\" : {' >> ./tmp/build.json",
+        "echo '       \"currentversion\": \"{{user `CurrentVersion`}}\",' >> ./tmp/build.json",
+        "echo '       \"productname\": \"{{user `ProductName`}}\",' >> ./tmp/build.json",
+        "echo '       \"editionid\": \"{{user `EditionID`}}\",' >> ./tmp/build.json",
+        "echo '       \"installationtype\": \"{{user `InstallationType`}}\",' >> ./tmp/build.json",
+        "echo '       \"releaseid\": \"{{user `ReleaseID`}}\"' >> ./tmp/build.json",
+
+        "echo '    }' >> ./tmp/build.json",
+        "echo '  }' >> ./tmp/build.json",
+        "echo '}' >> ./tmp/build.json"
+      ]
+    },
+    {
+      "type": "file",
+      "generated" : true,
+      "source": "./tmp/build.json",
+      "destination": "C:\\Packer\\puppet\\data\\build.json"
+    },
+    {
         "type": "file",
         "source": "../../common/scripts/config/",
         "destination": "C:\\Packer\\Config"
@@ -96,11 +133,7 @@
     },
     {
         "type": "powershell",
-        "script" : "../../common/scripts/provisioners/initiate-windows-update.ps1",
-        "environment_vars" : [
-          "ADMIN_USERNAME={{user `winrm_username`}}",
-          "ADMIN_PASSWORD={{user `winrm_password`}}"
-        ]
+        "script" : "../../common/scripts/provisioners/initiate-windows-update.ps1"
     },
     {
         "type" : "windows-restart",
@@ -118,22 +151,14 @@
     },
     {
         "type"   : "powershell",
-        "script" : "../../common/scripts/provisioners/install-cygwin.ps1",
-        "environment_vars": [
-            "QA_ROOT_PASSWD_PLAIN={{user `qa_root_passwd_plain`}}"
-        ]
+        "script" : "../../common/scripts/provisioners/install-cygwin.ps1"
     },
     {
         "type": "windows-restart"
     },
     {
         "type": "powershell",
-        "script" : "../../common/scripts/provisioners/puppet-configure.ps1",
-        "environment_vars" : [
-          "PackerTemplateName={{user `template_name`}}-{{user `version`}}",
-          "PackerSHA={{user `packer_sha`}}",
-          "PackerTemplateType=vagrant"
-        ]
+        "script" : "../../common/scripts/provisioners/puppet-configure.ps1"
     },
     {
         "type": "windows-restart"

--- a/templates/win/common/vmware.slipstream.json
+++ b/templates/win/common/vmware.slipstream.json
@@ -95,6 +95,41 @@
   ],
   "provisioners": [
     {
+      "type": "shell-local",
+      "inline" : [
+        "rm -f ./tmp/build.json",
+        "echo '{' > tmp/build.json",
+
+        "echo '  \"packer\" : {' >> ./tmp/build.json",
+        "echo '    \"template_name\": \"{{user `template_name`}}\",' >> ./tmp/build.json",
+        "echo '    \"packer_sha\": \"{{user `packer_sha`}}\",' >> ./tmp/build.json",
+        "echo '    \"version\": \"{{user `version`}}\",' >> ./tmp/build.json",
+        "echo '    \"build_date\": \"{{isotime}}\",' >> ./tmp/build.json",
+        "echo '    \"template_type\": \"{{user `packer_template_type`}}\",' >> ./tmp/build.json",
+        "echo '    \"memsize\": \"{{user `memsize`}}\",' >> ./tmp/build.json",
+        "echo '    \"admin_username\": \"{{user `winrm_username`}}\",' >> ./tmp/build.json",
+        "echo '    \"admin_password\": \"{{user `winrm_password`}}\",' >> ./tmp/build.json",
+        "echo '    \"qa_root_passwd_plain\": \"{{user `qa_root_passwd_plain`}}\",' >> ./tmp/build.json",
+
+        "echo '    \"windows\" : {' >> ./tmp/build.json",
+        "echo '       \"currentversion\": \"{{user `CurrentVersion`}}\",' >> ./tmp/build.json",
+        "echo '       \"productname\": \"{{user `ProductName`}}\",' >> ./tmp/build.json",
+        "echo '       \"editionid\": \"{{user `EditionID`}}\",' >> ./tmp/build.json",
+        "echo '       \"installationtype\": \"{{user `InstallationType`}}\",' >> ./tmp/build.json",
+        "echo '       \"releaseid\": \"{{user `ReleaseID`}}\"' >> ./tmp/build.json",
+
+        "echo '    }' >> ./tmp/build.json",
+        "echo '  }' >> ./tmp/build.json",
+        "echo '}' >> ./tmp/build.json"
+      ]
+    },
+    {
+      "type": "file",
+      "generated" : true,
+      "source": "./tmp/build.json",
+      "destination": "C:\\Packer\\puppet\\data\\build.json"
+    },
+    {
       "type": "powershell",
       "script" : "../../common/scripts/provisioners/test-bootstrap.ps1"
     },

--- a/templates/win/common/vmware.vcenter.bios.base.json
+++ b/templates/win/common/vmware.vcenter.bios.base.json
@@ -98,6 +98,41 @@
   ],
   "provisioners": [
     {
+      "type": "shell-local",
+      "inline" : [
+        "rm -f ./tmp/build.json",
+        "echo '{' > tmp/build.json",
+
+        "echo '  \"packer\" : {' >> ./tmp/build.json",
+        "echo '    \"template_name\": \"{{user `template_name`}}\",' >> ./tmp/build.json",
+        "echo '    \"packer_sha\": \"{{user `packer_sha`}}\",' >> ./tmp/build.json",
+        "echo '    \"version\": \"{{user `version`}}\",' >> ./tmp/build.json",
+        "echo '    \"build_date\": \"{{isotime}}\",' >> ./tmp/build.json",
+        "echo '    \"template_type\": \"{{user `packer_template_type`}}\",' >> ./tmp/build.json",
+        "echo '    \"memsize\": \"{{user `memsize`}}\",' >> ./tmp/build.json",
+        "echo '    \"admin_username\": \"{{user `winrm_username`}}\",' >> ./tmp/build.json",
+        "echo '    \"admin_password\": \"{{user `winrm_password`}}\",' >> ./tmp/build.json",
+        "echo '    \"qa_root_passwd_plain\": \"{{user `qa_root_passwd_plain`}}\",' >> ./tmp/build.json",
+
+        "echo '    \"windows\" : {' >> ./tmp/build.json",
+        "echo '       \"currentversion\": \"{{user `CurrentVersion`}}\",' >> ./tmp/build.json",
+        "echo '       \"productname\": \"{{user `ProductName`}}\",' >> ./tmp/build.json",
+        "echo '       \"editionid\": \"{{user `EditionID`}}\",' >> ./tmp/build.json",
+        "echo '       \"installationtype\": \"{{user `InstallationType`}}\",' >> ./tmp/build.json",
+        "echo '       \"releaseid\": \"{{user `ReleaseID`}}\"' >> ./tmp/build.json",
+
+        "echo '    }' >> ./tmp/build.json",
+        "echo '  }' >> ./tmp/build.json",
+        "echo '}' >> ./tmp/build.json"
+      ]
+    },
+    {
+      "type": "file",
+      "generated" : true,
+      "source": "./tmp/build.json",
+      "destination": "C:\\Packer\\puppet\\data\\build.json"
+    },
+    {
       "type"        : "file",
       "source": "../../common/scripts/common/",
       "destination": "C:\\Packer\\Scripts"
@@ -117,23 +152,11 @@
       "inline"      : [
           "C:/Packer/Scripts/test-packerbuild -TestPhase bootstrap-packerbuild"
         ],
-        "environment_vars" : [
-          "PBTEST_WindowsCurrentVersion={{user `CurrentVersion`}}",
-          "PBTEST_WindowsProductName={{user `ProductName`}}",
-          "PBTEST_WindowsEditionID={{user `EditionID`}}",
-          "PBTEST_WindowsInstallationType={{user `InstallationType`}}",
-          "PBTEST_WindowsReleaseID={{user `ReleaseID`}}",
-          "PBTEST_WindowsMemorySize={{user `memsize`}}"
-        ],
       "valid_exit_codes" : "{{user `valid_exit_codes`}}"
     },
     {
       "type"         : "powershell",
-      "script"       : "../../common/scripts/provisioners/initiate-windows-update.ps1",
-      "environment_vars" : [
-        "ADMIN_USERNAME={{user `winrm_username`}}",
-        "ADMIN_PASSWORD={{user `winrm_password`}}"
-      ]
+      "script"       : "../../common/scripts/provisioners/initiate-windows-update.ps1"
     },
     {
       "type" : "windows-restart",

--- a/templates/win/common/vmware.vcenter.cygwin.json
+++ b/templates/win/common/vmware.vcenter.cygwin.json
@@ -129,21 +129,37 @@
     {
       "type": "shell-local",
       "inline" : [
-        "rm -f ./tmp/build.yaml",
-        "echo '---' > tmp/build.yaml",
-        "echo \"packer::template_name: '{{user `template_name`}}'\" >> ./tmp/build.yaml",
-        "echo \"packer::packer_sha: '{{user `packer_sha`}}'\" >> ./tmp/build.yaml",
-        "echo \"packer::version: '{{user `version`}}'\" >> ./tmp/build.yaml",
-        "echo \"packer::build_date: '{{isotime}}'\" >> ./tmp/build.yaml",
-        "echo \"packer::template_type: '{{user `packer_template_type`}}'\" >> ./tmp/build.yaml",
-        "echo \"packer::packer_sha: '{{user `packer_sha`}}'\" >> ./tmp/build.yaml"
+        "rm -f ./tmp/build.json",
+        "echo '{' > tmp/build.json",
+
+        "echo '  \"packer\" : {' >> ./tmp/build.json",
+        "echo '    \"template_name\": \"{{user `template_name`}}\",' >> ./tmp/build.json",
+        "echo '    \"packer_sha\": \"{{user `packer_sha`}}\",' >> ./tmp/build.json",
+        "echo '    \"version\": \"{{user `version`}}\",' >> ./tmp/build.json",
+        "echo '    \"build_date\": \"{{isotime}}\",' >> ./tmp/build.json",
+        "echo '    \"template_type\": \"{{user `packer_template_type`}}\",' >> ./tmp/build.json",
+        "echo '    \"memsize\": \"{{user `memsize`}}\",' >> ./tmp/build.json",
+        "echo '    \"admin_username\": \"{{user `winrm_username`}}\",' >> ./tmp/build.json",
+        "echo '    \"admin_password\": \"{{user `winrm_password`}}\",' >> ./tmp/build.json",
+        "echo '    \"qa_root_passwd_plain\": \"{{user `qa_root_passwd_plain`}}\",' >> ./tmp/build.json",
+
+        "echo '    \"windows\" : {' >> ./tmp/build.json",
+        "echo '       \"currentversion\": \"{{user `CurrentVersion`}}\",' >> ./tmp/build.json",
+        "echo '       \"productname\": \"{{user `ProductName`}}\",' >> ./tmp/build.json",
+        "echo '       \"editionid\": \"{{user `EditionID`}}\",' >> ./tmp/build.json",
+        "echo '       \"installationtype\": \"{{user `InstallationType`}}\",' >> ./tmp/build.json",
+        "echo '       \"releaseid\": \"{{user `ReleaseID`}}\"' >> ./tmp/build.json",
+
+        "echo '    }' >> ./tmp/build.json",
+        "echo '  }' >> ./tmp/build.json",
+        "echo '}' >> ./tmp/build.json"
       ]
     },
     {
       "type": "file",
       "generated" : true,
-      "source": "./tmp/build.yaml",
-      "destination": "C:\\Packer\\puppet\\data\\build.yaml"
+      "source": "./tmp/build.json",
+      "destination": "C:\\Packer\\puppet\\data\\build.json"
     },
     {
       "type": "file",
@@ -190,23 +206,11 @@
       "inline" : [
           "C:/Packer/Scripts/test-packerbuild -TestPhase bootstrap-packerbuild"
         ],
-        "environment_vars" : [
-          "PBTEST_WindowsCurrentVersion={{user `CurrentVersion`}}",
-          "PBTEST_WindowsProductName={{user `ProductName`}}",
-          "PBTEST_WindowsEditionID={{user `EditionID`}}",
-          "PBTEST_WindowsInstallationType={{user `InstallationType`}}",
-          "PBTEST_WindowsReleaseID={{user `ReleaseID`}}",
-          "PBTEST_WindowsMemorySize={{user `memsize`}}"
-        ],
       "valid_exit_codes" : "{{user `valid_exit_codes`}}"
     },
     {
       "type": "powershell",
-      "script" : "../../common/scripts/provisioners/initiate-windows-update.ps1",
-      "environment_vars" : [
-        "ADMIN_USERNAME={{user `winrm_username`}}",
-        "ADMIN_PASSWORD={{user `winrm_password`}}"
-      ]
+      "script" : "../../common/scripts/provisioners/initiate-windows-update.ps1"
     },
     {
       "type" : "windows-restart",
@@ -221,10 +225,7 @@
     },
     {
       "type"   : "powershell",
-      "script" : "../../common/scripts/provisioners/install-cygwin.ps1",
-      "environment_vars" : [
-        "QA_ROOT_PASSWD_PLAIN={{user `qa_root_passwd_plain`}}"
-      ]
+      "script" : "../../common/scripts/provisioners/install-cygwin.ps1"
     },
     {
       "type": "windows-restart"
@@ -238,12 +239,7 @@
     },
     {
       "type"         : "powershell",
-      "script"       : "../../common/scripts/provisioners/initiate-puppet-configure.ps1",
-      "environment_vars" : [
-        "ADMIN_USERNAME={{user `winrm_username`}}",
-        "ADMIN_PASSWORD={{user `winrm_password`}}",
-        "QA_ROOT_PASSWD_PLAIN={{user `qa_root_passwd_plain`}}"
-      ]
+      "script"       : "../../common/scripts/provisioners/initiate-puppet-configure.ps1"
     },
     {
       "type" : "windows-restart",

--- a/templates/win/common/vmware.vcenter.platform9.json
+++ b/templates/win/common/vmware.vcenter.platform9.json
@@ -73,21 +73,37 @@
     {
       "type": "shell-local",
       "inline" : [
-        "rm -f ./tmp/build.yaml",
-        "echo '---' > tmp/build.yaml",
-        "echo \"packer::template_name: '{{user `template_name`}}'\" >> ./tmp/build.yaml",
-        "echo \"packer::packer_sha: '{{user `packer_sha`}}'\" >> ./tmp/build.yaml",
-        "echo \"packer::version: '{{user `version`}}'\" >> ./tmp/build.yaml",
-        "echo \"packer::build_date: '{{isotime}}'\" >> ./tmp/build.yaml",
-        "echo \"packer::template_type: '{{user `packer_template_type`}}'\" >> ./tmp/build.yaml",
-        "echo \"packer::packer_sha: '{{user `packer_sha`}}'\" >> ./tmp/build.yaml"
+        "rm -f ./tmp/build.json",
+        "echo '{' > tmp/build.json",
+
+        "echo '  \"packer\" : {' >> ./tmp/build.json",
+        "echo '    \"template_name\": \"{{user `template_name`}}\",' >> ./tmp/build.json",
+        "echo '    \"packer_sha\": \"{{user `packer_sha`}}\",' >> ./tmp/build.json",
+        "echo '    \"version\": \"{{user `version`}}\",' >> ./tmp/build.json",
+        "echo '    \"build_date\": \"{{isotime}}\",' >> ./tmp/build.json",
+        "echo '    \"template_type\": \"{{user `packer_template_type`}}\",' >> ./tmp/build.json",
+        "echo '    \"memsize\": \"{{user `memsize`}}\",' >> ./tmp/build.json",
+        "echo '    \"admin_username\": \"{{user `winrm_username`}}\",' >> ./tmp/build.json",
+        "echo '    \"admin_password\": \"{{user `winrm_password`}}\",' >> ./tmp/build.json",
+        "echo '    \"qa_root_passwd_plain\": \"{{user `qa_root_passwd_plain`}}\",' >> ./tmp/build.json",
+
+        "echo '    \"windows\" : {' >> ./tmp/build.json",
+        "echo '       \"currentversion\": \"{{user `CurrentVersion`}}\",' >> ./tmp/build.json",
+        "echo '       \"productname\": \"{{user `ProductName`}}\",' >> ./tmp/build.json",
+        "echo '       \"editionid\": \"{{user `EditionID`}}\",' >> ./tmp/build.json",
+        "echo '       \"installationtype\": \"{{user `InstallationType`}}\",' >> ./tmp/build.json",
+        "echo '       \"releaseid\": \"{{user `ReleaseID`}}\"' >> ./tmp/build.json",
+
+        "echo '    }' >> ./tmp/build.json",
+        "echo '  }' >> ./tmp/build.json",
+        "echo '}' >> ./tmp/build.json"
       ]
     },
     {
       "type": "file",
       "generated" : true,
-      "source": "./tmp/build.yaml",
-      "destination": "C:\\Packer\\puppet\\data\\build.yaml"
+      "source": "./tmp/build.json",
+      "destination": "C:\\Packer\\puppet\\data\\build.json"
     },
     {
       "type": "file",
@@ -125,19 +141,8 @@
       "destination": "C:\\Packer\\Config\\post-clone.autounattend.xml"
     },
     {
-      "type": "file",
-      "generated" : true,
-      "source": "./tmp/build.yaml",
-      "destination": "C:\\Packer\\puppet\\data\\build.yaml"
-    },
-    {
       "type"         : "powershell",
-      "script"       : "../../common/scripts/provisioners/initiate-puppet-configure.ps1",
-      "environment_vars" : [
-        "ADMIN_USERNAME={{user `winrm_username`}}",
-        "ADMIN_PASSWORD={{user `winrm_password`}}",
-        "QA_ROOT_PASSWD_PLAIN={{user `qa_root_passwd_plain`}}"
-      ]
+      "script"       : "../../common/scripts/provisioners/initiate-puppet-configure.ps1"
     },
     {
       "type" : "windows-restart",
@@ -159,10 +164,7 @@
     },
     {
       "type": "powershell",
-      "script" : "../../common/scripts/provisioners/config-platform9.ps1",
-      "environment_vars" : [
-        "QA_ROOT_PASSWD_PLAIN={{user `qa_root_passwd_plain`}}"
-      ]
+      "script" : "../../common/scripts/provisioners/config-platform9.ps1"
     },
     {
       "type": "powershell",

--- a/tests/test-syntax.sh
+++ b/tests/test-syntax.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 counter=0
-for file in $(find . -name "*.json" | egrep -v '^vars\.|.(vars|variables).|MAINTAINERS|metadata')
+for file in $(find . -name "*.json" | egrep -v '^vars\.|.(vars|variables).|MAINTAINERS|metadata|common\.json')
 do
     if ! ./packer validate -syntax-only  "$file" &> /dev/null ; then
         echo "$file"


### PR DESCRIPTION
Continue the work from IMAGES-1018 to remove environment variables to
inject data into the build:

1. Switch to .json format as this is easier to consume in powershell. This is done with PS2 support for the Windows-2008/2008r2 platform.
2. This requires changes to the puppet lookup and the variables used to access the .json data.
3. Windows Version/Edition information is passed in via .json file to be consumed by the packer testing.
4. This required moving the platform-package file processing to the bootstrap stage mainly for Windows-2008/2008r2 since .Net 3.5 is required to parse the .json format.

Note - this change has quite a bit of copy/pasta as the packer provider to write the .json file is repeated in several packer scripts. It is hoped to compress most of the windows build into a single packer script in a later ticket/PR which will eliminate much of the duplication.