### PR TITLE
Replats 348 add ha kurl image

### DIFF
--- a/scripts/kurl.sh
+++ b/scripts/kurl.sh
@@ -3,26 +3,33 @@
 # These should be passed in via custom_provisioning_env
 #APP='puppet-application-manager'
 #CHANNEL='standalone'
+#INSTALL=true (default, set false to to skip installation)
+INSTALL="${INSTALL:-true}"
 
 set -e
 
 #################################################################################
 # Provide a script to get kubernetes back into a working state after vm checkout.
 
-sudo mv /tmp/restart_k8s.sh /root
-sudo chmod 750 /root/restart_k8s.sh
+if [ "${INSTALL}" == 'true' ]; then
+  sudo mv /tmp/restart_k8s.sh /root
+  sudo chmod 750 /root/restart_k8s.sh
 
-cat << EOF | sudo tee -a /etc/motd
+  cat << EOF | sudo tee -a /etc/motd
 
 After initial checkout, run /root/restart_k8s.sh to get the Kubernetes environment restarted.
 
 EOF
 
+fi
+
 #############################
 # Install Kubernetes via Kurl
-curl -sSLO https://k8s.kurl.sh/bundle/${APP}-${CHANNEL}.tar.gz
-tar xzf ${APP}-${CHANNEL}.tar.gz
-rm ${APP}-${CHANNEL}.tar.gz
+curl -sSLO "https://k8s.kurl.sh/bundle/${APP}-${CHANNEL}.tar.gz"
+tar xzf "${APP}-${CHANNEL}.tar.gz"
+rm "${APP}-${CHANNEL}.tar.gz"
 
 dnf -y install bash-completion
-cat install.sh | sudo bash -s airgap preserve-selinux-config
+if [ "${INSTALL}" == 'true' ]; then
+  cat install.sh | sudo bash -s airgap preserve-selinux-config
+fi

--- a/scripts/kurl.sh
+++ b/scripts/kurl.sh
@@ -1,12 +1,18 @@
 #!/bin/bash
 
+set -e
+
 # These should be passed in via custom_provisioning_env
 #APP='puppet-application-manager'
 #CHANNEL='standalone'
 #INSTALL=true (default, set false to to skip installation)
 INSTALL="${INSTALL:-true}"
 
-set -e
+if [ "${CHANNEL}" == 'stable' ]; then
+  TARBALL="${APP}.tar.gz"
+else
+  TARBALL="${APP}-${CHANNEL}.tar.gz"
+fi
 
 #################################################################################
 # Provide a script to get kubernetes back into a working state after vm checkout.
@@ -25,9 +31,9 @@ fi
 
 #############################
 # Install Kubernetes via Kurl
-curl -sSLO "https://k8s.kurl.sh/bundle/${APP}-${CHANNEL}.tar.gz"
-tar xzf "${APP}-${CHANNEL}.tar.gz"
-rm "${APP}-${CHANNEL}.tar.gz"
+curl -sSLO "https://k8s.kurl.sh/bundle/${TARBALL}"
+tar xzf "${TARBALL}"
+rm "${TARBALL}"
 
 dnf -y install bash-completion
 if [ "${INSTALL}" == 'true' ]; then

--- a/templates/centos/8.3-kurl-ha/common/files/ks.cfg
+++ b/templates/centos/8.3-kurl-ha/common/files/ks.cfg
@@ -17,10 +17,12 @@ zerombr
 clearpart --all --initlabel
 # autopart only allows for 50GB on / and gives the rest to /home,
 # so we have to manually partition
-part pv.008002 --size=1 --grow --ondisk=sda
+# Of the 70GB provided to the centos images for their disk size, restrict the
+# root volume to 50GB so that the remnant can later be allocated to an
+# unformatted partition for Ceph.
+part pv.008002 --grow --size=1 --ondisk=sda
 volgroup VolGroup --pesize=4096 pv.008002
-logvol /  --name=vl_root --vgname=VolGroup --fstype=ext4 --grow --size=1
-part /ceph --size=16384
+logvol /  --name=vl_root --vgname=VolGroup --fstype=ext4 --size=51200
 part /boot --fstype=ext4 --size=1024
 
 auth  --useshadow  --enablemd5
@@ -43,4 +45,11 @@ nfs-utils
 -ipw2100-firmware
 -ipw2200-firmware
 -ivtv-firmware
+%end
+
+# The partition/logvol commands' --noformat seems only to work to bypass
+# formatting of an existing partition. In our case, for ceph, we want an
+# unformatted partition so creating it manually in this %post section.
+%post --erroronfail
+lvm lvcreate --extents 100%FREE --type linear --name vl_ceph VolGroup
 %end

--- a/templates/centos/8.3-kurl-ha/common/files/ks.cfg
+++ b/templates/centos/8.3-kurl-ha/common/files/ks.cfg
@@ -1,0 +1,46 @@
+install
+cdrom
+lang en_US.UTF-8
+keyboard us
+network --bootproto=dhcp
+rootpw --iscrypted $1$v4K9E8Wj$gZIHJ5JtQL5ZGZXeqSSsd0
+firewall --enabled --service=ssh
+authconfig --enableshadow --passalgo=sha512
+selinux --disabled
+timezone UTC
+bootloader --location=mbr
+
+text
+skipx
+zerombr
+
+clearpart --all --initlabel
+# autopart only allows for 50GB on / and gives the rest to /home,
+# so we have to manually partition
+part pv.008002 --size=1 --grow --ondisk=sda
+volgroup VolGroup --pesize=4096 pv.008002
+logvol swap --name=vl_swap --vgname=VolGroup --size=8192 --maxsize=8192
+logvol /  --name=vl_root --vgname=VolGroup --fstype=ext4 --grow --size=1
+part /boot --fstype=ext4 --size=1024
+
+auth  --useshadow  --enablemd5
+firstboot --disabled
+reboot --eject
+
+%packages --ignoremissing
+@core
+bzip2
+kernel-devel
+kernel-headers
+gcc
+make
+net-tools
+patch
+perl
+curl
+wget
+nfs-utils
+-ipw2100-firmware
+-ipw2200-firmware
+-ivtv-firmware
+%end

--- a/templates/centos/8.3-kurl-ha/common/files/ks.cfg
+++ b/templates/centos/8.3-kurl-ha/common/files/ks.cfg
@@ -19,7 +19,6 @@ clearpart --all --initlabel
 # so we have to manually partition
 part pv.008002 --size=1 --grow --ondisk=sda
 volgroup VolGroup --pesize=4096 pv.008002
-logvol swap --name=vl_swap --vgname=VolGroup --size=8192 --maxsize=8192
 logvol /  --name=vl_root --vgname=VolGroup --fstype=ext4 --grow --size=1
 part /ceph --size=16384
 part /boot --fstype=ext4 --size=1024

--- a/templates/centos/8.3-kurl-ha/common/files/ks.cfg
+++ b/templates/centos/8.3-kurl-ha/common/files/ks.cfg
@@ -21,6 +21,7 @@ part pv.008002 --size=1 --grow --ondisk=sda
 volgroup VolGroup --pesize=4096 pv.008002
 logvol swap --name=vl_swap --vgname=VolGroup --size=8192 --maxsize=8192
 logvol /  --name=vl_root --vgname=VolGroup --fstype=ext4 --grow --size=1
+part /ceph --noformat --size=16384
 part /boot --fstype=ext4 --size=1024
 
 auth  --useshadow  --enablemd5

--- a/templates/centos/8.3-kurl-ha/common/files/ks.cfg
+++ b/templates/centos/8.3-kurl-ha/common/files/ks.cfg
@@ -21,7 +21,7 @@ part pv.008002 --size=1 --grow --ondisk=sda
 volgroup VolGroup --pesize=4096 pv.008002
 logvol swap --name=vl_swap --vgname=VolGroup --size=8192 --maxsize=8192
 logvol /  --name=vl_root --vgname=VolGroup --fstype=ext4 --grow --size=1
-part /ceph --noformat --size=16384
+part /ceph --size=16384
 part /boot --fstype=ext4 --size=1024
 
 auth  --useshadow  --enablemd5

--- a/templates/centos/8.3-kurl-ha/x86_64/vars.json
+++ b/templates/centos/8.3-kurl-ha/x86_64/vars.json
@@ -1,8 +1,8 @@
 {
-    "template_name"                                         : "centos-8.3-kurl-beta-x86_64",
+    "template_name"                                         : "centos-8.3-kurl-ha-x86_64",
     "template_os"                                           : "centos8_64Guest",
     "beakerhost"                                            : "centos8-64",
-    "version"                                               : "0.1.1",
+    "version"                                               : "0.0.1",
     "iso_url"                                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/CentOS-8.3.2011-x86_64-dvd1.iso",
     "iso_checksum"                                          : "aaf9d4b3071c16dbbda01dfe06085e5d0fdac76df323e3bbe87cce4318052247",
     "iso_checksum_type"                                     : "sha256",
@@ -12,9 +12,6 @@
     "inject_http_seed_in_boot_command"                      : "true",
     "boot_command"                                          : "<tab> <wait>inst.text inst.ks=http://%s/ks.cfg<wait><enter>",
     "iso_name"                                              : "CentOS-8.3.2011-x86_64-dvd1.iso",
-    "custom_local_provisioning_env"                         : "REPO_URL=git@github.com:puppetlabs/kurl_test,BRANCH=main,DIRECTORY={{user `project_root`}}/local-repos",
-    "custom_local_provisioning_script"                      : "scripts/local-git-checkout.sh",
-    "custom_files_to_upload"                                : "{{user `project_root`}}/local-repos/kurl_test/tasks/restart_k8s.sh",
-    "custom_provisioning_env"                               : "APP=puppet-application-manager,CHANNEL=standalone",
+    "custom_provisioning_env"                               : "APP=puppet-application-manager,CHANNEL=",
     "custom_provisioning_script"                            : "scripts/kurl.sh"
 }

--- a/templates/centos/8.3-kurl-ha/x86_64/vars.json
+++ b/templates/centos/8.3-kurl-ha/x86_64/vars.json
@@ -12,6 +12,6 @@
     "inject_http_seed_in_boot_command"                      : "true",
     "boot_command"                                          : "<tab> <wait>inst.text inst.ks=http://%s/ks.cfg<wait><enter>",
     "iso_name"                                              : "CentOS-8.3.2011-x86_64-dvd1.iso",
-    "custom_provisioning_env"                               : "APP=puppet-application-manager,CHANNEL=",
+    "custom_provisioning_env"                               : "APP=puppet-application-manager,CHANNEL=stable,INSTALL=false",
     "custom_provisioning_script"                            : "scripts/kurl.sh"
 }

--- a/templates/centos/8.3-kurl-ha/x86_64/vars.json
+++ b/templates/centos/8.3-kurl-ha/x86_64/vars.json
@@ -1,0 +1,20 @@
+{
+    "template_name"                                         : "centos-8.3-kurl-beta-x86_64",
+    "template_os"                                           : "centos8_64Guest",
+    "beakerhost"                                            : "centos8-64",
+    "version"                                               : "0.1.1",
+    "iso_url"                                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/CentOS-8.3.2011-x86_64-dvd1.iso",
+    "iso_checksum"                                          : "aaf9d4b3071c16dbbda01dfe06085e5d0fdac76df323e3bbe87cce4318052247",
+    "iso_checksum_type"                                     : "sha256",
+    "vmware_base_vmx_data_memsize"                          : "8168",
+    "vmware_base_vmx_data_numvcpus"                         : "4",
+    "puppet_aio"                                            : "http://builds.delivery.puppetlabs.net/puppet-agent/6.19.1/artifacts/el/8/puppet6/x86_64/puppet-agent-6.19.1-1.el8.x86_64.rpm",
+    "inject_http_seed_in_boot_command"                      : "true",
+    "boot_command"                                          : "<tab> <wait>inst.text inst.ks=http://%s/ks.cfg<wait><enter>",
+    "iso_name"                                              : "CentOS-8.3.2011-x86_64-dvd1.iso",
+    "custom_local_provisioning_env"                         : "REPO_URL=git@github.com:puppetlabs/kurl_test,BRANCH=main,DIRECTORY={{user `project_root`}}/local-repos",
+    "custom_local_provisioning_script"                      : "scripts/local-git-checkout.sh",
+    "custom_files_to_upload"                                : "{{user `project_root`}}/local-repos/kurl_test/tasks/restart_k8s.sh",
+    "custom_provisioning_env"                               : "APP=puppet-application-manager,CHANNEL=standalone",
+    "custom_provisioning_script"                            : "scripts/kurl.sh"
+}


### PR DESCRIPTION
    (REPLATS-348) Add an unformatted partition to 8.3-kurl-ha for Ceph

The Ceph persistent volume manager for k8s needs to work with an
unformatted device. To start with, I've just carved out 16384MiB from the
71680MB sda volume. This is considerable smaller than the recommended
50GB + app req that we recommend, but may suffice for CI.

---

    (REPLATS-348) Only preload kurl in the 8.3-kurl-ha image

Restarting k8s was challenging for a standalone primary. It's likely to
be worse for an ha primary with ceph/rook, and then we'd need to worry
about joining other primaries to the cluster for ha.

Instead, we're just going to pre-download the kurl tarball, which should
be the bulk of the time, and then install fresh on checked out vms.

Curl's puppet-application-manager-stable instead of standalone, and
updates the kurl.sh to skip installation and managing a restart script
(which we aren't copying into the image) if we are not installing.