### PR TITLE
(REPLATS-702) Bump kurl-beta vm to version 0.3.17

### DIFF
--- a/scripts/kurl.sh
+++ b/scripts/kurl.sh
@@ -8,8 +8,11 @@ set -e
 
 ################################
 # Ensure packages are up to date
-echo " * Upgrade packages"
-sudo yum upgrade -y
+#echo " * Upgrade packages"
+#sudo yum upgrade -y
+# Can't do this right now because kURL v2022.05.19-0 doesn't have rhel 8.6
+# support, and this basically transforms the rhel-8.4 iso we start with to
+# 8.6, as far as the installer script is concerned.
 
 #############################
 # Install Kubernetes via Kurl

--- a/scripts/kurl.sh
+++ b/scripts/kurl.sh
@@ -18,7 +18,7 @@ set -e
 # Install Kubernetes via Kurl
 echo " * Installing Kubernetes via Kurl"
 echo " * Installing ${APP}-${CHANNEL}"
-curl -sSLO "https://k8s.kurl.sh/bundle/${APP}-${CHANNEL}.tar.gz"
+curl -sSLO "https://kurl.sh/bundle/${APP}-${CHANNEL}.tar.gz"
 tar xzf "${APP}-${CHANNEL}.tar.gz"
 rm "${APP}-${CHANNEL}.tar.gz"
 

--- a/templates/redhat/8.4-kurl-beta/x86_64/vars.json
+++ b/templates/redhat/8.4-kurl-beta/x86_64/vars.json
@@ -2,7 +2,7 @@
     "template_name"                                         : "redhat-8.4-kurl-beta-x86_64",
     "template_os"                                           : "rhel8_64Guest",
     "beakerhost"                                            : "redhat8-64",
-    "version"                                               : "0.3.16",
+    "version"                                               : "0.3.17",
     "iso_url"                                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/rhel-8.4-x86_64-dvd.iso",
     "iso_checksum"                                          : "aaf9d4b3071c16dbbda01dfe06085e5d0fdac76df323e3bbe87cce4318052247",
     "iso_checksum_type"                                     : "sha256",


### PR DESCRIPTION
Brings in puppetlabs/puppet-application-manager@2022-05-25-rc1
This brings in kURL v2022-05-19-0 and kots 1.70.1. This includes patches
to containers addressing some of the CVEs listed in REPLATS-690.