### PR TITLE
(IMAGES-1117) Add Win 10 1903 and 2019 LTSC

### DIFF
--- a/templates/win/10-1809/x86_64/files/platform-packages.ps1
+++ b/templates/win/10-1809/x86_64/files/platform-packages.ps1
@@ -1,0 +1,7 @@
+
+. C:\Packer\Scripts\windows-env.ps1
+
+Write-Output "Running Win-10 Package Customisationtemplates/windows-10/files/i386/platform-packages.ps1"
+
+# Flag to remove Apps packages and other nuisances
+Touch-File "$PackerLogs\AppsPackageRemove.Required"

--- a/templates/win/10-1809/x86_64/vars.json
+++ b/templates/win/10-1809/x86_64/vars.json
@@ -1,0 +1,21 @@
+{
+    "template_name"     : "win-10-1809-x86_64",
+    "beakerhost"        : "windows10ent-64",
+    "vbox_guest_os"     : "Windows81_64",
+    "vmware_guest_os"   : "windows8-64",
+    "vsphere_guest_os"  : "windows9_64Guest",
+    "windows_version"   : "Windows-10",
+    "image_name"        : "Windows 10 Enterprise LTSC 2019",
+    "product_key"       : "M7XTQ-FN8P6-TTKYV-9D4CC-J462D",
+    "iso_name"          : "en_windows_10_enterprise_ltsc_2019_x64_dvd_5795bb03.iso",
+    "iso_checksum_type" : "md5",
+    "iso_checksum"      : "1067be5346fed207089b3022165b8b19",
+    "boot_command"      : "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait>",
+
+    "CurrentVersion"    : "6.3",
+    "ProductName"       : "Windows 10 Enterprise LTSC 2019",
+    "EditionID"         : "EnterpriseS",
+    "InstallationType"  : "Client",
+    "ReleaseID"         : "1809"
+
+}

--- a/templates/win/10-ent/i386/vars.json
+++ b/templates/win/10-ent/i386/vars.json
@@ -8,9 +8,9 @@
     "windows_version"   : "Windows-10",
     "image_name"        : "Windows 10 Enterprise",
     "product_key"       : "NPPR9-FWDCX-D2C8J-H872K-2YT43",
-    "iso_name"          : "en_windows_10_business_edition_version_1809_updated_sept_2018_x86_dvd_37ef4f24.iso",
+    "iso_name"          : "en_windows_10_business_edition_version_1809_updated_may_2019_x86_dvd_d5e8af28.iso",
     "iso_checksum_type" : "md5",
-    "iso_checksum"      : "da090711be092fe5d128dfb8c56a0e19",
+    "iso_checksum"      : "8aab2f6abe556d9c0c83a38af57c61fb",
     "boot_command"      : "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait>",
 
     "CurrentVersion"    : "6.3",

--- a/templates/win/10-ent/x86_64/vars.json
+++ b/templates/win/10-ent/x86_64/vars.json
@@ -7,9 +7,9 @@
     "vsphere_guest_os"  : "windows9_64Guest",
     "image_name"        : "Windows 10 Enterprise",
     "product_key"       : "NPPR9-FWDCX-D2C8J-H872K-2YT43",
-    "iso_name"          : "en_windows_10_business_edition_version_1809_updated_sept_2018_x64_dvd_d57f2c0d.iso",
+    "iso_name"          : "en_windows_10_business_edition_version_1809_updated_may_2019_x64_dvd_7f62cc27.iso",
     "iso_checksum_type" : "md5",
-    "iso_checksum"      : "042cd8b6179e1a1e63bc633c9c744781",
+    "iso_checksum"      : "71351b946d522ab25cf1db01021a2d14",
     "boot_command"      : "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait>",
 
     "CurrentVersion"    : "6.1",

--- a/templates/win/10-next/i386/files/platform-packages.ps1
+++ b/templates/win/10-next/i386/files/platform-packages.ps1
@@ -1,0 +1,7 @@
+
+. C:\Packer\Scripts\windows-env.ps1
+
+Write-Output "Running Win-10 Package Customisation"
+
+# Flag to remove Apps packages and other nuisances
+Touch-File "$PackerLogs\AppsPackageRemove.Required"

--- a/templates/win/10-next/i386/vars.json
+++ b/templates/win/10-next/i386/vars.json
@@ -1,7 +1,7 @@
 {
     "template_name"     : "win-10-next-i386",
     "win_proc_arch"     : "x86",
-    "beakerhost"        : "windows10next-32",
+    "beakerhost"        : "windows10ent-32",
     "vbox_guest_os"     : "Windows10",
     "vmware_guest_os"   : "windows8",
     "vsphere_guest_os"  : "windows9Guest",

--- a/templates/win/10-next/i386/vars.json
+++ b/templates/win/10-next/i386/vars.json
@@ -1,0 +1,22 @@
+{
+    "template_name"     : "win-10-next-i386",
+    "win_proc_arch"     : "x86",
+    "beakerhost"        : "windows10next-32",
+    "vbox_guest_os"     : "Windows10",
+    "vmware_guest_os"   : "windows8",
+    "vsphere_guest_os"  : "windows9Guest",
+    "windows_version"   : "Windows-10",
+    "image_name"        : "Windows 10 Enterprise",
+    "product_key"       : "M7XTQ-FN8P6-TTKYV-9D4CC-J462D",
+    "iso_name"          : "en_windows_10_business_editions_version_1903_x86_dvd_ca4f0f49.iso",
+    "iso_checksum_type" : "md5",
+    "iso_checksum"      : "23b62778b7b577be88503f2208044c3e",
+    "boot_command"      : "<nexter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait>",
+
+    "CurrentVersion"    : "6.3",
+    "ProductName"       : "Windows 10 Enterprise",
+    "EditionID"         : "Enterprise",
+    "InstallationType"  : "Client",
+    "ReleaseID"         : "1903"
+
+}

--- a/templates/win/10-next/i386/vars.json
+++ b/templates/win/10-next/i386/vars.json
@@ -7,7 +7,7 @@
     "vsphere_guest_os"  : "windows9Guest",
     "windows_version"   : "Windows-10",
     "image_name"        : "Windows 10 Enterprise",
-    "product_key"       : "M7XTQ-FN8P6-TTKYV-9D4CC-J462D",
+    "product_key"       : "NPPR9-FWDCX-D2C8J-H872K-2YT43",
     "iso_name"          : "en_windows_10_business_editions_version_1903_x86_dvd_ca4f0f49.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "23b62778b7b577be88503f2208044c3e",

--- a/templates/win/10-next/x86_64/files/platform-packages.ps1
+++ b/templates/win/10-next/x86_64/files/platform-packages.ps1
@@ -1,0 +1,7 @@
+
+. C:\Packer\Scripts\windows-env.ps1
+
+Write-Output "Running Win-10 Package Customisationtemplates/windows-10/files/i386/platform-packages.ps1"
+
+# Flag to remove Apps packages and other nuisances
+Touch-File "$PackerLogs\AppsPackageRemove.Required"

--- a/templates/win/10-next/x86_64/vars.json
+++ b/templates/win/10-next/x86_64/vars.json
@@ -1,6 +1,6 @@
 {
     "template_name"     : "win-10-next-x86_64",
-    "beakerhost"        : "windows10next-64",
+    "beakerhost"        : "windows10ent-64",
     "vbox_guest_os"     : "Windows81_64",
     "vmware_guest_os"   : "windows8-64",
     "vsphere_guest_os"  : "windows9_64Guest",

--- a/templates/win/10-next/x86_64/vars.json
+++ b/templates/win/10-next/x86_64/vars.json
@@ -1,0 +1,21 @@
+{
+    "template_name"     : "win-10-next-x86_64",
+    "beakerhost"        : "windows10next-64",
+    "vbox_guest_os"     : "Windows81_64",
+    "vmware_guest_os"   : "windows8-64",
+    "vsphere_guest_os"  : "windows9_64Guest",
+    "windows_version"   : "Windows-10",
+    "image_name"        : "Windows 10 Enterprise",
+    "product_key"       : "M7XTQ-FN8P6-TTKYV-9D4CC-J462D",
+    "iso_name"          : "en_windows_10_business_editions_version_1903_x64_dvd_37200948.iso",
+    "iso_checksum_type" : "md5",
+    "iso_checksum"      : "16806bfff1d40930dfd200204e6105aa",
+    "boot_command"      : "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait>",
+
+    "CurrentVersion"    : "6.3",
+    "ProductName"       : "Windows 10 Enterprise",
+    "EditionID"         : "Enterprise",
+    "InstallationType"  : "Client",
+    "ReleaseID"         : "1903"
+
+}

--- a/templates/win/10-next/x86_64/vars.json
+++ b/templates/win/10-next/x86_64/vars.json
@@ -6,7 +6,7 @@
     "vsphere_guest_os"  : "windows9_64Guest",
     "windows_version"   : "Windows-10",
     "image_name"        : "Windows 10 Enterprise",
-    "product_key"       : "M7XTQ-FN8P6-TTKYV-9D4CC-J462D",
+    "product_key"       : "NPPR9-FWDCX-D2C8J-H872K-2YT43",
     "iso_name"          : "en_windows_10_business_editions_version_1903_x64_dvd_37200948.iso",
     "iso_checksum_type" : "md5",
     "iso_checksum"      : "16806bfff1d40930dfd200204e6105aa",

--- a/templates/win/10-pro/x86_64/vars.json
+++ b/templates/win/10-pro/x86_64/vars.json
@@ -7,9 +7,9 @@
     "windows_version"   : "Windows-10",
     "image_name"        : "Windows 10 Pro",
     "product_key"       : "W269N-WFGWX-YVC9B-4J6C9-T83GX",
-    "iso_name"          : "en_windows_10_business_edition_version_1809_updated_sept_2018_x64_dvd_d57f2c0d.iso",
+    "iso_name"          : "en_windows_10_business_edition_version_1809_updated_may_2019_x64_dvd_7f62cc27.iso",
     "iso_checksum_type" : "md5",
-    "iso_checksum"      : "042cd8b6179e1a1e63bc633c9c744781",
+    "iso_checksum"      : "71351b946d522ab25cf1db01021a2d14",
     "boot_command"      : "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait>",
 
     "CurrentVersion"    : "6.3",

--- a/templates/win/2019-fr/x86_64/files/platform-packages.ps1
+++ b/templates/win/2019-fr/x86_64/files/platform-packages.ps1
@@ -1,0 +1,12 @@
+
+. C:\Packer\Scripts\windows-env.ps1
+
+Write-Output "Running Win-2016 Package Customisation"
+
+if (-not (Test-Path "$PackerLogs\kb4500641.installed"))
+{
+  Write-Output "Installing Windows Update SSU kb4485447"
+  Install_Win_Patch -PatchUrl "http://download.windowsupdate.com/d/msdownload/update/software/secu/2019/05/windows10.0-kb4500641-x64_66a086b2ae104c6b295b0da94500b85125a6a562.msu"
+  Touch-File "$PackerLogs\kb4500641.installed"
+  Invoke-Reboot
+}

--- a/templates/win/2019-fr/x86_64/vars.json
+++ b/templates/win/2019-fr/x86_64/vars.json
@@ -1,0 +1,23 @@
+{
+    "template_name"     : "win-2019-fr-x86_64",
+    "locale"            : "fr-FR",
+    "winrm_username"    : "Administrateur",
+    "beakerhost"        : "windows2019_fr-64",
+    "beaker_locale"     : "fr",
+    "vbox_guest_os"     : "Windows2019_64",
+    "vmware_guest_os"   : "windows8srv-64",
+    "vsphere_guest_os"  : "windows9Server64Guest",
+    "windows_version"   : "Windows-2019",
+    "image_name"        : "Windows Server 2019 SERVERSTANDARD",
+    "product_key"       : "N69G4-B89J2-4G8F4-WWYCC-J464C",
+    "iso_name"          : "fr_windows_server_2019_updated_march_2019_x64_dvd_afbb129f.iso",
+    "iso_checksum_type" : "md5",
+    "iso_checksum"      : "3d20cdcfdfe59e3ab29be2607436dbc7",
+    "boot_command"      : "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter>",
+
+    "CurrentVersion"    : "6.3",
+    "ProductName"       : "Windows Server 2019 Standard",
+    "EditionID"         : "ServerStandard",
+    "InstallationType"  : "Server",
+    "ReleaseID"         : "1809"
+}

--- a/templates/win/2019-fr/x86_64/vars.json
+++ b/templates/win/2019-fr/x86_64/vars.json
@@ -2,7 +2,7 @@
     "template_name"     : "win-2019-fr-x86_64",
     "locale"            : "fr-FR",
     "winrm_username"    : "Administrateur",
-    "beakerhost"        : "windows2019_fr-64",
+    "beakerhost"        : "windows2019-64",
     "beaker_locale"     : "fr",
     "vbox_guest_os"     : "Windows2019_64",
     "vmware_guest_os"   : "windows8srv-64",

--- a/templates/win/2019-ja/x86_64/files/platform-packages.ps1
+++ b/templates/win/2019-ja/x86_64/files/platform-packages.ps1
@@ -1,0 +1,13 @@
+
+. C:\Packer\Scripts\windows-env.ps1
+
+Write-Output "Running Win-2012r2 JA Package Customisation"
+
+if (-not (Test-Path "$PackerLogs\DesktopExperience.installed"))
+{
+  # Enable Desktop experience to get cleanmgr
+  Write-Output "Enable Desktop-Experience"
+  Add-WindowsFeature Desktop-Experience
+  Touch-File "$PackerLogs\DesktopExperience.installed"
+  if (Test-PendingReboot) { Invoke-Reboot }
+}

--- a/templates/win/2019-ja/x86_64/files/slipstream-filter
+++ b/templates/win/2019-ja/x86_64/files/slipstream-filter
@@ -1,0 +1,1 @@
+# CAB files to be filtered out in case of DISM Issues

--- a/templates/win/2019-ja/x86_64/vars.json
+++ b/templates/win/2019-ja/x86_64/vars.json
@@ -1,0 +1,23 @@
+{
+    "template_name"     : "win-2019-ja-x86_64",
+    "locale"            : "ja-JP",
+    "beakerhost"        : "windows2019_ja-64",
+    "vbox_guest_os"     : "Windows2019_64",
+    "vmware_guest_os"   : "windows8srv-64",
+    "vsphere_guest_os"  : "windows8Server64Guest",
+    "beaker_locale"     : "ja",
+    "windows_version"   : "Windows-2019",
+    "image_name"        : "Windows Server 2019 SERVERSTANDARD",
+    "product_key"       : "N69G4-B89J2-4G8F4-WWYCC-J464C",
+    "iso_name"          : "ja_windows_server_2019_updated_march_2019_x64_dvd_fee81286.iso",
+    "iso_checksum_type" : "md5",
+    "iso_checksum"      : "be3135e3488418a80de6ff078ad105b0",
+    "boot_command"      : "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait>",
+
+    "CurrentVersion"    : "6.3",
+    "ProductName"       : "Windows Server 2019 Standard",
+    "EditionID"         : "ServerStandard",
+    "InstallationType"  : "Server",
+    "ReleaseID"         : "1809"
+
+}

--- a/templates/win/2019-ja/x86_64/vars.json
+++ b/templates/win/2019-ja/x86_64/vars.json
@@ -1,7 +1,7 @@
 {
     "template_name"     : "win-2019-ja-x86_64",
     "locale"            : "ja-JP",
-    "beakerhost"        : "windows2019_ja-64",
+    "beakerhost"        : "windows2019-64",
     "vbox_guest_os"     : "Windows2019_64",
     "vmware_guest_os"   : "windows8srv-64",
     "vsphere_guest_os"  : "windows8Server64Guest",


### PR DESCRIPTION
Adding Windows 10 Next to allow testing for the "Next" build of Windows 10 on a continuous basis - this initially will be for Build 1903. This allows the build to be evaluated without breaking the existing pipelines It will also be used to test the preview builds once they are available and 1903 (etc) has been "mainlined" into the Windows 10 build.

Also adding:
1. Windows 10 LTSC (Build 1809)
2. Windows 2019 French and Japanese