### PR TITLE
(REPLATS-169) Bump centos-8.3-kurl image version to 0.1.1

### DIFF
--- a/templates/centos/8.3-kurl-beta/x86_64/vars.json
+++ b/templates/centos/8.3-kurl-beta/x86_64/vars.json
@@ -2,7 +2,7 @@
     "template_name"                                         : "centos-8.3-kurl-beta-x86_64",
     "template_os"                                           : "centos8_64Guest",
     "beakerhost"                                            : "centos8-64",
-    "version"                                               : "0.1.0",
+    "version"                                               : "0.1.1",
     "iso_url"                                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/CentOS-8.3.2011-x86_64-dvd1.iso",
     "iso_checksum"                                          : "aaf9d4b3071c16dbbda01dfe06085e5d0fdac76df323e3bbe87cce4318052247",
     "iso_checksum_type"                                     : "sha256",


### PR DESCRIPTION
...to bring in Weave 2.8.1. We've been seeing transient issues with
weave networkpolicy rules not being up to date after a restarted vm and
want to see if pulling in the newer puppet-application-manager builds
that include a newer weave-net improve the problem.