### PR TITLE
Add entropy generating tools to fips image

### DIFF
--- a/templates/redhat/7.2-fips/common/files/ks.cfg
+++ b/templates/redhat/7.2-fips/common/files/ks.cfg
@@ -22,6 +22,9 @@ auth  --useshadow  --enablemd5
 firstboot --disabled
 reboot --eject
 
+repo --name=epel-release --baseurl=https://artifactory.delivery.puppetlabs.net/artifactory/rpm__remote_epel/7/x86_64/
+
+
 %packages --ignoremissing
 @core
 bzip2
@@ -34,6 +37,7 @@ net-tools
 patch
 perl
 rng-tools
+haveged
 curl
 wget
 nfs-utils

--- a/templates/redhat/7.2-fips/common/files/ks.cfg
+++ b/templates/redhat/7.2-fips/common/files/ks.cfg
@@ -33,6 +33,7 @@ make
 net-tools
 patch
 perl
+rng-tools
 curl
 wget
 nfs-utils

--- a/templates/redhat/7.2-fips/x86_64/vars.json
+++ b/templates/redhat/7.2-fips/x86_64/vars.json
@@ -2,7 +2,7 @@
     "template_name"                         : "redhat-fips-7.2-x86_64",
     "template_os"                           : "rhel7_64Guest",
     "beakerhost"                            : "redhatfips7-64",
-    "version"                               : "0.0.8",
+    "version"                               : "0.0.9",
     "iso_url"                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/rhel-server-7.2-x86_64-dvd.iso",
     "iso_checksum"                          : "03f3a0291634335f6995534d829bd21ffaa0d000004dfeb1b2fb81052d64a4d5",
     "iso_checksum_type"                     : "sha256",

--- a/templates/redhat/common/files/enable-fips.sh
+++ b/templates/redhat/common/files/enable-fips.sh
@@ -45,3 +45,13 @@ sed -i "/GRUB_DISABLE_RECOVERY/i \
 
 # Step 6: Generate /etc/grub2.cfg
 grub2-mkconfig -o /boot/grub2/grub.cfg 
+
+# Update rngd config to seed /dev/random from /dev/urandom - needed for testing, bad idea for production
+# Taken from https://developers.redhat.com/blog/2017/10/05/entropy-rhel-based-cloud-instances/
+systemctl enable rngd.service
+mkdir -p /etc/systemd/system/rngd.d/
+cat <<'DOWNWITHENTROPY' > /etc/systemd/system/rngd.d/customexec.conf
+[Service]
+ExecStart=
+ExecStart=/sbin/rngd -f -r /dev/urandom
+DOWNWITHENTROPY

--- a/templates/redhat/common/files/enable-fips.sh
+++ b/templates/redhat/common/files/enable-fips.sh
@@ -48,6 +48,7 @@ grub2-mkconfig -o /boot/grub2/grub.cfg
 
 # Update rngd config to seed /dev/random from /dev/urandom - needed for testing, bad idea for production
 # Taken from https://developers.redhat.com/blog/2017/10/05/entropy-rhel-based-cloud-instances/
+systemctl enable haveged.service
 systemctl enable rngd.service
 mkdir -p /etc/systemd/system/rngd.d/
 cat <<'DOWNWITHENTROPY' > /etc/systemd/system/rngd.d/customexec.conf


### PR DESCRIPTION
Our test pipelines for FIPS builds are rapidly exhausting the available pool of entropy.

this adds two tools to fips images help increase the available entropy pool - rng-tools and haveged

This is "fake" entropy and should not be relied on for production, but should be fine for our testing purposes