### PR TITLE
(IMAGES-1174) January 2020 Windows Patch Tuesday Fixes

### DIFF
--- a/templates/win/10-1511/x86_64/files/platform-packages.ps1
+++ b/templates/win/10-1511/x86_64/files/platform-packages.ps1
@@ -6,11 +6,19 @@ Write-Output "Running Win-10 Package Customisationtemplates/windows-10/files/i38
 # Flag to remove Apps packages and other nuisances
 Touch-File "$PackerLogs\AppsPackageRemove.Required"
 
-if (-not (Test-Path "$PackerLogs\kb4035632.installed"))
+# This is a hack - but it works to get the windows update working - as in applying a recent CU as an update.
+if (-not (Test-Path "$PackerLogs\kb4524153.installed"))
 {
-  Write-Output "Installing Windows Update SSU kb4035632"
-  Install_Win_Patch -PatchUrl "http://download.windowsupdate.com/d/msdownload/update/software/crup/2017/08/windows10.0-kb4035632-x64_ea26f11d518e5e363fe9681b290a56a6afe15a81.msu"
-  Touch-File "$PackerLogs\kb4035632.installed"
+  Write-Output "Installing Windows Update SSU kb4524153"
+  Install_Win_Patch -PatchUrl "http://download.windowsupdate.com/d/msdownload/update/software/secu/2019/09/windows10.0-kb4524153-x64_135d6f3ec9e9bb3a5e74ef669837166a08d7767f.msu"
+  Touch-File "$PackerLogs\kb4524153.installed"
   Invoke-Reboot
 }
 
+if (-not (Test-Path "$PackerLogs\kb4523200.installed"))
+{
+  Write-Output "Installing Windows Update SSU kb4523200"
+  Install_Win_Patch -PatchUrl "http://download.windowsupdate.com/d/msdownload/update/software/secu/2019/11/windows10.0-kb4523200-x64_8b9d9f7930dee5a052981864b86025ac832c2b21.msu"
+  Touch-File "$PackerLogs\kb4523200.installed"
+  Invoke-Reboot
+}

--- a/templates/win/10-ent/i386/files/platform-packages.ps1
+++ b/templates/win/10-ent/i386/files/platform-packages.ps1
@@ -5,3 +5,11 @@ Write-Output "Running Win-10 Package Customisation"
 
 # Flag to remove Apps packages and other nuisances
 Touch-File "$PackerLogs\AppsPackageRemove.Required"
+
+if (-not (Test-Path "$PackerLogs\KB4528759.installed"))
+{
+  Write-Output "Installing Windows Update SSU KB4528759"
+  Install_Win_Patch -PatchUrl "http://download.windowsupdate.com/d/msdownload/update/software/secu/2020/01/windows10.0-kb4528759-x86_5ee4c5443a4d70dcf2399e1c2afe57f625e72b3d.msu"
+  Touch-File "$PackerLogs\KB4528759.installed"
+  Invoke-Reboot
+}

--- a/templates/win/10-ent/x86_64/files/platform-packages.ps1
+++ b/templates/win/10-ent/x86_64/files/platform-packages.ps1
@@ -5,3 +5,11 @@ Write-Output "Running Win-10 Package Customisationtemplates/windows-10/files/i38
 
 # Flag to remove Apps packages and other nuisances
 Touch-File "$PackerLogs\AppsPackageRemove.Required"
+
+if (-not (Test-Path "$PackerLogs\KB4528759.installed"))
+{
+  Write-Output "Installing Windows Update SSU KB4528759"
+  Install_Win_Patch -PatchUrl "http://download.windowsupdate.com/d/msdownload/update/software/secu/2020/01/windows10.0-kb4528759-x64_c2d6639977986b927d0b9f1acf0fb203c38fc8c8.msu"
+  Touch-File "$PackerLogs\KB4528759.installed"
+  Invoke-Reboot
+}

--- a/templates/win/10-pro/x86_64/files/platform-packages.ps1
+++ b/templates/win/10-pro/x86_64/files/platform-packages.ps1
@@ -5,3 +5,11 @@ Write-Output "Running Win-10 Package Customisationtemplates/windows-10/files/i38
 
 # Flag to remove Apps packages and other nuisances
 Touch-File "$PackerLogs\AppsPackageRemove.Required"
+
+if (-not (Test-Path "$PackerLogs\KB4528759.installed"))
+{
+  Write-Output "Installing Windows Update SSU KB4528759"
+  Install_Win_Patch -PatchUrl "http://download.windowsupdate.com/d/msdownload/update/software/secu/2020/01/windows10.0-kb4528759-x64_c2d6639977986b927d0b9f1acf0fb203c38fc8c8.msu"
+  Touch-File "$PackerLogs\KB4528759.installed"
+  Invoke-Reboot
+}

--- a/templates/win/2019-core/x86_64/files/platform-packages.ps1
+++ b/templates/win/2019-core/x86_64/files/platform-packages.ps1
@@ -3,4 +3,10 @@
 
 Write-Output "Running Win-2019 Package Customisation"
 
-# None Needed
+if (-not (Test-Path "$PackerLogs\KB4523204.installed"))
+{
+  Write-Output "Installing Windows Update SSU KB4523204"
+  Install_Win_Patch -PatchUrl "http://download.windowsupdate.com/c/msdownload/update/software/secu/2019/11/windows10.0-kb4523204-x64_57098d9954748b2d7d767f73f60493bc592ff286.msu"
+  Touch-File "$PackerLogs\KB4523204.installed"
+  Invoke-Reboot
+}

--- a/templates/win/2019/x86_64/files/platform-packages.ps1
+++ b/templates/win/2019/x86_64/files/platform-packages.ps1
@@ -3,4 +3,10 @@
 
 Write-Output "Running Win-2019 Package Customisation"
 
-# None Needed
+if (-not (Test-Path "$PackerLogs\KB4523204.installed"))
+{
+  Write-Output "Installing Windows Update SSU KB4523204"
+  Install_Win_Patch -PatchUrl "http://download.windowsupdate.com/c/msdownload/update/software/secu/2019/11/windows10.0-kb4523204-x64_57098d9954748b2d7d767f73f60493bc592ff286.msu"
+  Touch-File "$PackerLogs\KB4523204.installed"
+  Invoke-Reboot
+}

--- a/templates/win/common/puppet/forge-modules.txt
+++ b/templates/win/common/puppet/forge-modules.txt
@@ -4,6 +4,7 @@
 # Specific versions are supported now (e.g. we need to stick to Powershell 1.0.6)
 # TODO Support custom forge URLs
 
+puppetlabs-pwshlib
 puppetlabs-powershell
 puppetlabs-registry
 puppetlabs-stdlib

--- a/templates/win/common/puppet/windows_group_policy/manifests/init.pp
+++ b/templates/win/common/puppet/windows_group_policy/manifests/init.pp
@@ -1,2 +1,2 @@
-class win_group_policy {
+class windows_group_policy {
 }

--- a/templates/win/common/scripts/bootstrap/bootstrap-packerbuild.ps1
+++ b/templates/win/common/scripts/bootstrap/bootstrap-packerbuild.ps1
@@ -43,9 +43,10 @@ if (-not (Test-Path "$PackerLogs\BootstrapSchedTask.installed")) {
 # Enable WSUS - this is being put at the top of the script deliberately as a recycle of wuauserv is
 # required - this most reliable way to do this is with a reboot so we want to get this out the way first
 # to prevent windows update starting anything.
-# Windows-10/2016 LTSB seem to consistenly break on WSUS, so disable WSUS completely for these.
+# DO NOT USE WSUS for Windows-10 (changed from Jan 2020) as too many SSU issues with it.
+# So WSUS is primarily for servicing Windows 2012r2 and then mainly for slipstreaming purposes
 # Same seems to apply to win-2012 so disabling for this too.
-if ($WindowsVersion -like $WindowsServer2012 -or ($WindowsVersion -like $WindowsServer2016 -and $WindowsInstallationType -eq "Client" -and $WindowsReleaseID -eq "1607")) {
+if ($WindowsVersion -like $WindowsServer2012 -or $WindowsVersion -like $WindowsServer2016 ) {
   Write-Output "Bypassing WSUS - Go Direct to Microsoft for updates"
   Disable-WindowsAutoUpdate
 }

--- a/templates/win/common/scripts/provisioners/initiate-puppet-configure.ps1
+++ b/templates/win/common/scripts/provisioners/initiate-puppet-configure.ps1
@@ -16,10 +16,10 @@ Write-Output "Setting up for Puppet Configuration"
 
 Write-Output "Installing Puppet Agent..."
 if ("$ARCH" -eq "x86") {
-  $PuppetMSIUrl = "https://downloads.puppetlabs.com/windows/puppet-agent-x86-latest.msi"
+  $PuppetMSIUrl = "https://downloads.puppetlabs.com/windows/puppet6/puppet-agent-x86-latest.msi"
 }
 else {
-  $PuppetMSIUrl = "https://downloads.puppetlabs.com/windows/puppet-agent-x64-latest.msi"
+  $PuppetMSIUrl = "https://downloads.puppetlabs.com/windows/puppet6/puppet-agent-x64-latest.msi"
 }
 Download-File "$PuppetMSIUrl" $PackerDownloads\puppet-agent.msi
 


### PR DESCRIPTION
A set of fixes that were needed to deliver the January 2020 Patch Tuesday Windows Refresh:
1. Fix Puppet Agent link to use Puppet 6
2. Disable WSUS for Windows 10/2016/2019
3. Add Servicing Stack Updates (SSU) for certain builds to allow update process to run