### PR TITLE
(PT-582) Remove dnf module workaround from kurl.sh script

### DIFF
--- a/scripts/kurl.sh
+++ b/scripts/kurl.sh
@@ -15,10 +15,6 @@ rm "${APP}-${CHANNEL}.tar.gz"
 
 cat install.sh | sudo bash -s airgap preserve-selinux-config
 
-# PT-582 Work around the dnf modular filtering bug by reseting the left over kurl.local @modulefailsafe
-echo " * Cleanup PT-582 kurl.local module bug"
-dnf module reset kurl.local -y
-
 # Stop pods and Kubelet before shutdown. The packer build fills the disk with 0s to compress the
 # image, which otherwise causes Kubelet to start erasing unused images that we still need. Other
 # pods may also be paused in an unexpected state if left running.

--- a/templates/redhat/8.4-kurl-beta/x86_64/vars.json
+++ b/templates/redhat/8.4-kurl-beta/x86_64/vars.json
@@ -2,7 +2,7 @@
     "template_name"                                         : "redhat-8.4-kurl-beta-x86_64",
     "template_os"                                           : "rhel8_64Guest",
     "beakerhost"                                            : "redhat8-64",
-    "version"                                               : "0.3.2",
+    "version"                                               : "0.3.3",
     "iso_url"                                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/rhel-8.4-x86_64-dvd.iso",
     "iso_checksum"                                          : "aaf9d4b3071c16dbbda01dfe06085e5d0fdac76df323e3bbe87cce4318052247",
     "iso_checksum_type"                                     : "sha256",


### PR DESCRIPTION
This was working around a bug in the local dnf repositories used by Kurl
when building the redhat-8.4-kurl-beta image.

As of https://kurl.sh/release-notes/v2021.12.01-0, kurl includes this
workaround itself. Consequently, the kurl.sh script was failing because
dnf would exit non-zero when we tried to `dnf module reset kurl.local`
because Kurl's install.sh script had already removed it...