### PR TITLE
(IMAGES-1145) enable ipv6 on redhat 7 fips

### DIFF
--- a/manifests/modules/packer/templates/vsphere/redhat.rb.erb
+++ b/manifests/modules/packer/templates/vsphere/redhat.rb.erb
@@ -30,15 +30,25 @@ puts '- Re-obtaining DHCP lease...'
     Kernel.system('/usr/sbin/ifup ens33')
   <% end -%>
   <% if @operatingsystemmajrelease == '7' -%>
-    network_interface_name = `ls /sys/class/net -I lo`.chomp
-    puts 'network_interface_name is: '
-    puts "#{network_interface_name}"
-    File.open("/var/lib/NetworkManager/dhclient-#{network_interface_name}.conf", 'a') do |f|
-      f << "send host-name #{hostname}"
+    network_interfaces_name = `ls /sys/class/net -I lo`.chomp
+    network_interfaces_name.split(" ").each do |network_interface_name|
+      puts 'network_interface_name is: #{network_interface_name}'
+      cfg_file="/etc/sysconfig/network-scripts/ifcfg-#{network_interface_name}"
+      if File.exists?(cfg_file) && File.readlines(cfg_file).grep(/File Managed by Puppet/).size > 0
+        File.open("/var/lib/NetworkManager/dhclient-#{network_interface_name}.conf", 'a') do |f|
+          f << "send host-name \"#{hostname}\";"
+        end
+      else
+        Kernel.system("nmcli con add con-name #{network_interface_name} type ethernet ifname #{network_interface_name}")
+      end
+      Kernel.system("/usr/sbin/ifdown #{network_interface_name}")
     end
+
     Kernel.system('/sbin/service NetworkManager restart')
-    Kernel.system("/usr/sbin/ifdown #{network_interface_name}")
-    Kernel.system("/usr/sbin/ifup #{network_interface_name}")
+
+    network_interfaces_name.split(" ").each do |network_interface_name|
+      Kernel.system("/usr/sbin/ifup #{network_interface_name}")
+    end
   <% end -%>
   <% if @operatingsystemmajrelease == '6' -%>
     File.open('/etc/dhcp/dhclient-eth0.conf', 'a') do |f|

--- a/templates/redhat/7.2-fips/x86_64/vars.json
+++ b/templates/redhat/7.2-fips/x86_64/vars.json
@@ -2,7 +2,7 @@
     "template_name"                         : "redhat-fips-7.2-x86_64",
     "template_os"                           : "rhel7_64Guest",
     "beakerhost"                            : "redhatfips7-64",
-    "version"                               : "0.0.7",
+    "version"                               : "0.0.8",
     "iso_url"                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/rhel-server-7.2-x86_64-dvd.iso",
     "iso_checksum"                          : "03f3a0291634335f6995534d829bd21ffaa0d000004dfeb1b2fb81052d64a4d5",
     "iso_checksum_type"                     : "sha256",


### PR DESCRIPTION
If the interface cfg file contains "File Managed by Puppet", it will be configured as before, otherwise Network Manager default configuration will be enabled for it