### PR TITLE
(QENG-7571) Update master platforms to 8GB RAM

### DIFF
--- a/templates/centos/6.9/x86_64/vars.json
+++ b/templates/centos/6.9/x86_64/vars.json
@@ -8,7 +8,7 @@
     "iso_checksum_type"                     : "sha256",
     "docker_base_image"                     : "centos:6.9",
     "virtualbox_base_template_os"           : "RedHat_64",
-    "vmware_vsphere_nocm_vmx_data_memsize"  : "6144",
+    "vmware_vsphere_nocm_vmx_data_memsize"  : "8168",
     "vmware_vsphere_nocm_vmx_data_numvcpus" : "2",
     "puppet_aio"                            : "http://yum.puppetlabs.com/el/6/PC1/x86_64/puppet-agent-1.10.10-1.el6.x86_64.rpm"
 }

--- a/templates/centos/7.6/x86_64/vars.json
+++ b/templates/centos/7.6/x86_64/vars.json
@@ -8,7 +8,7 @@
     "iso_checksum_type"                     : "sha256",
     "docker_base_image"                     : "centos:7.6.1810",
     "virtualbox_base_template_os"           : "RedHat_64",
-    "vmware_vsphere_nocm_vmx_data_memsize"  : "4096",
+    "vmware_vsphere_nocm_vmx_data_memsize"  : "8168",
     "vmware_vsphere_nocm_vmx_data_numvcpus" : "2",
     "puppet_aio"                            : "http://yum.puppetlabs.com/el/7/PC1/x86_64/puppet-agent-1.10.9-1.el7.x86_64.rpm"
 }

--- a/templates/centos/8.0/x86_64/vars.json
+++ b/templates/centos/8.0/x86_64/vars.json
@@ -6,7 +6,7 @@
     "iso_url"                                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/CentOS-8-x86_64-1905-dvd1.iso",
     "iso_checksum"                                          : "ea17ef71e0df3f6bf1d4bf1fc25bec1a76d1f211c115d39618fe688be34503e8",
     "iso_checksum_type"                                     : "sha256",
-    "vmware_base_vmx_data_memsize"                          : "6144",
+    "vmware_base_vmx_data_memsize"                          : "8168",
     "vmware_base_vmx_data_numvcpus"                         : "2",
     "puppet_aio"                                            : "http://builds.delivery.puppetlabs.net/puppet-agent/5.5.16/artifacts/el/8/puppet5/x86_64/puppet-agent-5.5.16-1.el8.x86_64.rpm",
     "inject_http_seed_in_boot_command"                      : "true",

--- a/templates/redhat/6.8/x86_64/vars.json
+++ b/templates/redhat/6.8/x86_64/vars.json
@@ -7,7 +7,7 @@
     "iso_checksum"                          : "d35fd1af20f6adef9b11b46c2534ae8b6e18de7754889e2b51808b436dff2804",
     "iso_checksum_type"                     : "sha256",
     "boot_command"                          : "<tab> <wait>text ks=hd:fd0:/ks.cfg<wait><enter>",
-    "vmware_vsphere_nocm_vmx_data_memsize"  : "6144",
+    "vmware_vsphere_nocm_vmx_data_memsize"  : "8168",
     "vmware_vsphere_nocm_vmx_data_numvcpus" : "2",
     "puppet_aio"                            : "http://yum.puppetlabs.com/el/6/PC1/x86_64/puppet-agent-1.10.9-1.el6.x86_64.rpm"
 }

--- a/templates/redhat/7.2-fips/x86_64/vars.json
+++ b/templates/redhat/7.2-fips/x86_64/vars.json
@@ -6,7 +6,7 @@
     "iso_url"                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/rhel-server-7.2-x86_64-dvd.iso",
     "iso_checksum"                          : "03f3a0291634335f6995534d829bd21ffaa0d000004dfeb1b2fb81052d64a4d5",
     "iso_checksum_type"                     : "sha256",
-    "vmware_base_vmx_data_memsize"          : "6144",
+    "vmware_base_vmx_data_memsize"          : "8168",
     "vmware_base_vmx_data_numvcpus"         : "2",
     "boot_command"                          : "<tab> <wait>inst.text inst.ks=hd:fd0:/ks.cfg<wait> fips=1<enter>",
     "puppet_aio"                            : "http://yum.puppetlabs.com/el/7/PC1/x86_64/puppet-agent-1.10.9-1.el7.x86_64.rpm",

--- a/templates/redhat/7.2/x86_64/vars.json
+++ b/templates/redhat/7.2/x86_64/vars.json
@@ -6,7 +6,7 @@
     "iso_url"                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/rhel-server-7.2-x86_64-dvd.iso",
     "iso_checksum"                          : "03f3a0291634335f6995534d829bd21ffaa0d000004dfeb1b2fb81052d64a4d5",
     "iso_checksum_type"                     : "sha256",
-    "vmware_vsphere_nocm_vmx_data_memsize"  : "6144",
+    "vmware_vsphere_nocm_vmx_data_memsize"  : "8168",
     "vmware_vsphere_nocm_vmx_data_numvcpus" : "2",
     "puppet_aio"                            : "http://yum.puppetlabs.com/el/7/PC1/x86_64/puppet-agent-1.10.9-1.el7.x86_64.rpm"
 }

--- a/templates/redhat/8.0/x86_64/vars.json
+++ b/templates/redhat/8.0/x86_64/vars.json
@@ -6,7 +6,7 @@
     "iso_url"                                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/rhel-8.0-x86_64-dvd.iso",
     "iso_checksum"                                          : "005d4f88fff6d63b0fc01a10822380ef52570edd8834321de7be63002cc6cc43",
     "iso_checksum_type"                                     : "sha256",
-    "vmware_base_vmx_data_memsize"                          : "6144",
+    "vmware_base_vmx_data_memsize"                          : "8168",
     "vmware_base_vmx_data_numvcpus"                         : "2",
     "puppet_aio"                                            : "http://yum.puppetlabs.com/el/7/PC1/x86_64/puppet-agent-1.10.9-1.el7.x86_64.rpm",
     "inject_http_seed_in_boot_command"                      : "true",

--- a/templates/sles/12.1/x86_64/vars.json
+++ b/templates/sles/12.1/x86_64/vars.json
@@ -6,7 +6,7 @@
     "iso_url"                               : "http://osmirror.delivery.puppetlabs.net/iso/SLE-12-SP1-Server-DVD-x86_64-GM-DVD1.iso",
     "iso_checksum"                          : "e1c0ba860f593d60c2c138a0cd35e2a3c65304b4c988b4c9f6051bff89871f62",
     "iso_checksum_type"                     : "sha256",
-    "vmware_vsphere_nocm_vmx_data_memsize"  : "6144",
+    "vmware_vsphere_nocm_vmx_data_memsize"  : "8168",
     "vmware_vsphere_nocm_vmx_data_numvcpus" : "2",
     "puppet_aio"                            : "http://yum.puppetlabs.com/sles/12/PC1/x86_64/puppet-agent-1.10.9-1.sles12.x86_64.rpm",
     "inject_http_seed_in_boot_command"      : "true"

--- a/templates/sles/15/x86_64/vars.json
+++ b/templates/sles/15/x86_64/vars.json
@@ -6,7 +6,7 @@
     "iso_url"                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/SLE-15-Installer-DVD-x86_64-GM-DVD1.iso",
     "iso_checksum"                          : "06bd8b78ef0ca6d5ff5000688727953e894805dc3de59060d74441f0fd0539ab",
     "iso_checksum_type"                     : "sha256",
-    "vmware_vsphere_nocm_vmx_data_memsize"  : "6144",
+    "vmware_vsphere_nocm_vmx_data_memsize"  : "8168",
     "vmware_vsphere_nocm_vmx_data_numvcpus" : "2",
     "puppet_aio"                            : "http://yum.puppetlabs.com/puppet5/sles/15/x86_64/puppet-agent-5.5.7-1.sles15.x86_64.rpm",
     "inject_http_seed_in_boot_command"      : "true"

--- a/templates/ubuntu/16.04/x86_64/vars.json
+++ b/templates/ubuntu/16.04/x86_64/vars.json
@@ -6,7 +6,7 @@
     "iso_url"                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/ubuntu-16.04-server-amd64.iso",
     "iso_checksum"                          : "b8b172cbdf04f5ff8adc8c2c1b4007ccf66f00fc6a324a6da6eba67de71746f6",
     "iso_checksum_type"                     : "sha256",
-    "vmware_vsphere_nocm_vmx_data_memsize"  : "6144",
+    "vmware_vsphere_nocm_vmx_data_memsize"  : "8168",
     "vmware_vsphere_nocm_vmx_data_numvcpus" : "2",
     "puppet_aio"                            : "http://apt.puppetlabs.com/pool/xenial/puppet5/p/puppet-agent/puppet-agent_5.3.2-1xenial_amd64.deb"
 }

--- a/templates/ubuntu/18.04/x86_64/vars.json
+++ b/templates/ubuntu/18.04/x86_64/vars.json
@@ -5,7 +5,7 @@
     "version"                               : "0.0.4",
     "iso_checksum"                          : "a7f5c7b0cdd0e9560d78f1e47660e066353bb8a79eb78d1fc3f4ea62a07e6cbc",
     "iso_checksum_type"                     : "sha256",
-    "vmware_vsphere_base_vmx_data_memsize"  : "6144",
+    "vmware_vsphere_base_vmx_data_memsize"  : "8168",
     "vmware_vsphere_base_vmx_data_numvcpus" : "2",
     "puppet_aio"                            : "http://apt.puppetlabs.com/pool/stretch/puppet5/p/puppet-agent/puppet-agent_5.3.2-1stretch_amd64.deb",
     "iso_name"                              : "ubuntu-18.04-server-amd64.iso"


### PR DESCRIPTION
This commit updates the packer templates for all the master platforms
updated as part of QENG-7571 to match the size of the *-8gb templates
created in that ticket.