### PR TITLE
(maint) Fix missing images for airgap tests

### DIFF
--- a/scripts/kurl.sh
+++ b/scripts/kurl.sh
@@ -26,3 +26,7 @@ rm ${APP}-${CHANNEL}.tar.gz
 
 dnf -y install bash-completion
 cat install.sh | sudo bash -s airgap preserve-selinux-config
+
+# Stop Kubelet before shutdown. The packer build fills the disk with 0s to compress the image,
+# which otherwise causes Kubelet to start erasing unused images that we still need.
+systemctl stop kubelet

--- a/templates/centos/8.3-kurl-beta/x86_64/vars.json
+++ b/templates/centos/8.3-kurl-beta/x86_64/vars.json
@@ -2,7 +2,7 @@
     "template_name"                                         : "centos-8.3-kurl-beta-x86_64",
     "template_os"                                           : "centos8_64Guest",
     "beakerhost"                                            : "centos8-64",
-    "version"                                               : "0.1.4",
+    "version"                                               : "0.1.5",
     "iso_url"                                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/CentOS-8.3.2011-x86_64-dvd1.iso",
     "iso_checksum"                                          : "aaf9d4b3071c16dbbda01dfe06085e5d0fdac76df323e3bbe87cce4318052247",
     "iso_checksum_type"                                     : "sha256",


### PR DESCRIPTION
Stops Kubelet before shutdown. The packer build fills the disk with 0s to compress the image, which otherwise causes Kubelet to start erasing unused images that we still need.