### PR TITLE
(REPLATS-708) Bump kurl-beta vm to version 0.3.18

### DIFF
--- a/templates/redhat/8.4-kurl-beta/x86_64/vars.json
+++ b/templates/redhat/8.4-kurl-beta/x86_64/vars.json
@@ -2,7 +2,7 @@
     "template_name"                                         : "redhat-8.4-kurl-beta-x86_64",
     "template_os"                                           : "rhel8_64Guest",
     "beakerhost"                                            : "redhat8-64",
-    "version"                                               : "0.3.17",
+    "version"                                               : "0.3.18",
     "iso_url"                                               : "https://artifactory.delivery.puppetlabs.net/artifactory/generic/iso/rhel-8.4-x86_64-dvd.iso",
     "iso_checksum"                                          : "aaf9d4b3071c16dbbda01dfe06085e5d0fdac76df323e3bbe87cce4318052247",
     "iso_checksum_type"                                     : "sha256",


### PR DESCRIPTION
Brings in puppetlabs/puppet-application-manager@2022-06-03-rc1
This brings in kurl v2022.06.01-0 and kots 1.71.0 with more CVE patches
listed in REPLATS-708.