### PR TITLE
(REPLATS-647) Bump kurl-beta vm to version 0.3.16

### DIFF
--- a/templates/redhat/8.4-kurl-beta/x86_64/vars.json
+++ b/templates/redhat/8.4-kurl-beta/x86_64/vars.json
@@ -2,7 +2,7 @@
     "template_name"                                         : "redhat-8.4-kurl-beta-x86_64",
     "template_os"                                           : "rhel8_64Guest",
     "beakerhost"                                            : "redhat8-64",
-    "version"                                               : "0.3.15",
+    "version"                                               : "0.3.16",
     "iso_url"                                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/rhel-8.4-x86_64-dvd.iso",
     "iso_checksum"                                          : "aaf9d4b3071c16dbbda01dfe06085e5d0fdac76df323e3bbe87cce4318052247",
     "iso_checksum_type"                                     : "sha256",


### PR DESCRIPTION
Brings in puppetlabs/puppet-application-manager@2022-04-08-rc1
This brings in kURL v2022.04.08-0 which has a patch to lower envoy
resource requirements that should fix our problem starting Comply on the
resource constrained test image.