### PR TITLE
(maint) Drain pods before imaging

### DIFF
--- a/scripts/kurl.sh
+++ b/scripts/kurl.sh
@@ -24,7 +24,6 @@ curl -sSLO https://k8s.kurl.sh/bundle/${APP}-${CHANNEL}.tar.gz
 tar xzf ${APP}-${CHANNEL}.tar.gz
 rm ${APP}-${CHANNEL}.tar.gz
 
-dnf -y install bash-completion
 cat install.sh | sudo bash -s airgap preserve-selinux-config
 
 # Stop Kubelet before shutdown. The packer build fills the disk with 0s to compress the image,

--- a/scripts/kurl.sh
+++ b/scripts/kurl.sh
@@ -26,6 +26,29 @@ rm ${APP}-${CHANNEL}.tar.gz
 
 cat install.sh | sudo bash -s airgap preserve-selinux-config
 
-# Stop Kubelet before shutdown. The packer build fills the disk with 0s to compress the image,
-# which otherwise causes Kubelet to start erasing unused images that we still need.
+# Stop pods and Kubelet before shutdown. The packer build fills the disk with 0s to compress the
+# image, which otherwise causes Kubelet to start erasing unused images that we still need. Other
+# pods may also be paused in an unexpected state if left running.
+echo " * Draining node"
+kubectl drain localhost.localdomain --delete-local-data --ignore-daemonsets
+
+echo " * Stopping kubelet"
 systemctl stop kubelet
+systemctl disable kubelet
+
+if [ "$(pgrep -c -f /usr/bin/containerd-shim-runc-v2)" != "0" ]; then
+  echo " * Clearing out any old containers"
+  systemctl start containerd
+  ready_pods=($(crictl pods -q --state ready))
+  for p in "${ready_pods[@]}"; do
+    crictl stopp "${p}" || true
+  done
+  pods=($(crictl pods -q))
+  for p in "${pods[@]}"; do
+    crictl rmp -f "${p}" || true
+  done
+fi
+
+echo " * Stopping containerd"
+systemctl stop containerd
+systemctl disable containerd

--- a/templates/centos/8.3-kurl-beta/common/files/ks.cfg
+++ b/templates/centos/8.3-kurl-beta/common/files/ks.cfg
@@ -41,6 +41,7 @@ curl
 wget
 nfs-utils
 ipvsadm
+bash-completion
 -ipw2100-firmware
 -ipw2200-firmware
 -ivtv-firmware

--- a/templates/centos/8.3-kurl-beta/x86_64/vars.json
+++ b/templates/centos/8.3-kurl-beta/x86_64/vars.json
@@ -2,7 +2,7 @@
     "template_name"                                         : "centos-8.3-kurl-beta-x86_64",
     "template_os"                                           : "centos8_64Guest",
     "beakerhost"                                            : "centos8-64",
-    "version"                                               : "0.1.7",
+    "version"                                               : "0.1.8",
     "iso_url"                                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/CentOS-8.3.2011-x86_64-dvd1.iso",
     "iso_checksum"                                          : "aaf9d4b3071c16dbbda01dfe06085e5d0fdac76df323e3bbe87cce4318052247",
     "iso_checksum_type"                                     : "sha256",


### PR DESCRIPTION
We're seeing transient issues with pods starting up after reinitializing via kubeadm. Drain all pods before we stop kubelet and create the image to ensure pods have a chance to safely shutdown.

Also prevents kubelet and containerd from starting on startup as the first thing we do in the restart script is to stop them. This avoids having to cleanup pods again.
