### PR TITLE
(IMAGES-1259) Fedora 34 fixes

### DIFF
--- a/manifests/modules/packer/templates/vsphere/redhat.rb.erb
+++ b/manifests/modules/packer/templates/vsphere/redhat.rb.erb
@@ -85,7 +85,7 @@ Kernel.system('/sbin/service NetworkManager restart')
 
 puts '- Cleaning up...'
 
-<% if ['28', '29', '30', '31'].include? @operatingsystemrelease -%>
+<% if ['28', '29', '30', '31', '34'].include? @operatingsystemrelease -%>
 # With systemd-networkd, disable the oneshot service that runs this script:
 Kernel.system('/bin/systemctl disable vsphere.bootstrap.service')
 <% else -%>

--- a/templates/fedora/34/files/ks.cfg
+++ b/templates/fedora/34/files/ks.cfg
@@ -1,7 +1,7 @@
 cdrom
 lang en_US.UTF-8
 keyboard us
-network --bootproto=dhcp --device=eth0
+network --bootproto=dhcp --device=ens192
 repo --name=updates
 rootpw puppet
 firewall --disabled
@@ -34,4 +34,7 @@ libxcrypt-compat
 %post
 echo PermitRootLogin yes >> /etc/ssh/sshd_config
 echo zchunk=False >> /etc/dnf/dnf.conf
+[ -h /etc/resolv.conf ] && rm -f /etc/resolv.conf && touch /etc/resolv.conf && /bin/systemctl restart NetworkManager
 %end
+
+services --disabled=systemd-resolved

--- a/templates/fedora/34/x86_64/vars.json
+++ b/templates/fedora/34/x86_64/vars.json
@@ -2,7 +2,7 @@
   "template_name"                         : "fedora-34-x86_64",
   "template_os"                           : "fedora64Guest",
   "beakerhost"                            : "fedora34-64",
-  "version"                               : "0.0.1",
+  "version"                               : "0.0.2",
   "iso_url"                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/Fedora-Server-dvd-x86_64-34-1.2.iso",
   "iso_checksum"                          : "cd2aefdbe1b5042865a39c49d32f5d21a9537c719aa87dde34d08ca06bc6681c",
   "iso_checksum_type"                     : "sha256",


### PR DESCRIPTION
Disabled systemd-resolved and restored /etc/resolv.conf as
normal file.