### PR TITLE
(MAINT) Adding a 7.2 image with tmpfs support

### DIFF
--- a/templates/centos/7.2-tmpfs/common/files/ks.cfg
+++ b/templates/centos/7.2-tmpfs/common/files/ks.cfg
@@ -1,0 +1,46 @@
+install
+cdrom
+lang en_US.UTF-8
+keyboard us
+network --bootproto=dhcp
+rootpw --iscrypted $1$v4K9E8Wj$gZIHJ5JtQL5ZGZXeqSSsd0
+firewall --enabled --service=ssh
+authconfig --enableshadow --passalgo=sha512
+selinux --disabled
+timezone UTC
+bootloader --location=mbr
+
+text
+skipx
+zerombr
+
+clearpart --all --initlabel
+autopart
+
+auth  --useshadow  --enablemd5
+firstboot --disabled
+reboot --eject
+
+%packages --ignoremissing
+@core
+bzip2
+open-vm-tools
+kernel-devel
+kernel-headers
+gcc
+make
+net-tools
+patch
+perl
+curl
+wget
+nfs-utils
+yum-autoupdate
+-ipw2100-firmware
+-ipw2200-firmware
+-ivtv-firmware
+%end
+
+%post --nochroot
+systemctl enable tmp.mount
+%end

--- a/templates/centos/7.2-tmpfs/x86_64/vars.json
+++ b/templates/centos/7.2-tmpfs/x86_64/vars.json
@@ -1,0 +1,14 @@
+{
+    "template_name"                         : "centos-7.2-tmpfs-x86_64",
+    "template_os"                           : "centos7_64Guest",
+    "beakerhost"                            : "centos7-64",
+    "version"                               : "0.0.1",
+    "iso_url"                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/CentOS-7-x86_64-DVD-1511.iso",
+    "iso_checksum"                          : "907e5755f824c5848b9c8efbb484f3cd945e93faa024bad6ba875226f9683b16",
+    "iso_checksum_type"                     : "sha256",
+    "vmware_base_vmx_data_memsize"          : "6144",
+    "vmware_base_vmx_data_numvcpus"         : "2",
+    "puppet_aio"                            : "http://builds.delivery.puppetlabs.net/puppet-agent/5.5.16/artifacts/el/7/puppet5/x86_64/puppet-agent-5.5.16-1.el7.x86_64.rpm",
+    "vmware_base_required_modules"          : "puppetlabs-stdlib saz-ssh puppetlabs-firewall",
+    "iso_name"                              : "CentOS-7-x86_64-DVD-1511.iso"
+}


### PR DESCRIPTION
This is my first time working in this repo.  I want to add a template to CI where tmpfs is enabled in centos 7.2.  This may become the default config, but we want to test this first, so here it is.  I've tested this manually by cloning a vm and running a command, now I want to get it into vmpooler.  The goal here is to reduce the I/O load in CI.  

Not sure if I should do this as 7.2-tmpfs or x86_64-tmpfs but I put it this way because the ks.cfg is in the common folder, and it's the ks.cfg config I need to fix.  

I looked at this documentation:
https://confluence.puppetlabs.com/display/SRE/Linux+Image+Packer+Generation

But did I miss anything further that would suggest how to test this?  I tried reverse engineering the Jenkins job but that was no fun.