### PR TITLE
(IMAGES-1082) update to PSWindowsUpdate 2.1.1.2

### DIFF
--- a/templates/win/10-1511/x86_64/files/platform-packages.ps1
+++ b/templates/win/10-1511/x86_64/files/platform-packages.ps1
@@ -5,3 +5,12 @@ Write-Output "Running Win-10 Package Customisationtemplates/windows-10/files/i38
 
 # Flag to remove Apps packages and other nuisances
 Touch-File "$PackerLogs\AppsPackageRemove.Required"
+
+if (-not (Test-Path "$PackerLogs\kb4035632.installed"))
+{
+  Write-Output "Installing Windows Update SSU kb4035632"
+  Install_Win_Patch -PatchUrl "http://download.windowsupdate.com/d/msdownload/update/software/crup/2017/08/windows10.0-kb4035632-x64_ea26f11d518e5e363fe9681b290a56a6afe15a81.msu"
+  Touch-File "$PackerLogs\kb4035632.installed"
+  Invoke-Reboot
+}
+

--- a/templates/win/10-1607/x86_64/files/platform-packages.ps1
+++ b/templates/win/10-1607/x86_64/files/platform-packages.ps1
@@ -3,5 +3,37 @@
 
 Write-Output "Running Win-10 Package Customisationtemplates/windows-10/files/i386/platform-packages.ps1"
 
+if (-not (Test-Path "$PackerLogs\kb4132216.installed"))
+{
+  Write-Output "Installing Windows Update SSU kb4132216"
+  Install_Win_Patch -PatchUrl "http://download.windowsupdate.com/c/msdownload/update/software/crup/2018/05/windows10.0-kb4132216-x64_9cbeb1024166bdeceff90cd564714e1dcd01296e.msu"
+  Touch-File "$PackerLogs\kb4132216.installed"
+  if (Test-PendingReboot) {Invoke-Reboot}
+}
+
+if (-not (Test-Path "$PackerLogs\kb4049065.installed"))
+{
+  Write-Output "Installing Windows Update SSU kb4049065"
+  Install_Win_Patch -PatchUrl "http://download.windowsupdate.com/d/msdownload/update/software/crup/2017/10/windows10.0-kb4049065-x64_f92abbe03d011154d52cf13be7fb60e2c6feb35b.msu"
+  Touch-File "$PackerLogs\kb4049065.installed"
+  if (Test-PendingReboot) {Invoke-Reboot}
+}
+
+if (-not (Test-Path "$PackerLogs\kb4465659.installed"))
+{
+  Write-Output "Installing Windows Update SSU kb4465659"
+  Install_Win_Patch -PatchUrl "http://download.windowsupdate.com/d/msdownload/update/software/secu/2018/11/windows10.0-kb4465659-x64_af8e00c5ba5117880cbc346278c7742a6efa6db1.msu"
+  Touch-File "$PackerLogs\kb4465659.installed"
+  if (Test-PendingReboot) {Invoke-Reboot}
+}
+
+if (-not (Test-Path "$PackerLogs\kb4485447.installed"))
+{
+  Write-Output "Installing Windows Update SSU kb4485447"
+  Install_Win_Patch -PatchUrl "http://download.windowsupdate.com/d/msdownload/update/software/secu/2019/02/windows10.0-kb4485447-x64_e9334a6f18fa0b63c95cd62930a058a51bba9a14.msu"
+  Touch-File "$PackerLogs\kb4485447.installed"
+  if (Test-PendingReboot) {Invoke-Reboot}
+}
+
 # Flag to remove Apps packages and other nuisances
 Touch-File "$PackerLogs\AppsPackageRemove.Required"

--- a/templates/win/2016-core/x86_64/files/platform-packages.ps1
+++ b/templates/win/2016-core/x86_64/files/platform-packages.ps1
@@ -3,4 +3,10 @@
 
 Write-Output "Running Win-2016 Core Package Customisation"
 
-# None Required
+if (-not (Test-Path "$PackerLogs\kb4485447.installed"))
+{
+  Write-Output "Installing Windows Update SSU kb4485447"
+  Install_Win_Patch -PatchUrl "http://download.windowsupdate.com/d/msdownload/update/software/secu/2019/02/windows10.0-kb4485447-x64_e9334a6f18fa0b63c95cd62930a058a51bba9a14.msu"
+  Touch-File "$PackerLogs\kb4485447.installed"
+  Invoke-Reboot
+}

--- a/templates/win/2016-fr/x86_64/files/platform-packages.ps1
+++ b/templates/win/2016-fr/x86_64/files/platform-packages.ps1
@@ -3,4 +3,10 @@
 
 Write-Output "Running Win-2016 Package Customisation"
 
-# None Needed
+if (-not (Test-Path "$PackerLogs\kb4485447.installed"))
+{
+  Write-Output "Installing Windows Update SSU kb4485447"
+  Install_Win_Patch -PatchUrl "http://download.windowsupdate.com/d/msdownload/update/software/secu/2019/02/windows10.0-kb4485447-x64_e9334a6f18fa0b63c95cd62930a058a51bba9a14.msu"
+  Touch-File "$PackerLogs\kb4485447.installed"
+  Invoke-Reboot
+}

--- a/templates/win/2016/x86_64/files/platform-packages.ps1
+++ b/templates/win/2016/x86_64/files/platform-packages.ps1
@@ -3,4 +3,10 @@
 
 Write-Output "Running Win-2016 Package Customisation"
 
-# None Needed
+if (-not (Test-Path "$PackerLogs\kb4485447.installed"))
+{
+  Write-Output "Installing Windows Update SSU kb4485447"
+  Install_Win_Patch -PatchUrl "http://download.windowsupdate.com/d/msdownload/update/software/secu/2019/02/windows10.0-kb4485447-x64_e9334a6f18fa0b63c95cd62930a058a51bba9a14.msu"
+  Touch-File "$PackerLogs\kb4485447.installed"
+  Invoke-Reboot
+}

--- a/templates/win/common/scripts/bootstrap/bootstrap-packerbuild.ps1
+++ b/templates/win/common/scripts/bootstrap/bootstrap-packerbuild.ps1
@@ -42,9 +42,9 @@ if (-not (Test-Path "$PackerLogs\BootstrapSchedTask.installed")) {
 # Enable WSUS - this is being put at the top of the script deliberately as a recycle of wuauserv is
 # required - this most reliable way to do this is with a reboot so we want to get this out the way first
 # to prevent windows update starting anything.
-# Windows-10/2016 seem to consistenly break on WSUS, so disable WSUS completely for these.
+# Windows-10/2016 LTSB seem to consistenly break on WSUS, so disable WSUS completely for these.
 # Same seems to apply to win-2012 so disabling for this too.
-if ($WindowsVersion -like $WindowsServer2016 -or $WindowsVersion -like $WindowsServer2012) {
+if ($WindowsVersion -like $WindowsServer2012 -or ($WindowsVersion -like $WindowsServer2016 -and $WindowsInstallationType -eq "Client" -and $WindowsReleaseID -eq "1607")) {
   Write-Output "Bypassing WSUS - Go Direct to Microsoft for updates"
   Disable-WindowsAutoUpdate
 }

--- a/templates/win/common/scripts/bootstrap/packer-windows-update.ps1
+++ b/templates/win/common/scripts/bootstrap/packer-windows-update.ps1
@@ -42,10 +42,10 @@ do {
     # The format and command for windows update differs across windows versions.
     # See below.
     If ($WindowsVersion -like $WindowsServer2016) {
-      # Use Latest (2.0.0.4) for Win-10/2016 only
+      # Use Latest (2.1.1.2) for Win-10/2016 only
       # Note 'KB2267602' is screened out as it doesn't appear to install correctly.
-      Write-Output "Running PSWindows Update - Verbose Mode"
-      Install-WindowsUpdate -Verbose -AcceptAll -UpdateType Software -IgnoreReboot -NotKBArticleID 'KB2267602'
+      Write-Output "Running PSWindows Update"
+      Install-WindowsUpdate -AcceptAll -UpdateType Software -IgnoreReboot -NotKBArticleID 'KB2267602'
     } elseif ($psversiontable.psversion.major -eq 2) {
       # Ignore errors on PS2 (in case of unblock file errors)
       Write-Output "Running PSWindows Update - Ignoring errors (PS2)"
@@ -53,7 +53,7 @@ do {
     } else {
       # All other versions - mainly 2012r2 use this version
       Write-Output "Running PSWindows Update - Non Verbose Mode"
-      Install-WindowsUpdate -AcceptAll -UpdateType Software -IgnoreReboot -Verbose
+      Install-WindowsUpdate -AcceptAll -UpdateType Software -IgnoreReboot
     }
     if (Test-PendingReboot) { 
       Invoke-Reboot 

--- a/templates/win/common/scripts/provisioners/initiate-windows-update.ps1
+++ b/templates/win/common/scripts/provisioners/initiate-windows-update.ps1
@@ -22,7 +22,7 @@ if (-not (Test-Path "$PackerLogs\PSWindowsUpdate.installed")) {
   # Download and install PSWindows Update Modules 
   # Use Version 2.0.0.4 (latest) for Win-10/2016 only as it doesn't play nicely with earlier versions
   If ($WindowsVersion -like $WindowsServer2016) {
-    $Global:PsWindowsUpdateVersion = "2.0.0.4"
+    $Global:PsWindowsUpdateVersion = "2.1.1.2"
   } else {
     $Global:PsWindowsUpdateVersion = "1.6.1.1"
   }


### PR DESCRIPTION
1. Update to Version 2.1.1.2 of the PsWindows Update tool as this appears to run faster for the Windows 10 series of builds. Retain earlier version for win-2012r2 due to WUHistory problem.
2. Add in specific patches to address Windows Service Stack (Update) issues that cause problems for the Windows 2016 build. This hopefully shortens the update time for Windows 2016 by avoding two cumulative update downloads and random failures to do the windows update.
3. Windows 10/2016 now appears to work correctly (and faster) with WSUS so enable these. Windows 10 2016 LTSB still fails to download from WSUS and Win-2012 doesn't get any updates from WSUS, so continue to exclude these.