### PR TITLE
(maint) Upgrade Packer to 1.5.1, fix template errors

### DIFF
--- a/templates/win/2012/x86_64/x86_64.vmware.slipstream.json
+++ b/templates/win/2012/x86_64/x86_64.vmware.slipstream.json
@@ -13,9 +13,7 @@
 
   "description": "Customised Win-2012 build to prepare slipstream ISO",
 
-  "_comment": [
-      "The boot_command is hacky because the UEFI boot file used requires the 'Press any key' to be done"
-  ],
+  "_comment": "The boot_command is hacky because the UEFI boot file used requires the 'Press any key' to be done",
   "builders": [
     {
       "name": "{{user `template_name`}}-{{user `provisioner`}}-{{user `template_config`}}",

--- a/templates/win/7/x86_64/x86_64.vmware.slipstream.json
+++ b/templates/win/7/x86_64/x86_64.vmware.slipstream.json
@@ -13,9 +13,7 @@
 
   "description": "Customised Win-7 build to prepare slipstream ISO",
 
-  "_comment": [
-      "The boot_command is hacky because the UEFI boot file used requires the 'Press any key' to be done"
-  ],
+  "_comment": "The boot_command is hacky because the UEFI boot file used requires the 'Press any key' to be done",
   "builders": [
     {
       "name": "{{user `template_name`}}-{{user `provisioner`}}-{{user `template_config`}}",

--- a/templates/win/common/google.appveyor.json
+++ b/templates/win/common/google.appveyor.json
@@ -22,9 +22,7 @@
 
   "description": "Builds a Windows Server appveyor image on Google Compute Engine",
 
-  "_comment": [
-      ""
-  ],
+  "_comment": "",
   "builders": [{
     "type"                : "googlecompute",
     "name"                : "{{user `template_name`}}-{{user `provisioner`}}-{{user `template_config`}}",

--- a/templates/win/common/virtualbox.slipstream.json
+++ b/templates/win/common/virtualbox.slipstream.json
@@ -24,9 +24,7 @@
 
   "description": "Generic build to prepare slipstream ISO for Win2012r2+ platforms using virtualbox",
 
-  "_comment": [
-      "The boot_command is hacky because the UEFI boot file used requires the 'Press any key' to be done"
-  ],
+  "_comment": "The boot_command is hacky because the UEFI boot file used requires the 'Press any key' to be done",
   "builders": [
     {
       "type"                    : "virtualbox-iso",

--- a/tests/test-setup.sh
+++ b/tests/test-setup.sh
@@ -10,7 +10,7 @@ if [ ! -f packer ] ; then
         arch="amd64"
     fi
     os=$(uname |tr '[:upper:]' '[:lower:]')
-    version="1.2.1"
+    version="1.5.1"
 
     filename="$project_name"_"$version"_"$os"_"$arch".zip
     download_link="$baseurl"/"$project_name"/"$version"/"$filename"


### PR DESCRIPTION
This commit upgrades the version of packer installed by the `Makefile`
to 1.5.1. After doing that upgrade, I found that several templates now
failed the tests because `_comment` fields were provided as arrays,
which is apparently unsupported now. I fixed up the arrays to be regular
strings and all of the templates appear to pass the tests now.