### PR TITLE
(IMAGES-1242) Update version for testing

### DIFF
--- a/templates/win/2019-mock/x86_64/vars.json
+++ b/templates/win/2019-mock/x86_64/vars.json
@@ -19,6 +19,7 @@
     "InstallationType"  : "Server",
     "ReleaseID"         : "1809",
 
-    "valid_exit_codes"  : "0,1"
+    "valid_exit_codes"  : "0,1",
+    "winupdate_valid_exit_codes": "0,1"
 
 }

--- a/templates/win/common/vars.json
+++ b/templates/win/common/vars.json
@@ -1,5 +1,5 @@
 {
-  "version"             : "20201113",
+  "version"             : "20201208",
 
   "headless"            : "true",
 


### PR DESCRIPTION
This is mainly to ensure we don't hammer the existing vmpooler images.
Also fix the win 2019 mock testing parameter.