### PR TITLE
(REPLATS-8) Add kURL image for testing

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -1,5 +1,4 @@
 include packer::repos
-include packer::updates
 include packer::sshd
 include packer::networking
 

--- a/manifests/modules/packer/manifests/networking/params.pp
+++ b/manifests/modules/packer/manifests/networking/params.pp
@@ -13,7 +13,7 @@ class packer::networking::params {
 
     redhat: {
       case $facts['operatingsystemrelease'] {
-        '7.0', '7.0.1406', '7.1.1503', '7.2.1511', '7.2', '7.3.1611', '7.4.1708', '7.5.1804', '7.6.1810', '8.0', '8.0.1905': {
+        '7.0', '7.0.1406', '7.1.1503', '7.2.1511', '7.2', '7.3.1611', '7.4.1708', '7.5.1804', '7.6.1810', '8.0', '8.0.1905', '8.3.2011': {
           case $::provisioner {
 
             'virtualbox': { $interface_script = '/etc/sysconfig/network-scripts/ifcfg-enp0s3' }

--- a/manifests/modules/packer/manifests/vsphere.pp
+++ b/manifests/modules/packer/manifests/vsphere.pp
@@ -19,6 +19,7 @@ class packer::vsphere(
 ) inherits packer::vsphere::params {
 
   include packer::vsphere::repos
+  include packer::vsphere::updates
   include packer::vsphere::networking
   include packer::vsphere::fw
 

--- a/manifests/modules/packer/manifests/vsphere/repos.pp
+++ b/manifests/modules/packer/manifests/vsphere/repos.pp
@@ -217,19 +217,19 @@ class packer::vsphere::repos(
             descr    => 'localmirror-base',
             baseurl  => "${base_url}/BaseOS/${facts['architecture']}/os",
             gpgcheck => '1',
-            gpgkey   => "file:///etc/pki/rpm-gpg/${gpgkey}"
+            gpgkey   => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial"
           }
           yumrepo { 'localmirror-appstream':
             descr    => 'localmirror-appstream',
             baseurl  => "${base_url}/AppStream/${facts['architecture']}/os",
             gpgcheck => '1',
-            gpgkey   => "file:///etc/pki/rpm-gpg/${gpgkey}"
+            gpgkey   => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial"
           }
           yumrepo { 'localmirror-extras':
             descr    => 'localmirror-extras',
             baseurl  => "${base_url}/extras/${facts['architecture']}/os",
             gpgcheck => '1',
-            gpgkey   => "file:///etc/pki/rpm-gpg/${gpgkey}"
+            gpgkey   => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial"
           }
         } else {
           yumrepo { 'localmirror-os':

--- a/manifests/modules/packer/manifests/vsphere/updates.pp
+++ b/manifests/modules/packer/manifests/vsphere/updates.pp
@@ -2,8 +2,7 @@
 #
 # A define that manages puppet modules
 #
-class packer::updates {
-
+class packer::vsphere::updates {
   $linux_pkgs = [
     'bash',
     'openssl',
@@ -14,18 +13,10 @@ class packer::updates {
     'openssh-client',
   ]
 
-  # Updating the EL 6.8 kernel causes a kernel panic on bootup in
-  # vCenter 5.5, so it is not included here. Remove this workaround
-  # when vCenter gets updated.
-  $redhat6_pkgs = [
-    'glibc',
-    'openssh',
-  ]
-
   $redhat_pkgs = [
+    #  'kernel',
     'glibc',
     'openssh',
-    'kernel',
   ]
 
   $suse_pkgs = [
@@ -40,8 +31,6 @@ class packer::updates {
 
   if $facts['osfamily'] == 'Debian' {
     $pkgs_to_update = $linux_pkgs + $debian_pkgs
-  } elsif $facts['osfamily'] == 'Redhat' and $facts['operatingsystemmajrelease'] == '6' {
-    $pkgs_to_update = $linux_pkgs + $redhat6_pkgs
   } elsif $::osfamily == 'Redhat' {
     $pkgs_to_update = $linux_pkgs + $redhat_pkgs
   } elsif $::osfamily == 'Suse' {

--- a/scripts/kurl.sh
+++ b/scripts/kurl.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# These should be passed in via custom_provisioning_env
+#APP='cd4pe'
+#CHANNEL='beta'
+
+set -e
+
+curl -sSLO https://k8s.kurl.sh/bundle/${APP}-${CHANNEL}.tar.gz
+tar xzf ${APP}-${CHANNEL}.tar.gz
+rm ${APP}-${CHANNEL}.tar.gz
+
+cat << EOF > patch.yaml
+apiVersion: cluster.kurl.sh/v1beta1
+kind: Installer
+metadata:
+  name: patch
+spec:
+  # Disable Prometheus. Not necessary for testing and reduces resource requirements.
+  prometheus:
+    version: ''
+EOF
+
+dnf -y install bash-completion
+cat install.sh | sudo bash -s airgap preserve-selinux-config installer-spec-file=patch.yaml

--- a/templates/centos/8.0-pdbpreload/x86_64/vars.json
+++ b/templates/centos/8.0-pdbpreload/x86_64/vars.json
@@ -8,7 +8,7 @@
     "iso_checksum_type"                                     : "sha256",
     "vmware_base_vmx_data_memsize"                          : "8168",
     "vmware_base_vmx_data_numvcpus"                         : "2",
-    "puppet_aio"                                            : "http://builds.delivery.puppetlabs.net/puppet-agent/5.5.16/artifacts/el/8/puppet5/x86_64/puppet-agent-5.5.16-1.el8.x86_64.rpm",
+    "puppet_aio"                                            : "http://builds.delivery.puppetlabs.net/puppet-agent/6.19.1/artifacts/el/8/puppet6/x86_64/puppet-agent-6.19.1-1.el8.x86_64.rpm",
     "inject_http_seed_in_boot_command"                      : "true",
     "boot_command"                                          : "<tab> <wait>inst.text inst.ks=http://%s/ks.cfg<wait><enter>",
     "iso_name"                                              : "CentOS-8-x86_64-1905-dvd1.iso",

--- a/templates/centos/8.0/x86_64/vars.json
+++ b/templates/centos/8.0/x86_64/vars.json
@@ -8,7 +8,7 @@
     "iso_checksum_type"                                     : "sha256",
     "vmware_base_vmx_data_memsize"                          : "8168",
     "vmware_base_vmx_data_numvcpus"                         : "2",
-    "puppet_aio"                                            : "http://builds.delivery.puppetlabs.net/puppet-agent/5.5.16/artifacts/el/8/puppet5/x86_64/puppet-agent-5.5.16-1.el8.x86_64.rpm",
+    "puppet_aio"                                            : "http://builds.delivery.puppetlabs.net/puppet-agent/6.19.1/artifacts/el/8/puppet6/x86_64/puppet-agent-6.19.1-1.el8.x86_64.rpm",
     "inject_http_seed_in_boot_command"                      : "true",
     "boot_command"                                          : "<tab> <wait>inst.text inst.ks=http://%s/ks.cfg<wait><enter>",
     "iso_name"                                              : "CentOS-8-x86_64-1905-dvd1.iso"

--- a/templates/centos/8.3-kurl-beta/common/files/ks.cfg
+++ b/templates/centos/8.3-kurl-beta/common/files/ks.cfg
@@ -1,0 +1,46 @@
+install
+cdrom
+lang en_US.UTF-8
+keyboard us
+network --bootproto=dhcp
+rootpw --iscrypted $1$v4K9E8Wj$gZIHJ5JtQL5ZGZXeqSSsd0
+firewall --enabled --service=ssh
+authconfig --enableshadow --passalgo=sha512
+selinux --disabled
+timezone UTC
+bootloader --location=mbr
+
+text
+skipx
+zerombr
+
+clearpart --all --initlabel
+# autopart only allows for 50GB on / and gives the rest to /home,
+# so we have to manually partition
+part pv.008002 --size=1 --grow --ondisk=sda
+volgroup VolGroup --pesize=4096 pv.008002
+logvol swap --name=vl_swap --vgname=VolGroup --size=8192 --maxsize=8192
+logvol /  --name=vl_root --vgname=VolGroup --fstype=ext4 --grow --size=1
+part /boot --fstype=ext4 --size=1024
+
+auth  --useshadow  --enablemd5
+firstboot --disabled
+reboot --eject
+
+%packages --ignoremissing
+@core
+bzip2
+kernel-devel
+kernel-headers
+gcc
+make
+net-tools
+patch
+perl
+curl
+wget
+nfs-utils
+-ipw2100-firmware
+-ipw2200-firmware
+-ivtv-firmware
+%end

--- a/templates/centos/8.3-kurl-beta/x86_64/vars.json
+++ b/templates/centos/8.3-kurl-beta/x86_64/vars.json
@@ -1,0 +1,17 @@
+{
+    "template_name"                                         : "centos-8.3-kurl-beta-x86_64",
+    "template_os"                                           : "centos8_64Guest",
+    "beakerhost"                                            : "centos8-64",
+    "version"                                               : "0.0.1",
+    "iso_url"                                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/CentOS-8.3.2011-x86_64-dvd1.iso",
+    "iso_checksum"                                          : "aaf9d4b3071c16dbbda01dfe06085e5d0fdac76df323e3bbe87cce4318052247",
+    "iso_checksum_type"                                     : "sha256",
+    "vmware_base_vmx_data_memsize"                          : "8168",
+    "vmware_base_vmx_data_numvcpus"                         : "4",
+    "puppet_aio"                                            : "http://builds.delivery.puppetlabs.net/puppet-agent/6.19.1/artifacts/el/8/puppet6/x86_64/puppet-agent-6.19.1-1.el8.x86_64.rpm",
+    "inject_http_seed_in_boot_command"                      : "true",
+    "boot_command"                                          : "<tab> <wait>inst.text inst.ks=http://%s/ks.cfg<wait><enter>",
+    "iso_name"                                              : "CentOS-8.3.2011-x86_64-dvd1.iso",
+    "custom_provisioning_env"                               : "APP=cd4pe,CHANNEL=beta",
+    "custom_provisioning_script"                            : "scripts/kurl.sh"
+}

--- a/templates/centos/README.md
+++ b/templates/centos/README.md
@@ -8,7 +8,7 @@ This contains all of the var files required to build any of the templates in the
 
 This repository includes OS platforms that are officially supported at Puppet and ones that are entirely maintained by the community. Packer templates include a `support_status` variable which indicates whether the template is puppet maintained vs. community maintained.
 
-Puppet maintained CentOS versions include 5.11, 6.8, 7.2 and 8.0. Any other versions of CentOS here are community maintained.
+Puppet maintained CentOS versions include 5.11, 6.8, 7.2, 8.0, and 8.3. Any other versions of CentOS here are community maintained.
 
 ### Building
 


### PR DESCRIPTION
Adds a CentOS 8 image with https://kurl.sh pre-installed based on CD4PE's Beta channel.