### PR TITLE
(REPLATS-360) Add ipvsadm used by restart_k8s.sh

### DIFF
--- a/templates/centos/8.3-kurl-beta/common/files/ks.cfg
+++ b/templates/centos/8.3-kurl-beta/common/files/ks.cfg
@@ -40,6 +40,7 @@ perl
 curl
 wget
 nfs-utils
+ipvsadm
 -ipw2100-firmware
 -ipw2200-firmware
 -ivtv-firmware

--- a/templates/centos/8.3-kurl-beta/x86_64/vars.json
+++ b/templates/centos/8.3-kurl-beta/x86_64/vars.json
@@ -2,7 +2,7 @@
     "template_name"                                         : "centos-8.3-kurl-beta-x86_64",
     "template_os"                                           : "centos8_64Guest",
     "beakerhost"                                            : "centos8-64",
-    "version"                                               : "0.1.6",
+    "version"                                               : "0.1.7",
     "iso_url"                                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/CentOS-8.3.2011-x86_64-dvd1.iso",
     "iso_checksum"                                          : "aaf9d4b3071c16dbbda01dfe06085e5d0fdac76df323e3bbe87cce4318052247",
     "iso_checksum_type"                                     : "sha256",


### PR DESCRIPTION
The script will install it as well, but may as well have it on the vm,
and we need to bump version anyway to pull the new script in.