### PR TITLE
(IMAGES-1084) Do not deploy updates repo on Jessie

### DIFF
--- a/manifests/modules/packer/manifests/vsphere/params.pp
+++ b/manifests/modules/packer/manifests/vsphere/params.pp
@@ -71,8 +71,8 @@ class packer::vsphere::params {
       $ruby_package          = [ 'ruby' ]
       $repo_name             = 'debian__remote'
       $repo_list             = 'main contrib non-free'
-      $security_repo_name    = 'debian__remote'
-      $security_release      = "${facts['lsbdistcodename']}"
+      $security_repo_name    = 'debian_security__remote'
+      $security_release      = "${facts['lsbdistcodename']}/security"
       $updates_release       = "${facts['lsbdistcodename']}-updates"
     }
 

--- a/manifests/modules/packer/manifests/vsphere/repos.pp
+++ b/manifests/modules/packer/manifests/vsphere/repos.pp
@@ -51,14 +51,16 @@ class packer::vsphere::repos(
         },
       }
 
-      apt::source { "${facts['lsbdistcodename']}-updates":
-        release  => $updates_release,
-        location => "${repo_mirror}/${repo_name}",
-        repos    => $repo_list,
-        include  => {
-          'src' => true,
-          'deb' => true,
-        },
+      if $facts['operatingsystem'] == 'Debian' and $facts['operatingsystemrelease'] >= 9 {
+        apt::source { "${facts['lsbdistcodename']}-updates":
+          release  => $updates_release,
+          location => "${repo_mirror}/${repo_name}",
+          repos    => $repo_list,
+          include  => {
+            'src' => true,
+            'deb' => true,
+          },
+        }
       }
 
       apt::source { "${facts['lsbdistcodename']}-security":


### PR DESCRIPTION
As part of the LTS process (apparently?), Debian has removed
jessie-updates in favor of the security updates repo.

This commit updates the repos configuration to only deploy the
-updates repo for Debians newer than Jessie. It also fixes the
security updates repo to ensure we can still get updated versions of
packages, rather than only the Jessie base system.