### PR TITLE
(maint) Adds RHEL 9 codeready repo

### DIFF
--- a/manifests/modules/packer/manifests/vsphere/repos.pp
+++ b/manifests/modules/packer/manifests/vsphere/repos.pp
@@ -155,6 +155,12 @@ class packer::vsphere::repos(
             gpgcheck => '1',
             gpgkey   => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release'
           }
+          yumrepo { 'localmirror-codeready-builder':
+            descr    => 'localmirror-codeready-builder',
+            baseurl  => "${base_url}/codeready-builder/${facts['architecture']}",
+            gpgcheck => '1',
+            gpgkey   => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release'
+          }
         } elsif $facts['operatingsystemmajrelease'] == '8' {
           yumrepo { 'localmirror-base':
             descr    => 'localmirror-base',

--- a/templates/redhat/9.0/x86_64/vars.json
+++ b/templates/redhat/9.0/x86_64/vars.json
@@ -2,7 +2,7 @@
     "template_name"                                         : "redhat-9-x86_64",
     "template_os"                                           : "rhel8_64Guest",
     "beakerhost"                                            : "redhat9-64",
-    "version"                                               : "0.0.2",
+    "version"                                               : "0.0.3",
     "iso_url"                                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/rhel-baseos-9.0-beta-0-x86_64-dvd.iso",
     "iso_checksum"                                          : "23e6d31e12a22b6d56f00889ea7dc465360ea84e3b7d7854e4c627ecd3160473",
     "iso_checksum_type"                                     : "sha256",


### PR DESCRIPTION
Currently, the codeready repository is being added by the packer manifest, but then subsequently purged by the vsphere manifest. This assures that the repository is not purged.