### PR TITLE
(IMAGES-1231) November 2020 Windows Image Refresh

### DIFF
--- a/templates/win/10-ent/i386/vars.json
+++ b/templates/win/10-ent/i386/vars.json
@@ -8,15 +8,15 @@
     "windows_version"   : "Windows-10",
     "image_name"        : "Windows 10 Enterprise",
     "product_key"       : "NPPR9-FWDCX-D2C8J-H872K-2YT43",
-    "iso_name"          : "en_windows_10_business_editions_version_1909_updated_july_2020_x86_dvd_9588cbe4.iso",
+    "iso_name"          : "en_windows_10_business_editions_version_2004_updated_july_2020_x86_dvd_de266803.iso",
     "iso_checksum_type" : "md5",
-    "iso_checksum"      : "10fbbbc89bc3e13ca7ef6c08ac3fa788",
+    "iso_checksum"      : "aee22fc79d88b392484e7a3992749c1e",
     "boot_command"      : "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait>",
 
     "CurrentVersion"    : "6.3",
     "ProductName"       : "Windows 10 Enterprise",
     "EditionID"         : "Enterprise",
     "InstallationType"  : "Client",
-    "ReleaseID"         : "1909"
+    "ReleaseID"         : "2004"
 
 }

--- a/templates/win/10-ent/x86_64/vars.json
+++ b/templates/win/10-ent/x86_64/vars.json
@@ -7,16 +7,15 @@
     "vsphere_guest_os"  : "windows9_64Guest",
     "image_name"        : "Windows 10 Enterprise",
     "product_key"       : "NPPR9-FWDCX-D2C8J-H872K-2YT43",
-    "iso_name"          : "en_windows_10_business_editions_version_1909_updated_july_2020_x64_dvd_1ca84e91.iso",
+    "iso_name"          : "en_windows_10_business_editions_version_2004_updated_july_2020_x64_dvd_8e76feb1.iso",
     "iso_checksum_type" : "md5",
-    "iso_checksum"      : "d607abde461509a7d468b73808b6cb96",
+    "iso_checksum"      : "b0bf9b4055c0ba160101e26ffd6d4c77",
     "boot_command"      : "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait>",
 
-    "CurrentVersion"    : "6.1",
+    "CurrentVersion"    : "6.3",
     "ProductName"       : "Windows 10 Enterprise",
     "EditionID"         : "Enterprise",
     "InstallationType"  : "Client",
-    "ReleaseID"         : "1909"
-
+    "ReleaseID"         : "2004"
 }
 

--- a/templates/win/10-next/i386/vars.json
+++ b/templates/win/10-next/i386/vars.json
@@ -8,15 +8,15 @@
     "windows_version"   : "Windows-10",
     "image_name"        : "Windows 10 Enterprise",
     "product_key"       : "NPPR9-FWDCX-D2C8J-H872K-2YT43",
-    "iso_name"          : "en_windows_10_business_editions_version_2004_updated_july_2020_x86_dvd_de266803.iso",
+    "iso_name"          : "en_windows_10_business_editions_version_20h2_x86_dvd_fae4084e.iso",
     "iso_checksum_type" : "md5",
-    "iso_checksum"      : "aee22fc79d88b392484e7a3992749c1e",
-    "boot_command"      : "<nexter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait>",
+    "iso_checksum"      : "f46c69b7e8187f9f4a7665c4f466cfb0",
+    "boot_command"      : "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait>",
 
     "CurrentVersion"    : "6.3",
     "ProductName"       : "Windows 10 Enterprise",
     "EditionID"         : "Enterprise",
     "InstallationType"  : "Client",
-    "ReleaseID"         : "2004"
+    "ReleaseID"         : "2009"
 
 }

--- a/templates/win/10-next/x86_64/vars.json
+++ b/templates/win/10-next/x86_64/vars.json
@@ -7,14 +7,14 @@
     "windows_version"   : "Windows-10",
     "image_name"        : "Windows 10 Enterprise",
     "product_key"       : "NPPR9-FWDCX-D2C8J-H872K-2YT43",
-    "iso_name"          : "en_windows_10_business_editions_version_2004_updated_july_2020_x64_dvd_8e76feb1.iso",
+    "iso_name"          : "en_windows_10_business_editions_version_20h2_x64_dvd_4788fb7c.iso",
     "iso_checksum_type" : "md5",
-    "iso_checksum"      : "b0bf9b4055c0ba160101e26ffd6d4c77",
+    "iso_checksum"      : "436a66d36e590b4714b4d75878c8c22c",
     "boot_command"      : "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait>",
 
     "CurrentVersion"    : "6.3",
     "ProductName"       : "Windows 10 Enterprise",
     "EditionID"         : "Enterprise",
     "InstallationType"  : "Client",
-    "ReleaseID"         : "2004"
+    "ReleaseID"         : "2009"
 }

--- a/templates/win/10-pro/x86_64/vars.json
+++ b/templates/win/10-pro/x86_64/vars.json
@@ -7,15 +7,15 @@
     "windows_version"   : "Windows-10",
     "image_name"        : "Windows 10 Pro",
     "product_key"       : "W269N-WFGWX-YVC9B-4J6C9-T83GX",
-    "iso_name"          : "en_windows_10_business_editions_version_1909_updated_july_2020_x64_dvd_1ca84e91.iso",
+    "iso_name"          : "en_windows_10_business_editions_version_2004_updated_july_2020_x64_dvd_8e76feb1.iso",
     "iso_checksum_type" : "md5",
-    "iso_checksum"      : "d607abde461509a7d468b73808b6cb96",
+    "iso_checksum"      : "b0bf9b4055c0ba160101e26ffd6d4c77",
     "boot_command"      : "<enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait><enter><wait>",
 
     "CurrentVersion"    : "6.3",
     "ProductName"       : "Windows 10 Pro",
     "EditionID"         : "Professional",
     "InstallationType"  : "Client",
-    "ReleaseID"         : "1909"
+    "ReleaseID"         : "2004"
 
 }

--- a/templates/win/common/puppet/windows_template/manifests/apps/chrome.pp
+++ b/templates/win/common/puppet/windows_template/manifests/apps/chrome.pp
@@ -5,9 +5,9 @@ class windows_template::apps::chrome()
 
   # Select package name/install title depending on archictecture
   if ($::architecture == 'x86') {
-    $chromeinstaller = 'GoogleChromeStandaloneEnterprise.84.0.4147.125.msi'
+    $chromeinstaller = 'GoogleChromeStandaloneEnterprise.86.0.4240.198.msi'
   } else {
-    $chromeinstaller = 'GoogleChromeStandaloneEnterprise64.84.0.4147.125.msi'
+    $chromeinstaller = 'GoogleChromeStandaloneEnterprise64.86.0.4240.198.msi'
   }
 
   download_file { $chromeinstaller :

--- a/templates/win/common/puppet/windows_template/manifests/apps/gitforwin.pp
+++ b/templates/win/common/puppet/windows_template/manifests/apps/gitforwin.pp
@@ -5,16 +5,16 @@ class windows_template::apps::gitforwin()
 
   # Select package name/install title depending on archictecture
   if ($::architecture == 'x86') {
-    $gitforwininstaller = 'Git-2.28.0-32-bit.exe'
+    $gitforwininstaller = 'Git-2.29.2.2-32-bit.exe'
   } else {
-    $gitforwininstaller = 'Git-2.28.0-64-bit.exe'
+    $gitforwininstaller = 'Git-2.29.2.2-64-bit.exe'
   }
 
   download_file { $gitforwininstaller :
     url                   => "${gitforwindownloadurl}/${gitforwininstaller}",
     destination_directory => $::packer_downloads
   }
-  -> package { 'Git version 2.28.0': # This version has strange string.
+  -> package { 'Git version 2.29.2.2': # This version has strange string.
     ensure          => installed,
     source          => "${::packer_downloads}\\${gitforwininstaller}",
     install_options => ['/VERYSILENT', "/LOADINF=${::packer_config}\\gitforwin.inf"]

--- a/templates/win/common/puppet/windows_template/manifests/apps/notepadplusplus.pp
+++ b/templates/win/common/puppet/windows_template/manifests/apps/notepadplusplus.pp
@@ -7,10 +7,10 @@ class windows_template::apps::notepadplusplus()
 
   # Select package name/install title depending on archictecture
   if ($::architecture == 'x86') {
-    $notepadppinstaller = 'npp.7.8.9.Installer.exe'
+    $notepadppinstaller = 'npp.7.9.1.Installer.exe'
     $notepadpparchtype = '(32-bit x86)'
   } else {
-    $notepadppinstaller = 'npp.7.8.9.Installer.x64.exe'
+    $notepadppinstaller = 'npp.7.9.1.Installer.x64.exe'
     $notepadpparchtype = '(64-bit x64)'
   }
 

--- a/templates/win/common/puppet/windows_template/manifests/apps/powershell7.pp
+++ b/templates/win/common/puppet/windows_template/manifests/apps/powershell7.pp
@@ -6,10 +6,10 @@ class windows_template::apps::powershell7()
 
   # Select package name/install title depending on archictecture
   if ($::architecture == 'x86') {
-    $ps7coreinstaller = 'PowerShell-7.0.3-win-x86.msi'
+    $ps7coreinstaller = 'PowerShell-7.1.0-win-x86.msi'
     $ps7corearchtype = 'x86'
   } else {
-    $ps7coreinstaller = 'PowerShell-7.0.3-win-x64.msi'
+    $ps7coreinstaller = 'PowerShell-7.1.0-win-x64.msi'
     $ps7corearchtype = 'x64'
   }
 

--- a/templates/win/common/scripts/acceptance/puppet/winpackages.Tests.ps1
+++ b/templates/win/common/scripts/acceptance/puppet/winpackages.Tests.ps1
@@ -7,9 +7,6 @@
 
 . C:\Packer\Scripts\windows-env.ps1
 
-# Google program directory is a bit strange.
-$GoogleProgDir = (${env:ProgramFiles(x86)}, ${env:ProgramFiles} -ne $null)[0]
-
 describe 'Windows Packages are installed' {
 
     it 'Git for Windows' {
@@ -32,6 +29,6 @@ describe -Tag 'DesktopOnly' 'Windows Desktop Packages are installed' {
     }
 
     it 'Chrome should be installed' {
-        "$GoogleProgDir\Google\Chrome\Application\chrome.exe" | Should Exist
+        "$ENV:PROGRAMFILES\Google\Chrome\Application\chrome.exe" | Should Exist
     }
 }

--- a/templates/win/common/scripts/acceptance/windows-update/WindowsUpdate.Tests.ps1
+++ b/templates/win/common/scripts/acceptance/windows-update/WindowsUpdate.Tests.ps1
@@ -11,8 +11,14 @@ Import-PsWindowsUpdateModule
 
 # Pull information from Windows Update operations.
 # Updates in last 12 hours (for very long update process)
-$WUHistory = get-wuhistory -Erroraction SilentlyContinue | Where-Object { [int]($(Get-Date) - $_.Date).TotalHours -le 12 }
-
+# Windows 10 etc needs the -Last 2 parameter to avoid a hang that has appeared since
+# Build 2004 was released.
+if ($WindowsVersion -Like $WindowsServer2016) {
+    $WUHistory = get-wuhistory -Erroraction SilentlyContinue -Last 2 | Where-Object { [int]($(Get-Date) - $_.Date).TotalHours -le 12 }
+}
+else {
+    $WUHistory = get-wuhistory -Erroraction SilentlyContinue | Where-Object { [int]($(Get-Date) - $_.Date).TotalHours -le 12 }
+}
 # Pending Update List.
 $WUUpdateList = get-WULIST -UpdateType Software -Erroraction SilentlyContinue -NotKBArticleID 'KB2267602'
 # Following to handle Win-2008r2/Win-7 which returns $null if no updates.

--- a/templates/win/common/scripts/common/puppet-configure.ps1
+++ b/templates/win/common/scripts/common/puppet-configure.ps1
@@ -36,13 +36,7 @@ $ENV:FACTER_windir               = "$ENV:WINDIR"
 $ENV:FACTER_administrator_sid     =  $WindowsAdminSID
 $ENV:FACTER_administrator_grp_sid = "S-1-5-32-544"
 $ENV:FACTER_psversionmajor        = $PSVersionTable.PSVersion.Major
-
-# Chrome root needs arch detection as under x86 on 64 bit boxen
-if ("$ARCH" -eq "x86") {
-  $ENV:FACTER_chrome_root        = "$ENV:ProgramFiles\Google\Chrome"
-} else {
-  $ENV:FACTER_chrome_root        = "$ENV:ProgramFiles `(x86`)\Google\Chrome"
-}
+$ENV:FACTER_chrome_root           = "$ENV:ProgramFiles\Google\Chrome"
 
 # Puppet run loop - use the Manifest in the Config Directory and run Puppet as many times up
 # to MaxAttempts until no further resources are modified.

--- a/templates/win/common/scripts/common/test-packerbuild.ps1
+++ b/templates/win/common/scripts/common/test-packerbuild.ps1
@@ -74,9 +74,13 @@ if (Test-Path "C:\Packer\Logs\$TestPhase.log") {
 # support an OS that's EOL at end of year.
 
 If ( $WindowsServerCore -or ($WindowsVersion -Like $WindowsServer2008)) {
+    Write-Output "========== Pester: $TestPhase START (DesktopOnly) ========"
     $PesterResults = Invoke-Pester -Script "$PackerAcceptance\$TestPhase\" -PassThru -ExcludeTag 'DesktopOnly'
+    Write-Output "========== Pester: $TestPhase END (DesktopOnly) ========"
 } else {
+    Write-Output "========== Pester: $TestPhase START (CoreOnly) ========"
     $PesterResults = Invoke-Pester -Script "$PackerAcceptance\$TestPhase\" -PassThru -ExcludeTag 'CoreOnly'
+    Write-Output "========== Pester: $TestPhase END (CoreOnly) ========"
 }
 
 Write-Output "========== Completed Packer Test Phase: $TestPhase ========"

--- a/templates/win/common/scripts/common/windows-env.ps1
+++ b/templates/win/common/scripts/common/windows-env.ps1
@@ -293,7 +293,8 @@ Function ForceFullyDelete-Path {
           Write-Output "Removing $Path" >> $LogFile 2>&1
           Takeown /d "$AnswerPromptYes" /R /f $Path >> $LogFile 2>&1
           Icacls $Path /grant:r "*${WindowsAdminSID}:(OI)(CI)F" /t /c >> $LogFile 2>&1
-          Remove-Item $Path -Recurse -Force >> $LogFile 2>&1
+          # Ignore any Packer Environment Files to avoid throwing errors in the log.
+          Remove-Item $Path -Exclude packer-ps-*.* -Recurse -Force >> $LogFile 2>&1
         }
       }
       catch {

--- a/templates/win/common/scripts/provisioners/cleanup-host.ps1
+++ b/templates/win/common/scripts/provisioners/cleanup-host.ps1
@@ -68,4 +68,3 @@ Write-Output "Reclaimed $SpaceReclaimed GB"
 
 # Sleep to let console log catch up (and get captured by packer)
 Start-Sleep -Seconds 20
-#End

--- a/templates/win/common/vars.json
+++ b/templates/win/common/vars.json
@@ -1,5 +1,5 @@
 {
-  "version"             : "20200813",
+  "version"             : "20201113",
 
   "headless"            : "true",
 

--- a/templates/win/common/vmpooler_deploy_record.sh
+++ b/templates/win/common/vmpooler_deploy_record.sh
@@ -8,6 +8,150 @@
 # Keeping a log open on vmpooler is also a really good idea.
 
 
+# November 2020 vmpooler updates
+
+# Windows 10 Odd templates
+platform-ci-utils imaging-update-vmpooler-pool-templates --instance=ci \
+    --pools=win-10-pro-x86_64:templates/netapp/acceptance2/win-10-pro-x86_64-20201113 \
+            win-10-1511-x86_64:templates/netapp/acceptance2/win-10-1511-x86_64-20201113 \
+            win-10-1607-x86_64:templates/netapp/acceptance2/win-10-1607-x86_64-20201113 \
+            win-10-1809-x86_64:templates/netapp/acceptance2/win-10-1809-x86_64-20201113
+#
+platform-ci-utils imaging-update-vmpooler-pool-templates --instance=ci \
+    --pools=win-10-pro-x86_64-pixa4:templates/netapp/acceptance4/win-10-pro-x86_64-20201113 \
+            win-10-1511-x86_64-pixa4:templates/netapp/acceptance4/win-10-1511-x86_64-20201113 \
+            win-10-1607-x86_64-pixa4:templates/netapp/acceptance4/win-10-1607-x86_64-20201113 \
+            win-10-1809-x86_64-pixa4:templates/netapp/acceptance4/win-10-1809-x86_64-20201113
+
+# Windows 10 Main Ent 
+platform-ci-utils imaging-update-vmpooler-pool-templates --instance=ci \
+    --pools=win-10-ent-i386:templates/netapp/acceptance2/win-10-ent-i386-20201113 \
+            win-10-ent-x86_64:templates/netapp/acceptance2/win-10-ent-x86_64-20201113
+#
+platform-ci-utils imaging-update-vmpooler-pool-templates --instance=ci \
+    --pools=win-10-ent-i386-pixa4:templates/netapp/acceptance4/win-10-ent-i386-20201113 \
+            win-10-ent-x86_64-pixa4:templates/netapp/acceptance4/win-10-ent-x86_64-20201113
+
+# Windows 10 Next Release
+platform-ci-utils imaging-update-vmpooler-pool-templates --instance=ci \
+    --pools=win-10-next-i386:templates/netapp/acceptance2/win-10-next-i386-20201113 \
+            win-10-next-x86_64:templates/netapp/acceptance2/win-10-next-x86_64-20201113
+#
+platform-ci-utils imaging-update-vmpooler-pool-templates --instance=ci \
+    --pools=win-10-next-i386-pixa4:templates/netapp/acceptance4/win-10-next-i386-20201113 \
+            win-10-next-x86_64-pixa4:templates/netapp/acceptance4/win-10-next-x86_64-20201113
+
+# Windows 81
+platform-ci-utils imaging-update-vmpooler-pool-templates --instance=ci \
+            --pools=win-81-x86_64:templates/netapp/acceptance2/win-81-x86_64-20201113
+#
+platform-ci-utils imaging-update-vmpooler-pool-templates --instance=ci \
+            --pools=win-81-x86_64-pixa4:templates/netapp/acceptance4/win-81-x86_64-20201113
+
+
+# Windows 2012r2 Primary 
+platform-ci-utils imaging-update-vmpooler-pool-templates --instance=ci \
+    --pools=win-2012r2-x86_64:templates/netapp/acceptance2/win-2012r2-x86_64-20201113
+#
+platform-ci-utils imaging-update-vmpooler-pool-templates --instance=ci \
+    --pools=win-2012r2-x86_64-pixa4:templates/netapp/acceptance4/win-2012r2-x86_64-20201113
+
+# Windows 2012/2012r2 remainder platforms
+platform-ci-utils imaging-update-vmpooler-pool-templates --instance=ci \
+    --pools=win-2012-x86_64:templates/netapp/acceptance2/win-2012-x86_64-20201113 \
+            win-2012r2-core-x86_64:templates/netapp/acceptance2/win-2012r2-core-x86_64-20201113 \
+            win-2012r2-fips-x86_64:templates/netapp/acceptance2/win-2012r2-fips-x86_64-20201113 \
+            win-2012r2-wmf5-x86_64:templates/netapp/acceptance2/win-2012r2-wmf5-x86_64-20201113
+#
+platform-ci-utils imaging-update-vmpooler-pool-templates --instance=ci \
+    --pools=win-2012-x86_64-pixa4:templates/netapp/acceptance4/win-2012-x86_64-20201113 \
+            win-2012r2-core-x86_64-pixa4:templates/netapp/acceptance4/win-2012r2-core-x86_64-20201113 \
+            win-2012r2-fips-x86_64-pixa4:templates/netapp/acceptance4/win-2012r2-fips-x86_64-20201113 \
+            win-2012r2-wmf5-x86_64-pixa4:templates/netapp/acceptance4/win-2012r2-wmf5-x86_64-20201113
+#....
+# Windows 2016
+platform-ci-utils imaging-update-vmpooler-pool-templates --instance=ci \
+    --pools=win-2016-core-x86_64:templates/netapp/acceptance2/win-2016-core-x86_64-20201113 \
+            win-2016-x86_64:templates/netapp/acceptance2/win-2016-x86_64-20201113 \
+            win-2016-x86_64-ipv6:templates/netapp/acceptance2/win-2016-x86_64-20201113-ipv6
+
+platform-ci-utils imaging-update-vmpooler-pool-templates --instance=ci \
+    --pools=win-2016-core-x86_64-pixa4:templates/netapp/acceptance4/win-2016-core-x86_64-20201113 \
+            win-2016-x86_64-pixa4:templates/netapp/acceptance4/win-2016-x86_64-20201113 \
+            win-2016-x86_64-ipv6-pixa4:templates/netapp/acceptance4/win-2016-x86_64-20201113-ipv6
+
+# Windows 2019
+platform-ci-utils imaging-update-vmpooler-pool-templates --instance=ci \
+    --pools=win-2019-core-x86_64:templates/netapp/acceptance2/win-2019-core-x86_64-20201113 \
+            win-2019-x86_64:templates/netapp/acceptance2/win-2019-x86_64-20201113 \
+            win-2019-ja-x86_64:templates/netapp/acceptance2/win-2019-ja-x86_64-20201113 \
+            win-2019-fr-x86_64:templates/netapp/acceptance2/win-2019-fr-x86_64-20201113
+
+platform-ci-utils imaging-update-vmpooler-pool-templates --instance=ci \
+    --pools=win-2019-core-x86_64-pixa4:templates/netapp/acceptance4/win-2019-core-x86_64-20201113 \
+            win-2019-x86_64-pixa4:templates/netapp/acceptance4/win-2019-x86_64-20201113 \
+            win-2019-ja-x86_64-pixa4:templates/netapp/acceptance4/win-2019-ja-x86_64-20201113 \
+            win-2019-fr-x86_64-pixa4:templates/netapp/acceptance4/win-2019-fr-x86_64-20201113
+
+platform-ci-utils imaging-update-vmpooler-pool-templates --instance=ci \
+    --pools=win-2019-wslssh-x86_64-pixa4:templates/netapp/acceptance4/win-2019-wslssh-x86_64-20200813
+
+#Done
+
+# PR Update command:
+
+platform-ci-utils imaging-update-pools-in-pl-modules \
+    --pools=win-10-pro-x86_64:templates/win-10-pro-x86_64-20201113 \
+            win-10-1511-x86_64:templates/win-10-1511-x86_64-20201113 \
+            win-10-1607-x86_64:templates/win-10-1607-x86_64-20201113 \
+            win-10-1809-x86_64:templates/win-10-1809-x86_64-20201113 \
+            win-10-pro-x86_64-pixa4:templates/acceptance4/win-10-pro-x86_64-20201113 \
+            win-10-1511-x86_64-pixa4:templates/acceptance4/win-10-1511-x86_64-20201113 \
+            win-10-1607-x86_64-pixa4:templates/acceptance4/win-10-1607-x86_64-20201113 \
+            win-10-1809-x86_64-pixa4:templates/acceptance4/win-10-1809-x86_64-20201113 \
+            win-10-ent-i386:templates/win-10-ent-i386-20201113 \
+            win-10-ent-x86_64:templates/win-10-ent-x86_64-20201113 \
+            win-10-ent-i386-pixa4:templates/acceptance4/win-10-ent-i386-20201113 \
+            win-10-ent-x86_64-pixa4:templates/acceptance4/win-10-ent-x86_64-20201113 \
+            win-10-next-i386:templates/win-10-next-i386-20201113 \
+            win-10-next-x86_64:templates/win-10-next-x86_64-20201113 \
+            win-10-next-i386-pixa4:templates/acceptance4/win-10-next-i386-20201113 \
+            win-10-next-x86_64-pixa4:templates/acceptance4/win-10-next-x86_64-20201113 \
+            win-81-x86_64:templates/win-81-x86_64-20201113 \
+            win-81-x86_64-pixa4:templates/acceptance4/win-81-x86_64-20201113 \
+            win-2012r2-x86_64:templates/win-2012r2-x86_64-20201113 \
+            win-2012r2-x86_64-pixa4:templates/acceptance4/win-2012r2-x86_64-20201113 \
+            win-2012-x86_64:templates/win-2012-x86_64-20201113 \
+            win-2012r2-core-x86_64:templates/win-2012r2-core-x86_64-20201113 \
+            win-2012r2-fips-x86_64:templates/win-2012r2-fips-x86_64-20201113 \
+            win-2012r2-wmf5-x86_64:templates/win-2012r2-wmf5-x86_64-20201113 \
+            win-2012-x86_64-pixa4:templates/acceptance4/win-2012-x86_64-20201113 \
+            win-2012r2-core-x86_64-pixa4:templates/acceptance4/win-2012r2-core-x86_64-20201113 \
+            win-2012r2-fips-x86_64-pixa4:templates/acceptance4/win-2012r2-fips-x86_64-20201113 \
+            win-2012r2-wmf5-x86_64-pixa4:templates/acceptance4/win-2012r2-wmf5-x86_64-20201113 \
+            win-2016-core-x86_64:templates/win-2016-core-x86_64-20201113 \
+            win-2016-x86_64:templates/win-2016-x86_64-20201113 \
+            win-2016-x86_64-ipv6:templates/win-2016-x86_64-20201113-ipv6 \
+            win-2016-core-x86_64-pixa4:templates/acceptance4/win-2016-core-x86_64-20201113 \
+            win-2016-x86_64-pixa4:templates/acceptance4/win-2016-x86_64-20201113 \
+            win-2016-x86_64-ipv6-pixa4:templates/acceptance4/win-2016-x86_64-20201113-ipv6 \
+            win-2019-core-x86_64:templates/win-2019-core-x86_64-20201113 \
+            win-2019-x86_64:templates/win-2019-x86_64-20201113 \
+            win-2019-ja-x86_64:templates/win-2019-ja-x86_64-20201113 \
+            win-2019-fr-x86_64:templates/win-2019-fr-x86_64-20201113 \
+            win-2019-core-x86_64-pixa4:templates/acceptance4/win-2019-core-x86_64-20201113 \
+            win-2019-x86_64-pixa4:templates/acceptance4/win-2019-x86_64-20201113 \
+            win-2019-ja-x86_64-pixa4:templates/acceptance4/win-2019-ja-x86_64-20201113 \
+            win-2019-fr-x86_64-pixa4:templates/acceptance4/win-2019-fr-x86_64-20201113
+
+
+
+
+
+
+
+# ######################################################################################
+
 # August 2020 vmpooler updates
 
 # Windows 10 Odd templates
@@ -107,38 +251,38 @@ platform-ci-utils imaging-update-pools-in-pl-modules \
             win-10-1511-x86_64-pixa4:templates/acceptance4/win-10-1511-x86_64-20200813 \
             win-10-1607-x86_64-pixa4:templates/acceptance4/win-10-1607-x86_64-20200813 \
             win-10-1809-x86_64-pixa4:templates/acceptance4/win-10-1809-x86_64-20200813 \
-			win-10-ent-i386:templates/win-10-ent-i386-20200813 \
+            win-10-ent-i386:templates/win-10-ent-i386-20200813 \
             win-10-ent-x86_64:templates/win-10-ent-x86_64-20200813 \
-			win-10-ent-i386-pixa4:templates/acceptance4/win-10-ent-i386-20200813 \
+            win-10-ent-i386-pixa4:templates/acceptance4/win-10-ent-i386-20200813 \
             win-10-ent-x86_64-pixa4:templates/acceptance4/win-10-ent-x86_64-20200813 \
-			win-10-next-i386:templates/win-10-next-i386-20200813 \
+            win-10-next-i386:templates/win-10-next-i386-20200813 \
             win-10-next-x86_64:templates/win-10-next-x86_64-20200813 \
-			win-10-next-i386-pixa4:templates/acceptance4/win-10-next-i386-20200813 \
+            win-10-next-i386-pixa4:templates/acceptance4/win-10-next-i386-20200813 \
             win-10-next-x86_64-pixa4:templates/acceptance4/win-10-next-x86_64-20200813 \
-			win-81-x86_64:templates/win-81-x86_64-20200813 \
-			win-81-x86_64-pixa4:templates/acceptance4/win-81-x86_64-20200813 \
-			win-2012r2-x86_64:templates/win-2012r2-x86_64-20200813 \
-			win-2012r2-x86_64-pixa4:templates/acceptance4/win-2012r2-x86_64-20200813 \
-			win-2012-x86_64:templates/win-2012-x86_64-20200813 \
+            win-81-x86_64:templates/win-81-x86_64-20200813 \
+            win-81-x86_64-pixa4:templates/acceptance4/win-81-x86_64-20200813 \
+            win-2012r2-x86_64:templates/win-2012r2-x86_64-20200813 \
+            win-2012r2-x86_64-pixa4:templates/acceptance4/win-2012r2-x86_64-20200813 \
+            win-2012-x86_64:templates/win-2012-x86_64-20200813 \
             win-2012r2-core-x86_64:templates/win-2012r2-core-x86_64-20200813 \
             win-2012r2-fips-x86_64:templates/win-2012r2-fips-x86_64-20200813 \
             win-2012r2-wmf5-x86_64:templates/win-2012r2-wmf5-x86_64-20200813 \
-			win-2012-x86_64-pixa4:templates/acceptance4/win-2012-x86_64-20200813 \
+            win-2012-x86_64-pixa4:templates/acceptance4/win-2012-x86_64-20200813 \
             win-2012r2-core-x86_64-pixa4:templates/acceptance4/win-2012r2-core-x86_64-20200813 \
             win-2012r2-fips-x86_64-pixa4:templates/acceptance4/win-2012r2-fips-x86_64-20200813 \
             win-2012r2-wmf5-x86_64-pixa4:templates/acceptance4/win-2012r2-wmf5-x86_64-20200813 \
-			win-2016-core-x86_64:templates/win-2016-core-x86_64-20200813 \
+            win-2016-core-x86_64:templates/win-2016-core-x86_64-20200813 \
             win-2016-x86_64:templates/win-2016-x86_64-20200813 \
             win-2016-x86_64-ipv6:templates/win-2016-x86_64-20200813-ipv6 \
-			win-2016-core-x86_64-pixa4:templates/acceptance4/win-2016-core-x86_64-20200813 \
+            win-2016-core-x86_64-pixa4:templates/acceptance4/win-2016-core-x86_64-20200813 \
             win-2016-x86_64-pixa4:templates/acceptance4/win-2016-x86_64-20200813 \
             win-2016-x86_64-ipv6-pixa4:templates/acceptance4/win-2016-x86_64-20200813-ipv6 \
-			win-2019-core-x86_64:templates/win-2019-core-x86_64-20200813 \
+            win-2019-core-x86_64:templates/win-2019-core-x86_64-20200813 \
             win-2019-x86_64:templates/win-2019-x86_64-20200813 \
             win-2019-wslssh-x86_64:templates/win-2019-wslssh-x86_64-20200813 \
             win-2019-ja-x86_64:templates/win-2019-ja-x86_64-20200813 \
             win-2019-fr-x86_64:templates/win-2019-fr-x86_64-20200813 \
-			win-2019-core-x86_64-pixa4:templates/acceptance4/win-2019-core-x86_64-20200813 \
+            win-2019-core-x86_64-pixa4:templates/acceptance4/win-2019-core-x86_64-20200813 \
             win-2019-x86_64-pixa4:templates/acceptance4/win-2019-x86_64-20200813 \
             win-2019-wslssh-x86_64-pixa4:templates/acceptance4/win-2019-wslssh-x86_64-20200813 \
             win-2019-ja-x86_64-pixa4:templates/acceptance4/win-2019-ja-x86_64-20200813 \

--- a/templates/win/common/vmware.vcenter.bios.base.json
+++ b/templates/win/common/vmware.vcenter.bios.base.json
@@ -92,7 +92,7 @@
       ],
       "iso_paths": [
         "{{user `iso_disk`}}{{user `iso_name`}}",
-        "{{user `iso_disk`}}windows-11.1.0.iso"
+        "{{user `iso_disk`}}windows-11.2.0.iso"
       ],
 
       "communicator"      : "winrm",

--- a/templates/win/common/vmware.vcenter.cygwin.json
+++ b/templates/win/common/vmware.vcenter.cygwin.json
@@ -100,7 +100,7 @@
       ],
       "iso_paths": [
         "{{user `iso_disk`}}{{user `iso_name`}}",
-        "{{user `iso_disk`}}windows-11.1.0.iso"
+        "{{user `iso_disk`}}windows-11.2.0.iso"
       ],
 
       "communicator"      : "winrm",
@@ -215,7 +215,7 @@
       "type": "powershell",
       "inline" : [
           "C:/Packer/Scripts/test-packerbuild -TestPhase bootstrap-packerbuild"
-        ],
+       ],
       "valid_exit_codes" : "{{user `valid_exit_codes`}}"
     },
     {

--- a/templates/win/common/vmware.vcenter.slipstream.json
+++ b/templates/win/common/vmware.vcenter.slipstream.json
@@ -99,7 +99,7 @@
       ],
       "iso_paths": [
         "{{user `iso_disk`}}{{user `iso_name`}}",
-        "{{user `iso_disk`}}windows-11.1.0.iso"
+        "{{user `iso_disk`}}windows-11.2.0.iso"
       ],
 
       "communicator"      : "winrm",

--- a/util/VMWarePowerCLI/FixupNov2020Images.ps1
+++ b/util/VMWarePowerCLI/FixupNov2020Images.ps1
@@ -1,0 +1,172 @@
+# Fixup November 2020 Windows Refresh images.
+# The Jenkins Image generation jobs placed the two images for each OS on the old tintri storage.
+# This script clones the machines onto the netapp storage.
+
+# It also creates the two 2010 ipv6 machines.
+
+
+# $NoConfirm = @{'Confirm'=$false}
+
+
+function Get-FolderPath {
+<#
+.SYNOPSIS
+  Returns the folderpath for a folder
+.DESCRIPTION
+  The function will return the complete folderpath for
+  a given folder, optionally with the "hidden" folders
+  included. The function also indicats if it is a "blue"
+  or "yellow" folder.
+.NOTES
+  Authors:	Luc Dekens
+.PARAMETER Folder
+  On or more folders
+.PARAMETER ShowHidden
+  Switch to specify if "hidden" folders should be included
+  in the returned path. The default is $false.
+.EXAMPLE
+  PS> Get-FolderPath -Folder (Get-Folder -Name "MyFolder")
+.EXAMPLE
+  PS> Get-Folder | Get-FolderPath -ShowHidden:$true
+#>
+  
+  param(
+  [parameter(valuefrompipeline = $true,
+  position = 0,
+  HelpMessage = "Enter a folder")]
+  [VMware.VimAutomation.ViCore.Impl.V1.Inventory.FolderImpl[]]$Folder,
+  [switch]$ShowHidden = $false
+  )
+  
+  begin{
+    $excludedNames = "Datacenters","vm","host"
+  }
+  
+  process{
+    $Folder | %{
+      $fld = $_.Extensiondata
+      $fldType = "yellow"
+      if($fld.ChildType -contains "VirtualMachine"){
+        $fldType = "blue"
+      }
+      $path = $fld.Name
+      while($fld.Parent){
+        $fld = Get-View $fld.Parent
+        if((!$ShowHidden -and $excludedNames -notcontains $fld.Name) -or $ShowHidden){
+          $path = $fld.Name + "\" + $path
+        }
+      }
+      $row = "" | Select Name,Path,Type
+      $row.Name = $_.Name
+      $row.Path = $path
+      $row.Type = $fldType
+      $row
+    }
+  }
+}
+
+function Get-FolderPathID {
+  param(
+    [Parameter(Mandatory = $true)]
+    [String]$FullPath
+  )
+
+  Get-folder -type VM -Name $FullPath.split('\')[-1] | ForEach-Object {$fpath= ($_ | Get-FolderPath).Path; $fid = $_.ID; if ($fpath -eq $FullPath) {  $fid}}
+
+}
+
+
+
+function Copy-FixTemplate {
+  param(
+    [Parameter(Mandatory = $true)]
+    [String]$TemplateName,
+    [String]$ToFolder,
+    [String]$DestHostname,
+    [String]$DestStorage,
+    [String]$Cluster
+  )
+
+  Write-Host "Working on $TemplateName"
+  # Cheat here - get-vm returns multiple VM's - just pick the first as it will do the job.
+  $CurrentVM = (Get-VM -Name $TemplateName)[0]
+
+  Write-Host "Cloning $TemplateName to $Cluster - $DestStorage/$DestHostname)"
+
+  # https://code.vmware.com/docs/7634/cmdlet-reference/doc/New-VM.html
+  new-vm -VM "$CurrentVM" -VMHost $DestHostname -Datastore $DestStorage -location (get-folder -id $ToFolder)  -Name "$TemplateName" -ResourcePool (Get-Cluster -Name $Cluster)
+}
+
+$fid_pix_templates_netapp_acceptance2 = Get-FolderPathID -FullPath 'pix\templates\netapp\acceptance2'
+$fid_pix_templates_netapp_acceptance4 = Get-FolderPathID -FullPath 'pix\templates\netapp\acceptance4'
+
+$dest_storage_acceptance2  = 'vmpooler_netapp_prod_2'
+$dest_hostname_acceptance2 = 'pix-jj26-chassis1-2.ops.puppetlabs.net'
+$dest_storage_acceptance4  = 'vmpooler_netapp_prod'
+$dest_hostname_acceptance4 = 'pix-jj27-u21.ops.puppetlabs.net'
+
+
+function Copy-FixBothTemplates {
+  param(
+    [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+    [String]$TemplateBaseName
+  )
+  process {
+    $TemplateName = $TemplateBaseName + '-20201113'
+
+    Copy-FixTemplate -TemplateName $TemplateName -ToFolder $fid_pix_templates_netapp_acceptance2 -DestHostname $dest_hostname_acceptance2 -DestStorage $dest_storage_acceptance2 -Cluster acceptance2
+    Copy-FixTemplate -TemplateName $TemplateName -ToFolder $fid_pix_templates_netapp_acceptance4 -DestHostname $dest_hostname_acceptance4 -DestStorage $dest_storage_acceptance4 -Cluster acceptance4
+  }
+}
+
+
+
+@(
+  "win-10-1511-x86_64"
+  "win-10-next-x86_64"
+  "win-10-1607-x86_64",
+  "win-10-1809-x86_64",
+  "win-10-ent-i386",
+  "win-10-ent-x86_64",
+  "win-10-next-i386",
+  "win-10-next-x86_64",
+  "win-10-pro-x86_64",
+  "win-2012-x86_64",
+  "win-2012r2-core-x86_64",
+  "win-2012r2-fips-x86_64",
+  "win-2012r2-wmf5-x86_64",
+  "win-2012r2-x86_64",
+  "win-2016-core-x86_64",
+  "win-2016-x86_64",
+  "win-2019-core-x86_64",
+  "win-2019-fr-x86_64",
+  "win-2019-ja-x86_64",
+  "win-2019-x86_64",
+  "win-81-x86_64"
+  ) | Copy-FixBothTemplates 
+
+# Finally do the ipv6 machine clones.
+
+function Copy-Ipv6Machines {
+  param (
+    [String]$ToFolder,
+    [String]$DestHostname,
+    [String]$DestStorage,
+    [String]$Cluster
+  )
+  $BaseName = 'win-2016-x86_64-20201113'
+  $ipv6_name = "$Basename-ipv6"
+  $CurrentVM = (Get-VM -Name $BaseName)[0]
+
+  Write-Host "Cloning $ipv6_name to $Cluster - $DestStorage/$DestHostname)"
+  
+  # https://code.vmware.com/docs/7634/cmdlet-reference/doc/New-VM.html
+  $ipv6_vm = new-vm -VM "$CurrentVM" -VMHost $DestHostname -Datastore $DestStorage -location (get-folder -id $ToFolder) -Name "$ipv6_name" -ResourcePool (Get-Cluster -Name $Cluster)
+  New-NetworkAdapter -vm $ipv6_vm -NetworkName ipv6_ds -Startconnected -WakeOnLan -Type VMXNET3
+  
+}
+
+Copy-Ipv6Machines -ToFolder $fid_pix_templates_netapp_acceptance2 -DestHostname $dest_hostname_acceptance2 -DestStorage $dest_storage_acceptance2 -Cluster acceptance2
+Copy-Ipv6Machines -ToFolder $fid_pix_templates_netapp_acceptance4 -DestHostname $dest_hostname_acceptance4 -DestStorage $dest_storage_acceptance4 -Cluster acceptance4
+
+


### PR DESCRIPTION
Generate the Windows November 2020 Patch Tuesday Image Refresh.

This picks up serious CVE-2020-3941 as well as updates to:
1. Powershell 7.1.0
2. NotePad++ 7.9.1
3. Google chrome 86.0.4240.198
4. Git for Windows 2.29.2.2
5. vmware tools 11.2.0 (via boot process)

Windows 10 is also updated to:
1. win-10-ent: Build 2004
2. win-10-next: Build 2009 (20H2)

Fixed issue with pswindows update testing - seems to be a bug in This
since Build 2004 where the get-wuhistory hangs - adding last 2 to the
command appears to be a vaid workaround.

Google appears to install in the Program Files directory (and no longer
in the x86 one) so adjust in scripting.

Filter our Packer Environment Files on the Forcefully delete so as to
avoid throwing (albeit non-fatal) errors in the cleanup scripts at the
end.

Create PowerCLI script to fixup images for new netapp storage pending
a fix in platform-ci-utils and ci-jobs.

Enter these updates in the command record script.