### PR TITLE
(maint) Fix building images besides redhat-8.4-kurl-beta

### DIFF
--- a/templates/common/vmware.vcenter.json
+++ b/templates/common/vmware.vcenter.json
@@ -72,7 +72,8 @@
       "tools_upload_flavor"                          : "linux",
       "project_root"                                 : "../../../..",
       "custom_provisioning_env"                      : "pe_ver=2018.1.4,pe_foo=bar",
-      "custom_provisioning_script"                   : "scripts/noop.sh"
+      "custom_provisioning_script"                   : "scripts/noop.sh",
+      "custom_files_to_upload"                       : "../../../../files/empty"
     },
 
  "builders": [


### PR DESCRIPTION
REPLATS-514 added a new file provisioner. When `custom_files_to_upload` is not defined, this file provisioner errors. Adds a default empty file that's uploaded if `custom_files_to_upload` is not overridden.