### PR TITLE
(IMAGES-1100) Enable Netbios/lmhosts

### DIFF
--- a/templates/win/common/scripts/platform9/platform9-post-clone-configuration.ps1
+++ b/templates/win/common/scripts/platform9/platform9-post-clone-configuration.ps1
@@ -43,6 +43,11 @@ if ($WindowsVersion -notlike $WindowsServer2016) {
   }
 }
 
+Write-Output "Re-enable NETBios and WinRM Services"
+Set-Service "lmhosts" -StartupType Automatic
+Set-Service "netbt" -StartupType Automatic
+Set-Service "WinRM" -StartupType Automatic
+
 # Put a restart in to make sure host is renamed.
 Write-Output "Restarting to allow host rename"
 if ($WindowsVersion -like $WindowsServer2008R2 -or $WindowsVersion -like $WindowsServer2008) {

--- a/templates/win/common/vars.json
+++ b/templates/win/common/vars.json
@@ -1,5 +1,5 @@
 {
-  "version"             : "201904XX_DEV",
+  "version"             : "20190423",
 
   "headless"            : "true",
 


### PR DESCRIPTION
Netbios/lmhosts was disabled pre-sysprep but not re-enabled which causes
issues setting up AD etc.

So set services back to default enabled.