### PR TITLE
(MAINT) Re-Assert Test checks for win-2012r2-core

### DIFF
--- a/templates/win/2012r2-core/x86_64/vars.json
+++ b/templates/win/2012r2-core/x86_64/vars.json
@@ -17,7 +17,5 @@
     "ProductName"       : "Windows Server 2012 R2 Standard",
     "EditionID"         : "ServerStandard",
     "InstallationType"  : "Server Core",
-    "ReleaseID"         : "N/A",
-
-    "valid_exit_codes"  : "0,1"
+    "ReleaseID"         : "N/A"
 }


### PR DESCRIPTION
The Pester tests were relaxed for Windows 2012r2 Core due to the lack
of updates (i.e. the slipstream was too successful). This can now be
relaxed with the May 19 update.