### PR TITLE
(REPLATS-360) Bump centos-8.3-kurl image version to 0.1.4

### DIFF
--- a/templates/centos/8.3-kurl-beta/x86_64/vars.json
+++ b/templates/centos/8.3-kurl-beta/x86_64/vars.json
@@ -2,7 +2,7 @@
     "template_name"                                         : "centos-8.3-kurl-beta-x86_64",
     "template_os"                                           : "centos8_64Guest",
     "beakerhost"                                            : "centos8-64",
-    "version"                                               : "0.1.3",
+    "version"                                               : "0.1.4",
     "iso_url"                                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/CentOS-8.3.2011-x86_64-dvd1.iso",
     "iso_checksum"                                          : "aaf9d4b3071c16dbbda01dfe06085e5d0fdac76df323e3bbe87cce4318052247",
     "iso_checksum_type"                                     : "sha256",
@@ -15,6 +15,6 @@
     "custom_local_provisioning_env"                         : "REPO_URL=git@github.com:puppetlabs/kurl_test,BRANCH=main,DIRECTORY={{user `project_root`}}/local-repos",
     "custom_local_provisioning_script"                      : "scripts/local-git-checkout.sh",
     "custom_files_to_upload"                                : "{{user `project_root`}}/local-repos/kurl_test/tasks/restart_k8s.sh",
-    "custom_provisioning_env"                               : "APP=puppet-application-manager,CHANNEL=standalone",
+    "custom_provisioning_env"                               : "APP=puppet-application-manager,CHANNEL=standalone-beta",
     "custom_provisioning_script"                            : "scripts/kurl.sh"
 }


### PR DESCRIPTION
...and switch channel from standalone to standalone-beta. There are
changes from the past month that we want to test before the next
release.