### PR TITLE
(MAINT) Use Packer vsphere-iso/clone plugins

### DIFF
--- a/templates/common/vmware.vcenter.json
+++ b/templates/common/vmware.vcenter.json
@@ -71,7 +71,7 @@
 
  "builders": [
     {
-      "type"                                         : "vsphere-23-iso",
+      "type"                                         : "vsphere-iso",
 
       "communicator"                                 : "{{user `communicator_protocol`}}",
       "ssh_username"                                 : "{{user `ssh_username`}}",

--- a/templates/common/vmware.vcenter.json
+++ b/templates/common/vmware.vcenter.json
@@ -26,6 +26,10 @@
       "packer_vcenter_net"                           : null,
       "packer_vcenter_insecure"                      : null,
 
+      "vmware_base_boot_wait"                        : "45s",
+      "shutdown_timeout"                             : "5m",
+
+
       "packer_sha"                                   : "{{user `packer_sha`}}",
 
       "convert_to_template"                          : "false",

--- a/templates/win/2008/x86_64/vmware.vcenter.cygwin.json
+++ b/templates/win/2008/x86_64/vmware.vcenter.cygwin.json
@@ -47,7 +47,7 @@
 
   "builders": [
     {
-      "type": "vsphere-23-iso",
+      "type": "vsphere-iso",
 
       "name"                   : "vcenter-iso",
       "vm_name"                : "{{user `template_name`}}-{{user `version`}}{{user `template_suffix`}}",

--- a/templates/win/2008/x86_64/vmware.vcenter.slipstream.json
+++ b/templates/win/2008/x86_64/vmware.vcenter.slipstream.json
@@ -46,7 +46,7 @@
   "description": "Specific build to prepare slipstream ISO for Windows 2008 platforms",
   "builders": [
     {
-      "type"              : "vsphere-23-iso",
+      "type"              : "vsphere-iso",
 
       "name"                   : "vsphere-slipstream",
       "vm_name"                : "{{user `template_name`}}-{{user `version`}}.slip{{user `template_suffix`}}",

--- a/templates/win/common/vmware.vcenter.bios.base.json
+++ b/templates/win/common/vmware.vcenter.bios.base.json
@@ -41,7 +41,7 @@
 
   "builders": [
     {
-      "type"                   : "vsphere-23-iso",
+      "type"                   : "vsphere-iso",
 
       "name"                   : "vcenter-base",
       "vm_name"                : "{{user `template_name`}}-{{user `version`}}{{user `template_suffix`}}",

--- a/templates/win/common/vmware.vcenter.cygwin.json
+++ b/templates/win/common/vmware.vcenter.cygwin.json
@@ -48,7 +48,7 @@
 
   "builders": [
     {
-      "type": "vsphere-23-iso",
+      "type": "vsphere-iso",
 
       "name"                   : "vcenter-iso",
       "vm_name"                : "{{user `template_name`}}-{{user `version`}}{{user `template_suffix`}}",

--- a/templates/win/common/vmware.vcenter.platform9.json
+++ b/templates/win/common/vmware.vcenter.platform9.json
@@ -34,7 +34,7 @@
 
   "builders": [
     {
-      "type"                   : "vsphere-23-clone",
+      "type"                   : "vsphere-clone",
 
       "name"                   : "vcenter-clone",
       "template"               : "{{user `base_template_name`}}",

--- a/templates/win/common/vmware.vcenter.slipstream.json
+++ b/templates/win/common/vmware.vcenter.slipstream.json
@@ -46,7 +46,7 @@
   "description": "Generic build to prepare slipstream ISO for Win2012r2+ platforms",
   "builders": [
     {
-      "type"              : "vsphere-23-iso",
+      "type"              : "vsphere-iso",
 
       "name"                   : "vsphere-slipstream",
       "vm_name"                : "{{user `template_name`}}-{{user `version`}}.slip{{user `template_suffix`}}",


### PR DESCRIPTION
Packer has not integrated the jetbrains vsphere-* plugins into its core
so switch over all vsphere builds to use this in favour of our local
versioned plugin.

This means the plugins can be removed from the builders.
One less thing to maintain - Yayyyyy