### PR TITLE
(PE-28666) Add centos-8-pdbpreload-x86_64

### DIFF
--- a/scripts/pdbpreload.sh
+++ b/scripts/pdbpreload.sh
@@ -1,0 +1,230 @@
+#!/bin/bash
+
+# These should be passed in via custom_provisioning_env
+#BRANCH='master'
+#VERSION='latest'
+#PLATFORM='el-8-x86_64'
+
+PE_TARBALL_URL="https://artifactory.delivery.puppetlabs.net/artifactory/generic_enterprise__local/${BRANCH}/ci-ready"
+EXT='.tar'
+BACKUP_DB_URL='http://slv-performance-results.s3-website-us-west-2.amazonaws.com/releases/Kearney/SLV-415/kearney_soak/master'
+BACKUP_TAR='db_backup.2019.05.29.tar.gz'
+TMP_DIR='/tmp'
+PUPPET_BIN='/opt/puppetlabs/bin'
+RUN_TUNE=1
+
+set -e
+
+# This isn't really used since we use %{::trusted.certname} below,
+# but sometimes we end up getting a spicy-proton name here due to
+# some sort of IP reuse thing, and it could cause weirdness.
+HOSTNAME=$(hostname -f)
+echo "### HOSTNAME = ${HOSTNAME} ###"
+
+df -h
+lsblk
+
+# Read LATEST file to grab the latest build from the directory
+if [ -z "${PE_VERSION}" ]; then
+  VERSION=$(curl ${PE_TARBALL_URL}/LATEST | tr -d '\n')
+else
+  VERSION=$PE_VERSION
+fi
+
+NAME="puppet-enterprise-${VERSION}-${PLATFORM}"
+TARBALL="${NAME}${EXT}"
+FULL_TARBALL_URL="${PE_TARBALL_URL}/${TARBALL}"
+
+echo "### Downloading PE tarball from ${FULL_TARBALL_URL} and saving to ${TMP_DIR} ###"
+wget -q -O ${TMP_DIR}/${TARBALL} ${FULL_TARBALL_URL} 
+echo '### Exploding tarball ###'
+tar -xf ${TMP_DIR}/${TARBALL} --directory ${TMP_DIR}
+echo '### Removing tarball ###'
+rm -f ${TMP_DIR}/${TARBALL}
+
+echo '### Setting up pe.conf ###'
+cat << EOF > ${TMP_DIR}/pe.conf
+{
+  "puppet_enterprise::puppet_master_host": "%{::trusted.certname}"
+  "console_admin_password": "puppetlabs",
+  "puppet_enterprise::master::recover_configuration::recover_configuration_interval": 0,
+  "pe_repo::enable_windows_bulk_pluginsync": true,
+  "meep_schema_version": "1.0",
+  "puppet_enterprise::profile::puppetdb::node_ttl": "0s",
+  "puppet_enterprise::profile::puppetdb::report_ttl": "0s",
+  "puppet_enterprise::puppetdb::database_ini::resource_events_ttl": "0s"
+}
+EOF
+
+echo '### Running installer ###'
+${TMP_DIR}/${NAME}/puppet-enterprise-installer -y -c ${TMP_DIR}/pe.conf
+
+# Puppet runs with changes exit 2
+set +e
+
+echo '### First puppet run post-install ###'
+${PUPPET_BIN}/puppet agent -t
+
+echo '### Second puppet run post-install ###'
+${PUPPET_BIN}/puppet agent -t
+
+if [ -n "${RUN_TUNE}" ]; then
+  echo '### Running puppet infra tune ###'
+  ${PUPPET_BIN}/puppet-infrastructure tune --local --pe_conf
+
+  echo '### Running puppet to apply changes ###'
+  ${PUPPET_BIN}/puppet agent -t
+fi
+
+set -e
+
+SERVICES=("pe-puppetdb" "pe-console-services" "pe-orchestration-services" "pe-puppetserver" "pe-nginx")
+
+if [ -n "${BACKUP_TAR}" ]; then
+  BACKUP_NAME=${BACKUP_TAR/.tar.gz/}
+  UPDATETIME_SQL="
+  DROP TABLE IF EXISTS max_report;
+
+  SELECT max(producer_timestamp)
+  INTO TEMPORARY TABLE max_report
+  FROM reports;
+
+  DROP TABLE IF EXISTS max_resource_event;
+
+  SELECT max(timestamp)
+  INTO TEMPORARY TABLE max_resource_event
+  FROM resource_events;
+
+  DROP TABLE IF EXISTS time_diff;
+
+  SELECT (DATE_PART('day', now() - (select max from max_report)) * 24 +
+          DATE_PART('hour', now() - (select max from max_report))) * 60 +
+          DATE_PART('minute', now() - (select max from max_report)) as minute_diff
+  INTO TEMPORARY TABLE time_diff;
+
+  DROP TABLE IF EXISTS resource_events_time_diff;
+
+  SELECT (DATE_PART('day', now() - (select max from max_resource_event)) * 24 +
+          DATE_PART('hour', now() - (select max from max_resource_event))) * 60 +
+          DATE_PART('minute', now() - (select max from max_resource_event)) as minute_diff
+  INTO TEMPORARY TABLE resource_events_time_diff;
+
+  UPDATE reports
+    SET producer_timestamp = producer_timestamp + ((select minute_diff from time_diff) * INTERVAL '1 minute'),
+    start_time = start_time + ((select minute_diff from time_diff) * INTERVAL '1 minute'),
+    end_time = end_time + ((select minute_diff from time_diff) * INTERVAL '1 minute'),
+    receive_time = receive_time + ((select minute_diff from time_diff) * INTERVAL '1 minute');
+
+  UPDATE resource_events
+    SET timestamp = timestamp + ((select minute_diff from resource_events_time_diff) * INTERVAL '1 minute');
+
+  UPDATE catalogs
+    SET producer_timestamp = producer_timestamp + ((select minute_diff from time_diff) * INTERVAL '1 minute'),
+    timestamp = timestamp + ((select minute_diff from time_diff) * INTERVAL '1 minute');
+
+  UPDATE factsets
+    SET producer_timestamp = producer_timestamp + ((select minute_diff from time_diff) * INTERVAL '1 minute'),
+    timestamp = timestamp + ((select minute_diff from time_diff) * INTERVAL '1 minute');
+
+  DROP TABLE IF EXISTS time_diff;
+  DROP TABLE IF EXISTS max_report;
+  DROP TABLE IF EXISTS resource_events_time_diff;
+  DROP TABLE IF EXISTS max_resource_event;
+  "
+
+  PG_SCRIPT="
+  log() {
+    message=\$1
+    ts=\"\$(date +'%Y-%m-%dT%H.%M.%S%z')\"
+    echo \"\${ts}: \${message}\"
+  }
+
+  log \"Restoring pe-puppetdb\"
+  /opt/puppetlabs/server/bin/pg_restore -U pe-postgres --if-exists -cCd template1 ${TMP_DIR}/${BACKUP_NAME}/pe-puppetdb.backup
+  log \"Updating pe-puppetdb times\"
+  /opt/puppetlabs/server/bin/psql -d pe-puppetdb -a -c \"${UPDATETIME_SQL}\"
+  "
+
+  echo '### Downloading backup database ###'
+  wget -q -O ${TMP_DIR}/${BACKUP_TAR} ${BACKUP_DB_URL}/${BACKUP_TAR} > /dev/null
+
+  echo '### Extracting backup from tar file ###'
+  tar -xf ${TMP_DIR}/${BACKUP_TAR} --directory ${TMP_DIR} --skip-old-files
+
+  echo '### Removing backup tarball ###'
+  rm -f ${TMP_DIR}/${BACKUP_TAR}
+
+  for SERVICE in "${SERVICES[@]}"; do
+    echo "### Stopping ${SERVICE} ###"
+    ${PUPPET_BIN}/puppet resource service ${SERVICE} ensure=stopped >/dev/null
+  done
+
+  echo "### Stopping puppet ###"
+  ${PUPPET_BIN}/puppet resource service puppet ensure=stopped >/dev/null
+
+  echo '### Restoring PuppetDB database ###'
+  echo '### Note: ignore errors about TOC and the public schema ###'
+  su - pe-postgres -s /bin/bash -c "${PG_SCRIPT}"
+
+  for SERVICE in "${SERVICES[@]}"; do
+    echo "### Restarting ${SERVICE} ###"
+    ${PUPPET_BIN}/puppet resource service ${SERVICE} ensure=running >/dev/null
+  done
+
+  # Can't rely on puppet resource, as it will exit without the service
+  # having actually finished starting up. PuppetDB will likely be
+  # doing a very long migraiton, so we need to actually check on it
+  # through systemctl.
+  echo '### Waiting for pe-puppetdb service to finish starting ###'
+  systemctl is-active --quiet pe-puppetdb
+  while [[ "$?" != "0" ]]; do
+    systemctl is-active --quiet pe-puppetdb
+    sleep 1
+  done
+
+  set +e
+  echo '### Running puppet to register master in pe-puppetdb ###'
+  ${PUPPET_BIN}/puppet agent -t
+
+  echo '### Running puppet to reconfigure master based on its presence in PuppetDB ###'
+  ${PUPPET_BIN}/puppet agent -t
+  set -e
+
+  echo '### Getting access token ###'
+  echo puppetlabs | ${PUPPET_BIN}/puppet access login --username admin --lifetime 5y
+
+  echo '### Finding old compiler nodes to purge ###'
+  # Because doing a puppet query and interpreting the results in bash is a nightmare,
+  # we just take the compilers we know to be in the SLV database.  The
+  # query is commented out here for future improvement purposes.
+  #${PUPPET_BIN}/puppet query "resources[certname] { type = 'Class' and title = 'Puppet_enterprise::Profile::Master' and certname != '${HOSTNAME}' }"
+  OLD_COMPILERS=("ip-10-227-1-160.amz-dev.puppet.net" "ip-10-227-2-122.amz-dev.puppet.net")
+  
+  for COMPILER in "${OLD_COMPILERS[@]}"; do
+    echo "### Purging ${COMPILER} ###"
+    ${PUPPET_BIN}/puppet node purge ${COMPILER}
+  done
+
+  set +e
+  echo '### Running puppet to register old compiler purge ###'
+  ${PUPPET_BIN}/puppet agent -t
+  set -e
+fi
+set +e
+echo '### Running puppet to clean up any remaining changes ###'
+${PUPPET_BIN}/puppet agent -t
+set -e
+
+# We should get no changes here
+echo '### Running puppet one more time just to be safe ###'
+${PUPPET_BIN}/puppet agent -t
+
+# The refresh_master_hostname plan requires user_data.conf to be present
+echo '### Running puppet infra recover_configuration to generate user_data.conf ###'
+${PUPPET_BIN}/puppet-infrastructure recover_configuration
+
+echo '### Creating refresh_hostname script ###'
+echo BOLT_DISABLE_ANALYTICS=true /opt/puppetlabs/installer/bin/bolt --boltdir=/opt/puppetlabs/installer/share/Boltdir plan run enterprise_tasks::testing::refresh_master_hostname > /root/refresh_hostname.sh
+chmod +x /root/refresh_hostname.sh
+
+echo '### Setup complete ###'

--- a/templates/centos/8.0-pdbpreload/common/files/ks.cfg
+++ b/templates/centos/8.0-pdbpreload/common/files/ks.cfg
@@ -1,0 +1,40 @@
+install
+cdrom
+lang en_US.UTF-8
+keyboard us
+network --bootproto=dhcp
+rootpw --iscrypted $1$v4K9E8Wj$gZIHJ5JtQL5ZGZXeqSSsd0
+firewall --enabled --service=ssh
+authconfig --enableshadow --passalgo=sha512
+selinux --disabled
+timezone UTC
+bootloader --location=mbr
+
+text
+skipx
+zerombr
+
+clearpart --all --initlabel
+autopart
+
+auth  --useshadow  --enablemd5
+firstboot --disabled
+reboot --eject
+
+%packages --ignoremissing
+@core
+bzip2
+kernel-devel
+kernel-headers
+gcc
+make
+net-tools
+patch
+perl
+curl
+wget
+nfs-utils
+-ipw2100-firmware
+-ipw2200-firmware
+-ivtv-firmware
+%end

--- a/templates/centos/8.0-pdbpreload/common/files/ks.cfg
+++ b/templates/centos/8.0-pdbpreload/common/files/ks.cfg
@@ -15,7 +15,13 @@ skipx
 zerombr
 
 clearpart --all --initlabel
-autopart
+# autopart only allows for 50GB on / and gives the rest to /home,
+# so we have to manually partition
+part pv.008002 --size=1 --grow --ondisk=sda
+volgroup VolGroup --pesize=4096 pv.008002
+logvol swap --name=vl_swap --vgname=VolGroup --size=8192 --maxsize=8192
+logvol /  --name=vl_root --vgname=VolGroup --fstype=ext4 --grow --size=1
+part /boot --fstype=ext4 --size=1024
 
 auth  --useshadow  --enablemd5
 firstboot --disabled

--- a/templates/centos/8.0-pdbpreload/x86_64/vars.json
+++ b/templates/centos/8.0-pdbpreload/x86_64/vars.json
@@ -2,7 +2,7 @@
     "template_name"                                         : "centos-8-pdbpreload-x86_64",
     "template_os"                                           : "centos8_64Guest",
     "beakerhost"                                            : "centos8-64",
-    "version"                                               : "0.0.1",
+    "version"                                               : "0.0.2",
     "iso_url"                                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/CentOS-8-x86_64-1905-dvd1.iso",
     "iso_checksum"                                          : "ea17ef71e0df3f6bf1d4bf1fc25bec1a76d1f211c115d39618fe688be34503e8",
     "iso_checksum_type"                                     : "sha256",

--- a/templates/centos/8.0-pdbpreload/x86_64/vars.json
+++ b/templates/centos/8.0-pdbpreload/x86_64/vars.json
@@ -1,0 +1,17 @@
+{
+    "template_name"                                         : "centos-8-pdbpreload-x86_64",
+    "template_os"                                           : "centos8_64Guest",
+    "beakerhost"                                            : "centos8-64",
+    "version"                                               : "0.0.1",
+    "iso_url"                                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/CentOS-8-x86_64-1905-dvd1.iso",
+    "iso_checksum"                                          : "ea17ef71e0df3f6bf1d4bf1fc25bec1a76d1f211c115d39618fe688be34503e8",
+    "iso_checksum_type"                                     : "sha256",
+    "vmware_base_vmx_data_memsize"                          : "8168",
+    "vmware_base_vmx_data_numvcpus"                         : "2",
+    "puppet_aio"                                            : "http://builds.delivery.puppetlabs.net/puppet-agent/5.5.16/artifacts/el/8/puppet5/x86_64/puppet-agent-5.5.16-1.el8.x86_64.rpm",
+    "inject_http_seed_in_boot_command"                      : "true",
+    "boot_command"                                          : "<tab> <wait>inst.text inst.ks=http://%s/ks.cfg<wait><enter>",
+    "iso_name"                                              : "CentOS-8-x86_64-1905-dvd1.iso",
+    "custom_provisioning_env"                               : "BRANCH=master,VERSION=latest,PLATFORM=el-8-x86_64",
+    "custom_provisioning_script"                            : "scripts/pdbpreload.sh"
+}

--- a/templates/centos/8.0/common/files/ks.cfg
+++ b/templates/centos/8.0/common/files/ks.cfg
@@ -15,7 +15,13 @@ skipx
 zerombr
 
 clearpart --all --initlabel
-autopart
+# autopart only allows for 50GB on / and gives the rest to /home,
+# so we have to manually partition
+part pv.008002 --size=1 --grow --ondisk=sda
+volgroup VolGroup --pesize=4096 pv.008002
+logvol swap --name=vl_swap --vgname=VolGroup --size=8192 --maxsize=8192
+logvol /  --name=vl_root --vgname=VolGroup --fstype=ext4 --grow --size=1
+part /boot --fstype=ext4 --size=1024
 
 auth  --useshadow  --enablemd5
 firstboot --disabled

--- a/templates/centos/8.0/x86_64/vars.json
+++ b/templates/centos/8.0/x86_64/vars.json
@@ -2,7 +2,7 @@
     "template_name"                                         : "centos-8-x86_64",
     "template_os"                                           : "centos8_64Guest",
     "beakerhost"                                            : "centos8-64",
-    "version"                                               : "0.0.1",
+    "version"                                               : "0.0.2",
     "iso_url"                                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/CentOS-8-x86_64-1905-dvd1.iso",
     "iso_checksum"                                          : "ea17ef71e0df3f6bf1d4bf1fc25bec1a76d1f211c115d39618fe688be34503e8",
     "iso_checksum_type"                                     : "sha256",

--- a/templates/common/vmware.vcenter.json
+++ b/templates/common/vmware.vcenter.json
@@ -72,7 +72,7 @@
       "tools_upload_flavor"                          : "linux",
       "project_root"                                 : "../../../..",
       "custom_provisioning_env"                      : "pe_ver=2018.1.4,pe_foo=bar",
-      "custom_provisioning_script"                   : "{{user `project_root`}}/scripts/noop.sh"
+      "custom_provisioning_script"                   : "scripts/noop.sh"
     },
 
  "builders": [
@@ -227,7 +227,7 @@
     {
       "type"                                       : "shell",
       "environment_vars"                           : "{{user `custom_provisioning_env`}}",
-      "scripts"                                    : "{{user `custom_provisioning_script`}}"
+      "scripts"                                    : "{{user `project_root`}}/{{user `custom_provisioning_script`}}"
     },
 
     {


### PR DESCRIPTION
## (DIO-409) Add project_root to custom script path
Because project_root seems not to be available within vars.json of a template, this sets the custom_provisioning_script to add the project_root to the beginning in the top level vmware.vcenter.json, so the user just has to specify 'scripts/myscript.sh' for custom_provisioning_script.

## (PE-28666) Add centos-8-pdbpreload-x86_64
This adds a new centos 8 template that includes setting up PE with the latest master build, and importing the SLV soak database. This will be used for HA testing.

## (PE-28666) Manually partition centos 8
Because autopart only allocates 50GB max to / and gives the rest to /home, and we need more than this for pdbpreload nodes (and the base centos 8 image so replicas can be provisioned), this changes to manually setting up the root, swap and boot partitions.
