### PR TITLE
(maint) Corrects template file parameter

### DIFF
--- a/templates/common/vmware.vcenter.json
+++ b/templates/common/vmware.vcenter.json
@@ -231,7 +231,7 @@
 
     {
       "type"                                         : "file",
-      "sources"                                      : "{{user `custom_files_to_upload`}}",
+      "source"                                       : "{{user `custom_files_to_upload`}}",
       "destination"                                  : "/tmp/"
     },
 


### PR DESCRIPTION
A file provisioner in the vmware.vcenter.json template was missing [the required `source` parameter](https://www.packer.io/docs/provisioners/file#configuration-reference-1) and instead had the optional `sources` parameter.

I believe that this was causing an imaging pipeline to fail: https://jenkins-sre.delivery.puppetlabs.net/view/imaging/view/Redhat/job/imaging_redhat-9.0_x86_64_vmware_vcenter_packer_build_packer/2/console