### PR TITLE
(REPLATS-514) Fix custom files to upload default

### DIFF
--- a/templates/common/vmware.vcenter.json
+++ b/templates/common/vmware.vcenter.json
@@ -232,7 +232,7 @@
 
     {
       "type"                                         : "file",
-      "source"                                       : "{{user `custom_files_to_upload`}}",
+      "sources"                                      : "{{user `custom_files_to_upload`}}",
       "destination"                                  : "/tmp/"
     },
 

--- a/templates/common/vmware.vcenter.json
+++ b/templates/common/vmware.vcenter.json
@@ -72,7 +72,8 @@
       "tools_upload_flavor"                          : "linux",
       "project_root"                                 : "../../../..",
       "custom_provisioning_env"                      : "pe_ver=2018.1.4,pe_foo=bar",
-      "custom_provisioning_script"                   : "scripts/noop.sh"
+      "custom_provisioning_script"                   : "scripts/noop.sh",
+      "custom_files_to_upload"                       : "/dev/null"
     },
 
  "builders": [


### PR DESCRIPTION
When I pulled the file provisioner back in from 3318e6a, I forgot to
include the default value for custom_files_to_upload. Consequently other
images using vmware.vcenter.json as their base template would fail,
since they had no value set here. Readding as /dev/null so that the
builder is effectively a noop unless an image specifies something to
copy.

---

@mhashizume this also reverts 5b90b4 because when I'm using custom_files_to_upload, I'm passing an array, so I believe sources is the required parameter. If you made that change because you were trying to correct my mistake with the default, then we're probably okay? But if something else was broken, please let me know. Thanks!