### PR TITLE
(IMAGES-1070) April Patch Tuesday Version

### DIFF
--- a/templates/win/common/vars.json
+++ b/templates/win/common/vars.json
@@ -1,5 +1,5 @@
 {
-  "version"             : "20190400_PROD",
+  "version"             : "20190412",
 
   "headless"            : "true",
 


### PR DESCRIPTION
Drop the _PROD suffix as well as the imaging pipeline now puts the "dev_image" suffix on Dev/Test builds.

The initial run failed with pipeline issues and the version number had 00 for the day number.
So updating version to tomorrow's (build) date.