### PR TITLE
(maint) Updates cleanup script for macOS

### DIFF
--- a/scripts/cleanup-scrub.sh
+++ b/scripts/cleanup-scrub.sh
@@ -4,8 +4,8 @@ if [[ $OSTYPE == darwin* ]]; then
 # Turn off hibernation and get rid of the sleepimage
     pmset hibernatemode 0
     rm -f /var/vm/sleepimage
-    OSX_VERS=$(sw_vers -productVersion | awk -F "." '{print $2}')
-    if [ "$OSX_VERS" -lt 11 ] || $(csrutil status | grep -q disabled); then
+    MACOS_VERS=$(sw_vers -productVersion | awk -F "." '{print $1}')
+    if [ "$MACOS_VERS" -lt 11 ] || $(csrutil status | grep -q disabled); then
         launchctl unload /System/Library/LaunchDaemons/com.apple.dynamic_pager.plist
         sleep 5
     fi


### PR DESCRIPTION
`awk` in the Mac section of the cleanup script uses the wrong variable to get the major version of the OS. Some examples from macOS 10.15:
```
steeper-paradox:~ root# sw_vers -productVersion | awk -F "." '{print $2}'
15
steeper-paradox:~ root# sw_vers -productVersion | awk -F "." '{print $1}'
10
```

And macOS 12:
```
esthetic-idea:~ root# sw_vers -productVersion | awk -F "." '{print $2}'
2
esthetic-idea:~ root# sw_vers -productVersion | awk -F "." '{print $1}'
12
```