### PR TITLE
(IMAGES-1114) Add packer support for Fedora 30

### DIFF
--- a/manifests/modules/packer/manifests/networking/params.pp
+++ b/manifests/modules/packer/manifests/networking/params.pp
@@ -40,7 +40,7 @@ class packer::networking::params {
           $udev_rule     = undef
           $udev_rule_gen = undef
         }
-        '29': {
+        '29', '30': {
           $interface_script = undef
           $udev_rule        = undef
           $udev_rule_gen    = undef

--- a/manifests/modules/packer/manifests/vmtools.pp
+++ b/manifests/modules/packer/manifests/vmtools.pp
@@ -15,7 +15,7 @@ class packer::vmtools(
   # At some point it's going to become more worthwhile to flip this so
   # installing open-vm-tools is the default.
   if ( ($facts['osfamily'] == 'debian' and $facts['operatingsystemmajrelease'] in ['7', '8', '9', 'buster/sid', '16.04', '14.04', '18.04', '18.10']) or
-        ($facts['osfamily'] == 'redhat' and $facts['operatingsystemmajrelease'] in ['7', '8', '25', '26', '27', '28', '29']) or
+        ($facts['osfamily'] == 'redhat' and $facts['operatingsystemmajrelease'] in ['7', '8', '25', '26', '27', '28', '29', '30']) or
         ($facts['osfamily'] == 'suse' and $facts['operatingsystemmajrelease'] in ['15'])
     ) {
       package { 'open-vm-tools':

--- a/manifests/modules/packer/manifests/vsphere.pp
+++ b/manifests/modules/packer/manifests/vsphere.pp
@@ -40,7 +40,7 @@ class packer::vsphere(
 
   case $facts['osfamily'] {
     redhat: {
-      if $facts['operatingsystemrelease'] in ['24', '25', '26', '27', '28', '29'] {
+      if $facts['operatingsystemrelease'] in ['24', '25', '26', '27', '28', '29', '30'] {
         Package {
           provider => 'dnf',
         }
@@ -53,7 +53,7 @@ class packer::vsphere(
         }
       }
 
-      if $facts['operatingsystemrelease'] in ['28', '29'] {
+      if $facts['operatingsystemrelease'] in ['28', '29', '30'] {
         # Enable systemd service for vsphere bootstrap instead of relying on rc.local
         file { "/etc/systemd/system/multi-user.target.wants/${startup_file_source}":
           ensure => 'link',

--- a/manifests/modules/packer/manifests/vsphere/params.pp
+++ b/manifests/modules/packer/manifests/vsphere/params.pp
@@ -101,7 +101,7 @@ class packer::vsphere::params {
     }
 
     'Fedora': {
-      if $facts['operatingsystemrelease'] in ['28', '29'] {
+      if $facts['operatingsystemrelease'] in ['28', '29', '30'] {
         $startup_file          = '/etc/systemd/system/vsphere.bootstrap.service'
         $startup_file_source   = 'vsphere.bootstrap.service'
         $startup_file_perms    = '0644'

--- a/manifests/modules/packer/templates/vsphere/redhat.rb.erb
+++ b/manifests/modules/packer/templates/vsphere/redhat.rb.erb
@@ -14,7 +14,7 @@ File.open('/etc/hostname', 'w') do |f|
   f.write(hostname)
 end
 
-<% if ['28', '29'].include? @operatingsystemrelease -%>
+<% if ['28', '29', '30'].include? @operatingsystemrelease -%>
 # systemd-networkd
 Kernel.system("/usr/bin/hostnamectl set-hostname #{hostname}")
 <% else -%>
@@ -56,7 +56,7 @@ puts '- Re-obtaining DHCP lease...'
 <% end -%>
 
 <% if @operatingsystem == 'Fedora' -%>
-  <% if ['28', '29'].include? @operatingsystemrelease -%>
+  <% if ['28', '29', '30'].include? @operatingsystemrelease -%>
 # systemd-networkd's DHCP client uses /etc/machine-id instead of the
 # link layer address (as dhclient does) to generate a client ID.
 # /etc/machine-id will be the same on VMs cloned from the same template,
@@ -72,7 +72,7 @@ Kernel.system('/sbin/service NetworkManager restart')
 
 puts '- Cleaning up...'
 
-<% if ['28', '29'].include? @operatingsystemrelease -%>
+<% if ['28', '29', '30'].include? @operatingsystemrelease -%>
 # With systemd-networkd, disable the oneshot service that runs this script:
 Kernel.system('/bin/systemctl disable vsphere.bootstrap.service')
 <% else -%>

--- a/templates/fedora/30/files/ks.cfg
+++ b/templates/fedora/30/files/ks.cfg
@@ -1,0 +1,36 @@
+install
+cdrom
+lang en_US.UTF-8
+keyboard us
+network --bootproto=dhcp --device=eth0
+repo --name=updates
+rootpw puppet
+firewall --disabled
+authconfig --enableshadow --passalgo=sha512
+selinux --disabled
+timezone UTC
+bootloader --location=mbr
+text
+skipx
+zerombr
+clearpart --all --initlabel
+autopart
+auth  --useshadow  --enablemd5
+firstboot --disabled
+reboot
+
+%packages --ignoremissing
+bzip2
+kernel-devel
+kernel-headers
+tar
+wget
+nfs-utils
+net-tools
+libxcrypt-compat
+-plymouth
+-plymouth-core-libs
+%end
+
+%post
+%end

--- a/templates/fedora/30/x86_64/vars.json
+++ b/templates/fedora/30/x86_64/vars.json
@@ -1,0 +1,14 @@
+{
+    "template_name"                         : "fedora-30-x86_64",
+    "template_os"                           : "fedora64Guest",
+    "beakerhost"                            : "fedora30-64",
+    "version"                               : "0.0.1",
+    "iso_url"                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/Fedora-Server-dvd-x86_64-30-1.2.iso",
+    "iso_checksum"                          : "bb0622b78449298e24a96b90b561b429edec71aae72b8f7a8c3da4d81e4df5b7",
+    "iso_checksum_type"                     : "sha256",
+    "vmware_vsphere_nocm_vmx_data_memsize"  : "4096",
+    "vmware_vsphere_nocm_vmx_data_numvcpus" : "2",
+    "floppy_files"                          : "../files/ks.cfg",
+    "puppet_aio"                            : "http://yum.puppetlabs.com/puppet6/fedora/29/x86_64/puppet-agent-6.4.2-1.fc29.x86_64.rpm",
+    "iso_name"                              : "Fedora-Server-dvd-x86_64-30-1.2.iso"
+}

--- a/templates/fedora/README.md
+++ b/templates/fedora/README.md
@@ -8,7 +8,7 @@ This contains all of the var files required to build any of the other templates 
 
 This repository includes OS platforms that are officially supported at Puppet and ones that are entirely maintained by the community. Packer templates include a `support_status` variable which indicates whether the template is puppet maintained vs. community maintained.
 
-Puppet maintained Fedora versions include 26, 27, and 28. Any other versions of Fedora here are community maintained.
+Puppet maintained Fedora versions include 26, 27, 28, 29 and 30. Any other versions of Fedora here are community maintained.
 
 ### Building
 


### PR DESCRIPTION
Added Fedora 30 to puppetlabs-packer:
- installed `libxcrypt-compat` for libcrypt.so.1 required by Puppet-provided ruby
- disabled consistent network device renaming (keep eth0)