### PR TITLE
(REPLATS-168) Add a k8s restart script for kurl image

### DIFF
--- a/scripts/kurl.sh
+++ b/scripts/kurl.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # These should be passed in via custom_provisioning_env
-#APP='cd4pe'
-#CHANNEL='beta'
+#APP='puppet-application-manager'
+#CHANNEL='standalone-beta'
 
 set -e
 

--- a/scripts/kurl.sh
+++ b/scripts/kurl.sh
@@ -6,6 +6,22 @@
 
 set -e
 
+#################################################################################
+# Provide a script to get kubernetes back into a working state after vm checkout.
+sudo yum install -y git
+/usr/bin/git clone git@github.com:puppetlabs/kurl_test
+sudo cp kurl_test/tasks/restart_k8s.sh /root
+sudo chmod 750 /root/restart_k8s.sh
+rm -rf kurl_test
+
+sudo cat << EOF >> /etc/motd
+
+After initial checkout, run /root/restart_k8s.sh to get the Kubernetes environment restarted.
+
+EOF
+
+#############################
+# Install Kubernetes via Kurl
 curl -sSLO https://k8s.kurl.sh/bundle/${APP}-${CHANNEL}.tar.gz
 tar xzf ${APP}-${CHANNEL}.tar.gz
 rm ${APP}-${CHANNEL}.tar.gz

--- a/scripts/kurl.sh
+++ b/scripts/kurl.sh
@@ -2,7 +2,7 @@
 
 # These should be passed in via custom_provisioning_env
 #APP='puppet-application-manager'
-#CHANNEL='standalone-beta'
+#CHANNEL='standalone'
 
 set -e
 

--- a/scripts/kurl.sh
+++ b/scripts/kurl.sh
@@ -24,16 +24,5 @@ curl -sSLO https://k8s.kurl.sh/bundle/${APP}-${CHANNEL}.tar.gz
 tar xzf ${APP}-${CHANNEL}.tar.gz
 rm ${APP}-${CHANNEL}.tar.gz
 
-cat << EOF > patch.yaml
-apiVersion: cluster.kurl.sh/v1beta1
-kind: Installer
-metadata:
-  name: patch
-spec:
-  # Disable Prometheus. Not necessary for testing and reduces resource requirements.
-  prometheus:
-    version: ''
-EOF
-
 dnf -y install bash-completion
-cat install.sh | sudo bash -s airgap preserve-selinux-config installer-spec-file=patch.yaml
+cat install.sh | sudo bash -s airgap preserve-selinux-config

--- a/scripts/kurl.sh
+++ b/scripts/kurl.sh
@@ -8,13 +8,11 @@ set -e
 
 #################################################################################
 # Provide a script to get kubernetes back into a working state after vm checkout.
-sudo yum install -y git
-/usr/bin/git clone git@github.com:puppetlabs/kurl_test
-sudo cp kurl_test/tasks/restart_k8s.sh /root
-sudo chmod 750 /root/restart_k8s.sh
-rm -rf kurl_test
 
-sudo cat << EOF >> /etc/motd
+sudo mv /tmp/restart_k8s.sh /root
+sudo chmod 750 /root/restart_k8s.sh
+
+cat << EOF | sudo tee -a /etc/motd
 
 After initial checkout, run /root/restart_k8s.sh to get the Kubernetes environment restarted.
 

--- a/scripts/local-git-checkout.sh
+++ b/scripts/local-git-checkout.sh
@@ -1,0 +1,35 @@
+#! /bin/bash
+
+set -e
+set -x
+
+# Checkout a git repo locally on the builder for later use in the build process.
+# Credentials are assumed to already be handled (so a repo Jenkins has access to).
+#
+# Requires the following variables passed in via custom_local_provisioning_env:
+#
+# A repository to clone
+# REPO_URL='git@github.cim:puppetlabs/some-repo'
+# A directory to clone into
+# DIRECTORY='/tmp'
+# A branch to checkout
+# BRANCH='main'
+
+if [ -z "${DIRECTORY}" ]; then
+  echo "No DIRECTORY was set; nowhere to clone to."
+  exit 1
+fi
+
+repo="${REPO_URL##*/}"
+
+if [ -z "${repo}" ]; then
+  echo "Failed to determine repository name from REPO_URL: '${REPO_URL}'"
+  exit 1
+fi
+
+mkdir -p "${DIRECTORY}"
+location="${DIRECTORY}/${repo}"
+rm -rf "${location}" # in case image builder isn't cleaned between runs...
+git clone "${REPO_URL}" "${location}"
+cd "${location}" || exit
+git checkout "${BRANCH}"

--- a/templates/centos/8.3-kurl-beta/x86_64/vars.json
+++ b/templates/centos/8.3-kurl-beta/x86_64/vars.json
@@ -12,6 +12,6 @@
     "inject_http_seed_in_boot_command"                      : "true",
     "boot_command"                                          : "<tab> <wait>inst.text inst.ks=http://%s/ks.cfg<wait><enter>",
     "iso_name"                                              : "CentOS-8.3.2011-x86_64-dvd1.iso",
-    "custom_provisioning_env"                               : "APP=cd4pe,CHANNEL=beta",
+    "custom_provisioning_env"                               : "APP=puppet-application-manager,CHANNEL=standalone-beta",
     "custom_provisioning_script"                            : "scripts/kurl.sh"
 }

--- a/templates/centos/8.3-kurl-beta/x86_64/vars.json
+++ b/templates/centos/8.3-kurl-beta/x86_64/vars.json
@@ -15,6 +15,6 @@
     "custom_local_provisioning_env"                         : "REPO_URL=git@github.com:puppetlabs/kurl_test,BRANCH=main,DIRECTORY={{user `project_root`}}/local-repos",
     "custom_local_provisioning_script"                      : "scripts/local-git-checkout.sh",
     "custom_files_to_upload"                                : "{{user `project_root`}}/local-repos/kurl_test/tasks/restart_k8s.sh",
-    "custom_provisioning_env"                               : "APP=puppet-application-manager,CHANNEL=standalone-beta",
+    "custom_provisioning_env"                               : "APP=puppet-application-manager,CHANNEL=standalone",
     "custom_provisioning_script"                            : "scripts/kurl.sh"
 }

--- a/templates/centos/8.3-kurl-beta/x86_64/vars.json
+++ b/templates/centos/8.3-kurl-beta/x86_64/vars.json
@@ -12,6 +12,9 @@
     "inject_http_seed_in_boot_command"                      : "true",
     "boot_command"                                          : "<tab> <wait>inst.text inst.ks=http://%s/ks.cfg<wait><enter>",
     "iso_name"                                              : "CentOS-8.3.2011-x86_64-dvd1.iso",
+    "custom_local_provisioning_env"                         : "REPO_URL=git@github.com:puppetlabs/kurl_test,BRANCH=main,DIRECTORY={{user `project_root`}}/local-repos",
+    "custom_local_provisioning_script"                      : "scripts/local-git-checkout.sh",
+    "custom_files_to_upload"                                : "{{user `project_root`}}/local-repos/kurl_test/tasks/restart_k8s.sh",
     "custom_provisioning_env"                               : "APP=puppet-application-manager,CHANNEL=standalone-beta",
     "custom_provisioning_script"                            : "scripts/kurl.sh"
 }

--- a/templates/centos/8.3-kurl-beta/x86_64/vars.json
+++ b/templates/centos/8.3-kurl-beta/x86_64/vars.json
@@ -2,7 +2,7 @@
     "template_name"                                         : "centos-8.3-kurl-beta-x86_64",
     "template_os"                                           : "centos8_64Guest",
     "beakerhost"                                            : "centos8-64",
-    "version"                                               : "0.0.1",
+    "version"                                               : "0.1.0",
     "iso_url"                                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/CentOS-8.3.2011-x86_64-dvd1.iso",
     "iso_checksum"                                          : "aaf9d4b3071c16dbbda01dfe06085e5d0fdac76df323e3bbe87cce4318052247",
     "iso_checksum_type"                                     : "sha256",

--- a/templates/common/vmware.vcenter.json
+++ b/templates/common/vmware.vcenter.json
@@ -72,7 +72,10 @@
       "tools_upload_flavor"                          : "linux",
       "project_root"                                 : "../../../..",
       "custom_provisioning_env"                      : "pe_ver=2018.1.4,pe_foo=bar",
-      "custom_provisioning_script"                   : "scripts/noop.sh"
+      "custom_provisioning_script"                   : "scripts/noop.sh",
+      "custom_local_provisioning_env"                : "",
+      "custom_local_provisioning_script"             : "scripts/noop.sh",
+      "custom_files_to_upload"                       : "/dev/null"
     },
 
  "builders": [
@@ -228,6 +231,20 @@
                                                         "{{user `project_root`}}/scripts/cleanup-aio.sh"
                                                      ]
     },
+
+    {
+      "type"                                       : "shell-local",
+      "environment_vars"                           : "{{user `custom_local_provisioning_env`}}",
+      "scripts"                                    : "{{user `project_root`}}/{{user `custom_local_provisioning_script`}}"
+    },
+
+    {
+      "type"                                         : "file",
+      "sources"                                      : "{{user `custom_files_to_upload`}}",
+      "destination"                                  : "/tmp/",
+      "generated"                                    : true
+    },
+
     {
       "type"                                       : "shell",
       "environment_vars"                           : "{{user `custom_provisioning_env`}}",


### PR DESCRIPTION
When a kurl vm is checked out, there's a multi step process to get
containerd and the k8s services running again. It becomes more
complicated when the host ip has changed and k8s services need to be
reconfigured for the new ip.

In order to make it simple for anyone manually checking out a kurl vm to
reset it to a working state, this patch pulls down the restart-k8s.sh
script from the kurl_test repo into /root so it's available to be run
when a vm is checked out.

There doesn't seem to be a straight forward mechanism for including
arbitrary files with puppetlabs-packer without modifying the
templates/common/vmware.vcenter.json to include an additional file
provisioner. But that would affect all the images using that template.