### PR TITLE
(maint) disable name-service/cache on Solaris 11.4

### DIFF
--- a/templates/solaris/11.4/common/files/profile.xml
+++ b/templates/solaris/11.4/common/files/profile.xml
@@ -85,6 +85,9 @@ Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
       </property_group>
     </instance>
   </service>
+  <service name='system/name-service/cache' type='service' version='1'>
+    <instance enabled="false" name="default"/>
+  </service>
   <service name='network/dns/client' type='service' version='1'>
     <property_group name='config' type='application'>
         <property name='nameserver' type='net_address'>

--- a/templates/solaris/11.4/x86_64/vars.json
+++ b/templates/solaris/11.4/x86_64/vars.json
@@ -2,7 +2,7 @@
     "template_name"                         : "solaris-114-x86_64",
     "template_os"                           : "solaris11-64",
     "beakerhost"                            : "solaris114-32",
-    "version"                               : "0.0.4",
+    "version"                               : "0.0.5",
     "iso_url"                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/sol-11_4-ai-x86.iso",
     "iso_checksum"                          : "e3a29507e583acbc0b912f371c8f328fea7cb6257d587cbc0a651477a52b0a29",
     "iso_checksum_type"                     : "sha256",


### PR DESCRIPTION
on Solaris 11.4, name-service/cache uses old nscd application that doesn't know how to handle DNAME record